### PR TITLE
[callbacks] Return this from some methods to support chaining

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -127,6 +127,7 @@ bool zjs_remove_callback_list_func(int32_t id, jerry_value_t js_func)
             }
         }
     }
+    DBG_PRINT("could not remove callback %d\n", id);
     return false;
 }
 

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -92,28 +92,28 @@ static jerry_value_t add_listener(const jerry_value_t function_obj,
 {
     if (!jerry_value_is_string(argv[0])) {
         DBG_PRINT("first parameter must be event string\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     if (!jerry_value_is_function(argv[1])) {
         DBG_PRINT("second parameter must be a listener function\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     int sz = jerry_get_string_size(argv[0]);
     if (sz > ZJS_MAX_EVENT_NAME_SIZE) {
         DBG_PRINT("event name is too long\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     char name[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)name, sz);
     if (len != sz) {
         DBG_PRINT("size mismatch\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     name[len] = '\0';
 
     zjs_add_event_listener(this, name, argv[1]);
 
-    return ZJS_UNDEFINED;
+    return this;
 }
 
 static jerry_value_t emit_event(const jerry_value_t function_obj,
@@ -152,22 +152,22 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
         DBG_PRINT("native handle not found\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     if (!jerry_value_is_string(argv[0])) {
         DBG_PRINT("event name must be first parameter\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     if (!jerry_value_is_function(argv[1])) {
         DBG_PRINT("event listener must be second parameter\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     int sz = jerry_get_string_size(argv[0]);
     char event[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
     if (len != sz) {
         DBG_PRINT("size mismatch\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     event[len] = '\0';
 
@@ -175,7 +175,7 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
     if (!jerry_value_is_object(event_obj)) {
         DBG_PRINT("event object not found for '%s'\n", event);
-        return ZJS_UNDEFINED;
+        return this;
     }
 
     int32_t callback_id = -1;
@@ -185,12 +185,12 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
         zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
         DBG_PRINT("callback_id not found for '%s'\n", event);
-        return ZJS_UNDEFINED;
+        return this;
     }
 
-    bool removed = zjs_remove_callback_list_func(callback_id, argv[1]);
+    zjs_remove_callback_list_func(callback_id, argv[1]);
 
-    return jerry_create_boolean(removed);
+    return this;
 }
 
 static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
@@ -203,18 +203,18 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
         DBG_PRINT("native handle not found\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     if (!jerry_value_is_string(argv[0])) {
         DBG_PRINT("event name must be first parameter\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     int sz = jerry_get_string_size(argv[0]);
     char event[sz];
     int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
     if (len != sz) {
         DBG_PRINT("size mismatch\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     event[len] = '\0';
 
@@ -222,7 +222,7 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
     if (!jerry_value_is_object(event_obj)) {
         DBG_PRINT("event object not found for '%s'\n", event);
-        return ZJS_UNDEFINED;
+        return this;
     }
 
     int32_t callback_id = -1;
@@ -232,7 +232,7 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
         zjs_obj_get_int32(event_obj, "callback_id", &callback_id);
     } else {
         DBG_PRINT("callback_id not found for '%s'\n", event);
-        return ZJS_UNDEFINED;
+        return this;
     }
 
     zjs_remove_callback(callback_id);
@@ -241,7 +241,7 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
     jerry_delete_property(ev->map, (const jerry_value_t)event_name_val);
     jerry_release_value(event_name_val);
 
-    return ZJS_UNDEFINED;
+    return this;
 }
 
 bool foreach_event_name(const jerry_value_t prop_name,
@@ -302,15 +302,15 @@ static jerry_value_t set_max_listeners(const jerry_value_t function_obj,
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     if (!jerry_get_object_native_handle(event_emitter, (uintptr_t*)&ev)) {
         DBG_PRINT("native handle not found\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     if (!jerry_value_is_number(argv[0])) {
         DBG_PRINT("max listeners count must be first parameter\n");
-        return ZJS_UNDEFINED;
+        return this;
     }
     ev->max_listeners = (uint32_t)jerry_get_number_value(argv[0]);
 
-    return ZJS_UNDEFINED;
+    return this;
 }
 
 bool foreach_listener(const jerry_value_t prop_name,


### PR DESCRIPTION
This unifies the interface with that of node.js. The methods that support
chaining are:
- add_listener
- remove_listener
- remove_all_listener
- set_max_listeners
