### PR TITLE
[zjs_k64f_pins] SW3 button is confirmed to be on PTA4.

### DIFF
--- a/src/zjs_k64f_pins.c
+++ b/src/zjs_k64f_pins.c
@@ -71,9 +71,9 @@ jerry_value_t zjs_k64f_init()
     zjs_obj_add_number(obj, PTE + 26, "LEDG");  // verified
     zjs_obj_add_number(obj, PTB + 21, "LEDB");  // verified
 
-    // These are onboard switches SW2 and SW3
+    // These are onboard switches SW2 and SW3 (SW1 is Reset)
     zjs_obj_add_number(obj, PTC +  6, "SW2");  // verified (press: falling edge)
-    zjs_obj_add_number(obj, PTC + 13, "SW3");  // doesn't work (elsewhere PTA4)
+    zjs_obj_add_number(obj, PTA +  4, "SW3");
 
     // TODO: More pins at https://developer.mbed.org/platforms/FRDM-K64F/
 


### PR DESCRIPTION
This is also what https://developer.mbed.org/platforms/FRDM-K64F/ lists.

Signed-off-by: Paul Sokolovsky paul.sokolovsky@linaro.org
