### PR TITLE
[memory] Creating functions to free memory

### DIFF
--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -268,7 +268,7 @@ static void zjs_buffer_callback_free(uintptr_t handle)
     }
 }
 
-void zjs_buffer_free_buffers()
+void zjs_buffer_cleanup()
 {
     zjs_buffer_t **pItem = &zjs_buffers;
     while (*pItem) {

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -268,6 +268,16 @@ static void zjs_buffer_callback_free(uintptr_t handle)
     }
 }
 
+void zjs_buffer_free_buffers()
+{
+    zjs_buffer_t **pItem = &zjs_buffers;
+    while (*pItem) {
+        zjs_free((*pItem)->buffer);
+        pItem = &(*pItem)->next;
+    }
+    zjs_buffers = NULL;
+}
+
 static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_val,
                                              const jerry_value_t this,
                                              const jerry_value_t argv[],

--- a/src/zjs_buffer.h
+++ b/src/zjs_buffer.h
@@ -18,4 +18,6 @@ zjs_buffer_t *zjs_buffer_find(const jerry_value_t obj);
 
 jerry_value_t zjs_buffer_create(uint32_t size);
 
+void zjs_buffer_free_buffers();
+
 #endif  // __zjs_buffer_h__

--- a/src/zjs_buffer.h
+++ b/src/zjs_buffer.h
@@ -18,6 +18,6 @@ zjs_buffer_t *zjs_buffer_find(const jerry_value_t obj);
 
 jerry_value_t zjs_buffer_create(uint32_t size);
 
-void zjs_buffer_free_buffers();
+void zjs_buffer_cleanup();
 
 #endif  // __zjs_buffer_h__

--- a/src/zjs_ipm.c
+++ b/src/zjs_ipm.c
@@ -98,4 +98,14 @@ void zjs_ipm_register_callback(uint32_t msg_id, ipm_callback_t cb)
 #endif
 }
 
+void zjs_ipm_free_callbacks() {
+    #ifdef CONFIG_X86
+    struct zjs_ipm_callback **pItem = &zjs_ipm_callbacks;
+    while (*pItem) {
+        zjs_free(*pItem);
+        pItem = &(*pItem)->next;
+    }
+    zjs_ipm_callbacks = NULL;
+    #endif
+}
 #endif // QEMU_BUILD

--- a/src/zjs_ipm.c
+++ b/src/zjs_ipm.c
@@ -98,7 +98,7 @@ void zjs_ipm_register_callback(uint32_t msg_id, ipm_callback_t cb)
 #endif
 }
 
-void zjs_ipm_free_callbacks() {
+void zjs_ipm_cleanup() {
     #ifdef CONFIG_X86
     struct zjs_ipm_callback **pItem = &zjs_ipm_callbacks;
     while (*pItem) {

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -104,4 +104,6 @@ int zjs_ipm_send(uint32_t id, zjs_ipm_message_t *data);
 
 void zjs_ipm_register_callback(uint32_t msg_id, ipm_callback_t cb);
 
+void zjs_ipm_free_callbacks();
+
 #endif  // __zjs_ipm_h__

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -104,6 +104,6 @@ int zjs_ipm_send(uint32_t id, zjs_ipm_message_t *data);
 
 void zjs_ipm_register_callback(uint32_t msg_id, ipm_callback_t cb);
 
-void zjs_ipm_free_callbacks();
+void zjs_ipm_cleanup();
 
 #endif  // __zjs_ipm_h__

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -108,7 +108,7 @@ static bool delete_timer(int32_t id)
     return false;
 }
 
-void zjs_timers_free_timers()
+void zjs_timers_cleanup()
 {
     for (zjs_timer_t **ptm = &zjs_timers; *ptm; ptm = &(*ptm)->next) {
         zjs_timer_t *tm = *ptm;

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -108,6 +108,23 @@ static bool delete_timer(int32_t id)
     return false;
 }
 
+void zjs_timers_free_timers()
+{
+    for (zjs_timer_t **ptm = &zjs_timers; *ptm; ptm = &(*ptm)->next) {
+        zjs_timer_t *tm = *ptm;
+        int i;
+        zjs_port_timer_stop(&tm->timer);
+        *ptm = tm->next;
+        for (i = 0; i < tm->argc; ++i) {
+            jerry_release_value(tm->argv[i]);
+        }
+        zjs_remove_callback(tm->callback_id);
+        zjs_free(tm->argv);
+        zjs_free(tm);
+    }
+    zjs_timers = NULL;
+}
+
 static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
                                       const jerry_value_t this,
                                       const jerry_value_t argv[],

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -112,10 +112,9 @@ void zjs_timers_cleanup()
 {
     for (zjs_timer_t **ptm = &zjs_timers; *ptm; ptm = &(*ptm)->next) {
         zjs_timer_t *tm = *ptm;
-        int i;
         zjs_port_timer_stop(&tm->timer);
         *ptm = tm->next;
-        for (i = 0; i < tm->argc; ++i) {
+        for (int i = 0; i < tm->argc; ++i) {
             jerry_release_value(tm->argv[i]);
         }
         zjs_remove_callback(tm->callback_id);

--- a/src/zjs_timers.h
+++ b/src/zjs_timers.h
@@ -5,5 +5,6 @@
 
 void zjs_timers_process_events();
 void zjs_timers_init();
+void zjs_timers_free_timers();
 
 #endif  // __zjs_timers_h__

--- a/src/zjs_timers.h
+++ b/src/zjs_timers.h
@@ -5,6 +5,6 @@
 
 void zjs_timers_process_events();
 void zjs_timers_init();
-void zjs_timers_free_timers();
+void zjs_timers_cleanup();
 
 #endif  // __zjs_timers_h__


### PR DESCRIPTION
Creating a free all memory function for each section of code that
uses malloc.  This will allow ashell to free any memory that
JerryScript failed to free when the JavaScript is halted and
restarted.