### PR TITLE
[memory] Free global javascript objects and allow multiple restart

### DIFF
--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -122,6 +122,26 @@ void javascript_eval_code(const char *source_buffer)
     jerry_release_value(ret_val);
 }
 
+
+void restore_zjs_api() {    
+#ifdef ZJS_POOL_CONFIG    
+    zjs_init_mem_pools();
+#ifdef DUMP_MEM_STATS    
+    zjs_print_pools();
+#endif
+#endif
+
+    jerry_init(JERRY_INIT_EMPTY);
+    zjs_timers_init();
+#ifndef ZJS_LINUX_BUILD
+    //zjs_queue_init();
+#endif
+
+    zjs_buffer_init();
+    zjs_init_callbacks();
+    zjs_modules_init();
+}
+
 void javascript_stop()
 {
     if (parsed_code == 0)
@@ -133,9 +153,9 @@ void javascript_stop()
 
     /* Cleanup engine */
     jerry_cleanup();
+    zjs_ipm_free_callbacks();
 
-    /* Initialize engine */
-    jerry_init(JERRY_INIT_EMPTY);
+    restore_zjs_api();
 }
 
 int javascript_parse_code(const char *file_name, bool show_lines)
@@ -218,7 +238,7 @@ void javascript_run_code(const char *file_name)
     /* Execute the parsed source code in the Global scope */
     jerry_value_t ret_value = jerry_run(parsed_code);
 
-    if (jerry_value_has_error_flag(parsed_code)) {
+    if (jerry_value_has_error_flag(ret_value)) {
         javascript_print_error(ret_value);
     }
 

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -123,20 +123,18 @@ void javascript_eval_code(const char *source_buffer)
 }
 
 
-void restore_zjs_api() {    
-#ifdef ZJS_POOL_CONFIG    
+void restore_zjs_api() {
+#ifdef ZJS_POOL_CONFIG
     zjs_init_mem_pools();
-#ifdef DUMP_MEM_STATS    
+#ifdef DUMP_MEM_STATS
     zjs_print_pools();
 #endif
 #endif
-
     jerry_init(JERRY_INIT_EMPTY);
     zjs_timers_init();
-#ifndef ZJS_LINUX_BUILD
-    //zjs_queue_init();
+#ifdef BUILD_MODULE_CONSOLE
+    zjs_console_init();
 #endif
-
     zjs_buffer_init();
     zjs_init_callbacks();
     zjs_modules_init();

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -453,5 +453,6 @@ void zjs_buffer_init()
 {
     jerry_value_t global_obj = jerry_get_global_object();
     zjs_obj_add_function(global_obj, zjs_buffer, "Buffer");
+    jerry_release_value(global_obj);
 }
 #endif // BUILD_MODULE_BUFFER

--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -71,6 +71,7 @@ void zjs_console_init(void)
     zjs_obj_add_function(console, console_error, "warn");
 
     zjs_set_property(global_obj, "console", console);
+    jerry_release_value(global_obj);
 }
 
 #endif

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -323,6 +323,8 @@ static jerry_value_t zjs_gpio_open(const jerry_value_t function_obj,
 
         handle->pin = newpin;
         handle->pin_obj = async ? jerry_acquire_value(pinobj) : pinobj;
+        handle->devnum = devnum;
+
         // Register a C callback (will be called after the ISR is called)
         handle->callbackId = zjs_add_c_callback(handle, gpio_c_callback);
         // Set the native handle so we can free it when close() is called

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -39,6 +39,7 @@ void (*zjs_gpio_convert_pin)(uint32_t orig, int *dev, int *pin) =
 struct gpio_handle {
     struct gpio_callback callback;  // Callback structure for zephyr
     uint32_t pin;                   // Pin associated with this handle
+    uint32_t devnum;
     uint32_t value;                 // Value of the pin
     int32_t callbackId;             // ID for the C callback
     jerry_value_t pin_obj;          // Pin object returned from open()
@@ -185,6 +186,18 @@ static jerry_value_t zjs_gpio_pin_close(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
+static void zjs_gpio_free_cb(const uintptr_t native)
+{
+    struct gpio_handle* handle = (struct gpio_handle*)native;
+    zjs_remove_callback(handle->callbackId);
+    if (handle->onchange_func) {
+        jerry_release_value(handle->onchange_func);
+    }
+
+    gpio_remove_callback(zjs_gpio_dev[handle->devnum], &handle->callback);
+    zjs_free(handle);
+}
+
 // Called after the promise is fulfilled/rejected
 static void post_open_promise(void* h)
 {
@@ -313,7 +326,7 @@ static jerry_value_t zjs_gpio_open(const jerry_value_t function_obj,
         // Register a C callback (will be called after the ISR is called)
         handle->callbackId = zjs_add_c_callback(handle, gpio_c_callback);
         // Set the native handle so we can free it when close() is called
-        jerry_set_object_native_handle(pinobj, (uintptr_t)handle, NULL);
+        jerry_set_object_native_handle(pinobj, (uintptr_t)handle, zjs_gpio_free_cb);
     }
 
     if (async) {

--- a/src/zjs_ipm.c
+++ b/src/zjs_ipm.c
@@ -98,4 +98,15 @@ void zjs_ipm_register_callback(uint32_t msg_id, ipm_callback_t cb)
 #endif
 }
 
+void zjs_ipm_free_callbacks() {
+    #ifdef CONFIG_X86
+    struct zjs_ipm_callback **pItem = &zjs_ipm_callbacks;
+    while (*pItem) {        
+        zjs_free(*pItem);            
+        pItem = &(*pItem)->next;
+    }
+    zjs_free(zjs_ipm_callbacks);
+    zjs_ipm_callbacks = NULL;
+    #endif
+}
 #endif // QEMU_BUILD

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -109,4 +109,5 @@ void zjs_modules_init()
 
     // create the C handler for require JS call
     zjs_obj_add_function(global_obj, native_require_handler, "require");
+    jerry_release_value(global_obj);
 }

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -108,6 +108,11 @@ static bool delete_timer(int32_t id)
     return false;
 }
 
+static void zjs_timer_free_cb(uintptr_t handle)
+{
+    delete_timer(((zjs_timer_t *)handle)->callback_id);
+}
+
 static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
                                       const jerry_value_t this,
                                       const jerry_value_t argv[],
@@ -126,7 +131,7 @@ static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
     zjs_timer_t* handle = add_timer(interval, callback, this, repeat, argv, argc - 2);
     if (handle->callback_id == -1)
         return zjs_error("native_set_interval_handler: timer alloc failed");
-    jerry_set_object_native_handle(timer_obj, (uintptr_t)handle, NULL);
+    jerry_set_object_native_handle(timer_obj, (uintptr_t)handle, zjs_timer_free_cb);
 
     return timer_obj;
 }
@@ -223,4 +228,5 @@ void zjs_timers_init()
     // create the C handler for clearTimeout JS call (same as clearInterval)
     zjs_obj_add_function(global_obj, native_clear_interval_handler,
                          "clearTimeout");
+    jerry_release_value(global_obj);
 }


### PR DESCRIPTION
This adds the necessary code to supply JerryScript with callbacks
to free memory when an object is garbage collected.  It also makes
the changes needed to ensure global JavaScript objects get GC'd.
Finally - it adds the code needed by ashell to be able to run
a ZJS JavaScript file multiple times without rebooting.

Signed-off-by: Brian J Jones brian.j.jones@intel.com
