### PR TITLE
[modules] Changing modules to use singletons

### DIFF
--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -104,6 +104,7 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
         }
     }
 
+    PRINT("MODULE: `%s'\n", module);
     return zjs_error("native_require_handler: module not found");
 }
 

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -31,6 +31,7 @@
 typedef struct module {
     const char *name;
     initcb_t init;
+    jerry_value_t instance;
 } module_t;
 
 module_t zjs_modules_array[] = {
@@ -95,16 +96,26 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
     for (int i = 0; i < modcount; i++) {
         module_t *mod = &zjs_modules_array[i];
         if (!strcmp(mod->name, module)) {
-            return jerry_acquire_value(mod->init());
+            // We only want one intance of each module at a time
+            if (mod->instance == 0) {
+                mod->instance = jerry_acquire_value(mod->init());
+            }
+            return mod->instance;
         }
     }
 
-    PRINT("MODULE: `%s'\n", module);
     return zjs_error("native_require_handler: module not found");
 }
 
 void zjs_modules_init()
 {
+    int modcount = sizeof(zjs_modules_array) / sizeof(module_t);
+
+    for (int i = 0; i < modcount; i++) {
+        module_t *mod = &zjs_modules_array[i];
+        mod->instance = 0;
+    }
+
     jerry_value_t global_obj = jerry_get_global_object();
 
     // create the C handler for require JS call


### PR DESCRIPTION
Each module will now only be created once.  Additional calls to
requires("module") will return the previously created instance.
This will cut down on memory consumption and prevent unintended
behavior.