### PR TITLE
[Makefile] Pass OUTPUT param to JerryScript, so it could load .config file.

### DIFF
--- a/Makefile.app
+++ b/Makefile.app
@@ -2,5 +2,5 @@ JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 
 $(KBUILD_ZEPHYR_APP):
 	@echo "Building" $@
-	make -C $(JERRY_BASE) -f targets/zephyr/Makefile.zephyr BOARD=$(BOARD) jerry
+	make -C $(JERRY_BASE) -f targets/zephyr/Makefile.zephyr BOARD=$(BOARD) OUTPUT=$O jerry
 	cp $(JERRY_BASE)/build/$(BOARD)/obj-$(BOARD)/lib/$@ $(O)


### PR DESCRIPTION
JerryScript by default uses adhoc location for Zephyr output directory,
which makes it be unable to find Zephyr .config file, which is needed
for proper toolchain selection (based on CONFIG_ARCH setting).

Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org
