### PR TITLE
[IPM] No need to malloc memory on ipm

### DIFF
--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -19,38 +19,10 @@
 
 static struct nano_sem glcd_sem;
 
-
-static zjs_ipm_message_t* zjs_glcd_alloc_msg()
-{
-    zjs_ipm_message_t *msg = zjs_malloc(sizeof(zjs_ipm_message_t));
-    if (!msg) {
-        PRINT("zjs_glcd_alloc_msg: cannot allocate message\n");
-        return NULL;
-    } else {
-        memset(msg, 0, sizeof(zjs_ipm_message_t));
-    }
-
-    msg->id = MSG_ID_GLCD;
-    msg->flags = 0 | MSG_SAFE_TO_FREE_FLAG;
-    msg->error_code = ERROR_IPM_NONE;
-    return msg;
-}
-
-static void zjs_glcd_free_msg(zjs_ipm_message_t* msg)
-{
-    if (!msg)
-        return;
-
-    if ((msg->flags & MSG_SAFE_TO_FREE_FLAG) == MSG_SAFE_TO_FREE_FLAG) {
-        zjs_free(msg);
-    } else {
-        PRINT("zjs_glcd_free_msg: error! do not free message\n");
-    }
-}
-
 static bool zjs_glcd_ipm_send_sync(zjs_ipm_message_t* send,
                                    zjs_ipm_message_t* result) {
-    send->flags |= MSG_SYNC_FLAG;
+    send->id = MSG_ID_GLCD;
+    send->flags = 0 | MSG_SYNC_FLAG;
     send->user_data = (void *)result;
     send->error_code = ERROR_IPM_NONE;
 
@@ -59,9 +31,11 @@ static bool zjs_glcd_ipm_send_sync(zjs_ipm_message_t* send,
         return false;
     }
 
-    // block until reply or timeout
+    // block until reply or timeout, we shouldn't see the ARC
+    // time out, if the ARC response comes back after it
+    // times out, it could pollute the result on the stack
     if (!nano_sem_take(&glcd_sem, ZJS_GLCD_TIMEOUT_TICKS)) {
-        PRINT("zjs_glcd_ipm_send_sync: ipm timed out\n");
+        PRINT("zjs_glcd_ipm_send_sync: FATAL ERROR, ipm timed out\n");
         return false;
     }
 
@@ -73,24 +47,20 @@ static jerry_value_t zjs_glcd_call_remote_function(zjs_ipm_message_t* send)
     if (!send)
         return zjs_error("zjs_glcd_call_remote_function: invalid send message");
 
-    zjs_ipm_message_t* reply = zjs_glcd_alloc_msg();;
+    zjs_ipm_message_t reply;
 
-    bool success = zjs_glcd_ipm_send_sync(send, reply);
-    zjs_glcd_free_msg(send);
+    bool success = zjs_glcd_ipm_send_sync(send, &reply);
 
     if (!success) {
-        zjs_glcd_free_msg(reply);
-        return zjs_error("zjs_glcd_print: ipm message failed or timed out!");
+        return zjs_error("zjs_glcd_call_remote_function: ipm message failed or timed out!");
     }
 
-    if (reply->error_code != ERROR_IPM_NONE) {
-        PRINT("zjs_glcd_print: error code: %lu\n", reply->error_code);
-        zjs_glcd_free_msg(reply);
-        return zjs_error("zjs_glcd_print: error received");
+    if (reply.error_code != ERROR_IPM_NONE) {
+        PRINT("error code: %lu\n", reply.error_code);
+        return zjs_error("zjs_glcd_call_remote_function: error received");
     }
 
-    uint8_t value = reply->data.glcd.value;
-    zjs_glcd_free_msg(reply);
+    uint8_t value = reply.data.glcd.value;
 
     return jerry_create_number(value);
 }
@@ -122,7 +92,6 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
                                     const jerry_length_t argc)
 {
     if (argc < 1 || !jerry_value_is_string(argv[0])) {
-        PRINT("zjs_glcd_print: invalid argument\n");
         return zjs_error("zjs_glcd_print: invalid argument");
     }
 
@@ -130,8 +99,7 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
 
     char *buffer = zjs_malloc(sz+1);
     if (!buffer) {
-        PRINT("zjs_glcd_print: cannot allocate buffer\n");
-        return zjs_error("cannot allocate buffer");
+        return zjs_error("zjs_glcd_print: cannot allocate buffer");
     }
 
     int len = jerry_string_to_char_buffer(argv[0],
@@ -140,11 +108,11 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
     buffer[len] = '\0';
 
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
-    send->type = TYPE_GLCD_PRINT;
-    send->data.glcd.buffer = buffer;
+    zjs_ipm_message_t send;
+    send.type = TYPE_GLCD_PRINT;
+    send.data.glcd.buffer = buffer;
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
     zjs_free(buffer);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
@@ -156,11 +124,11 @@ static jerry_value_t zjs_glcd_clear(const jerry_value_t function_obj,
                                     const jerry_length_t argc)
 {
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
+    zjs_ipm_message_t send;
     // no input parameter to set
-    send->type = TYPE_GLCD_CLEAR;
+    send.type = TYPE_GLCD_CLEAR;
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
@@ -177,12 +145,12 @@ static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj,
     }
 
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
-    send->type = TYPE_GLCD_SET_CURSOR_POS;
-    send->data.glcd.col = (uint8_t)jerry_get_number_value(argv[0]);
-    send->data.glcd.row = (uint8_t)jerry_get_number_value(argv[1]);
+    zjs_ipm_message_t send;
+    send.type = TYPE_GLCD_SET_CURSOR_POS;
+    send.data.glcd.col = (uint8_t)jerry_get_number_value(argv[0]);
+    send.data.glcd.row = (uint8_t)jerry_get_number_value(argv[1]);
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
@@ -197,11 +165,11 @@ static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj,
     }
 
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
-    send->type = TYPE_GLCD_SELECT_COLOR;
-    send->data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
+    zjs_ipm_message_t send;
+    send.type = TYPE_GLCD_SELECT_COLOR;
+    send.data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
@@ -219,13 +187,13 @@ static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj,
     }
 
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
-    send->type = TYPE_GLCD_SET_COLOR;
-    send->data.glcd.color_r = (uint8_t)jerry_get_number_value(argv[0]);
-    send->data.glcd.color_g = (uint8_t)jerry_get_number_value(argv[1]);
-    send->data.glcd.color_b = (uint8_t)jerry_get_number_value(argv[2]);
+    zjs_ipm_message_t send;
+    send.type = TYPE_GLCD_SET_COLOR;
+    send.data.glcd.color_r = (uint8_t)jerry_get_number_value(argv[0]);
+    send.data.glcd.color_g = (uint8_t)jerry_get_number_value(argv[1]);
+    send.data.glcd.color_b = (uint8_t)jerry_get_number_value(argv[2]);
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
@@ -240,11 +208,11 @@ static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj,
     }
 
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
-    send->type = TYPE_GLCD_SET_FUNCTION;
-    send->data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
+    zjs_ipm_message_t send;
+    send.type = TYPE_GLCD_SET_FUNCTION;
+    send.data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
@@ -255,11 +223,11 @@ static jerry_value_t zjs_glcd_get_function(const jerry_value_t function_obj,
                                            const jerry_length_t argc)
 {
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
+    zjs_ipm_message_t send;
     // no input parameter to set
-    send->type = TYPE_GLCD_GET_FUNCTION;
+    send.type = TYPE_GLCD_GET_FUNCTION;
 
-    return zjs_glcd_call_remote_function(send);
+    return zjs_glcd_call_remote_function(&send);
 }
 
 static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj,
