### PR TITLE
Add Travis CI configuration file to setup continous integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: generic # setting language to C will override cross-compiler and fail
+
+sudo: required
+dist: trusty
+
+env:
+  global:
+    - ZEPHYR_GCC_VARIANT=zephyr
+    - ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
+    - ZEPHYR_BASE=$TRAVIS_BUILD_DIR/deps/zephyr
+    - ZEPHYR_SDK_VERSION=0.8.2
+    - ZEPHYR_SDK_DOWNLOAD_FOLDER=https://nexus.zephyrproject.org/content/repositories/releases/org/zephyrproject/zephyr-sdk/$ZEPHYR_SDK_VERSION-i686/
+    - ZEPHYR_SDK_SETUP_BINARY=zephyr-sdk-$ZEPHYR_SDK_VERSION-i686-setup.run
+    - ZEPHYR_SDK_DOWNLOAD_URL=$ZEPHYR_SDK_DOWNLOAD_FOLDER$ZEPHYR_SDK_SETUP_BINARY
+  matrix:
+    - TARGET="default"
+    - TARGET="arc"
+    - TARGET="linux"
+    - TARGET="BOARD=frdm_k64f"
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install make gcc g++ python3-ply ncurses-dev -qq
+
+install: >
+  if [ "$TARGET" != "linux" ]; then
+    wget $ZEPHYR_SDK_DOWNLOAD_URL &&
+    chmod +x $ZEPHYR_SDK_SETUP_BINARY &&
+    ./$ZEPHYR_SDK_SETUP_BINARY --quiet -- -y -d $ZEPHYR_SDK_INSTALL_DIR > /dev/null;
+  fi
+
+before_script: >
+  source zjs-env.sh && make update && source deps/zephyr/zephyr-env.sh
+
+script: >
+  if [ "$TARGET" == "default" ]; then
+    make V=1; else
+    make V=1 "${TARGET}";
+  fi


### PR DESCRIPTION
This is the first iteration of enabling CI for the project. Each PR
and push command will trigger a message to the Travis CI infrastructure
which will attempt to build the project for the x86 (default), arc, linux
and Freedom Board targets, and report the results in the PR comments and
with an email. The exact behavior depends on the configuration selected
in the Travis CI control panel.

Signed-off-by: Francesco Balestrieri <francesco.balestrieri@intel.com>