### PR TITLE
[README] Fix bogus command to add user to group

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ source ~/.bashrc
 Add your user to the plugdev group with this command:
 
 ```bash
-$ sudo useradd -G plugdev USERNAME
+$ sudo usermod -a -G plugdev USERNAME
 ```
 
 #### Add udev rules


### PR DESCRIPTION
I typed 'useradd' when I meant 'usermod' and worse, without the -a
flag it wipes out your other group memberships.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>