@@ -272,11 +240,11 @@ static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj
     }
 
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
-    send->type = TYPE_GLCD_SET_DISPLAY_STATE;
-    send->data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
+    zjs_ipm_message_t send;
+    send.type = TYPE_GLCD_SET_DISPLAY_STATE;
+    send.data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
@@ -287,11 +255,11 @@ static jerry_value_t zjs_glcd_get_display_state(const jerry_value_t function_obj
                                                 const jerry_length_t argc)
 {
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
+    zjs_ipm_message_t send;
     // no input parameter to set
-    send->type = TYPE_GLCD_GET_DISPLAY_STATE;
+    send.type = TYPE_GLCD_GET_DISPLAY_STATE;
 
-    return zjs_glcd_call_remote_function(send);
+    return zjs_glcd_call_remote_function(&send);
 }
 
 static jerry_value_t zjs_glcd_set_input_state(const jerry_value_t function_obj,
@@ -304,11 +272,11 @@ static jerry_value_t zjs_glcd_set_input_state(const jerry_value_t function_obj,
     }
 
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
-    send->type = TYPE_GLCD_SET_INPUT_STATE;
-    send->data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
+    zjs_ipm_message_t send;
+    send.type = TYPE_GLCD_SET_INPUT_STATE;
+    send.data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
 
     return jerry_value_has_error_flag(result) ? result : ZJS_UNDEFINED;
 }
@@ -319,11 +287,11 @@ static jerry_value_t zjs_glcd_get_input_state(const jerry_value_t function_obj,
                                               const jerry_length_t argc)
 {
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
+    zjs_ipm_message_t send;
     // no input parameter to set
-    send->type = TYPE_GLCD_GET_INPUT_STATE;
+    send.type = TYPE_GLCD_GET_INPUT_STATE;
 
-    return zjs_glcd_call_remote_function(send);
+    return zjs_glcd_call_remote_function(&send);
 }
 
 static jerry_value_t zjs_glcd_init(const jerry_value_t function_obj,
@@ -332,11 +300,11 @@ static jerry_value_t zjs_glcd_init(const jerry_value_t function_obj,
                                    const jerry_length_t argc)
 {
     // send IPM message to the ARC side
-    zjs_ipm_message_t* send = zjs_glcd_alloc_msg();
+    zjs_ipm_message_t send;
     // no input parameter to set
-    send->type = TYPE_GLCD_INIT;
+    send.type = TYPE_GLCD_INIT;
 
-    jerry_value_t result = zjs_glcd_call_remote_function(send);
+    jerry_value_t result = zjs_glcd_call_remote_function(&send);
 
     if (jerry_value_has_error_flag(result)) {
         return result;


### PR DESCRIPTION
We don't have to malloc heap memory for sending/receiving IPM
messages in sync API, since the ARC is guaranteed to receive the message
after the send() function returns, we can immediately free up
the IPM message, and so to make it more efficient, we just use
the stack memory to store the struct.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>