### PR TITLE
[Sensor] Initial implementation of the Generic Sensor API

### DIFF
--- a/arc/src/Makefile.base
+++ b/arc/src/Makefile.base
@@ -2,9 +2,4 @@ ccflags-y += ${PROJECTINCLUDE} \
 	-I$(ZEPHYR_BASE)/drivers \
 	-I$(src)/../../src \
 
-ccflags-y += -DBUILD_MODULE_AIO
-ccflags-y += -DBUILD_MODULE_I2C
-ccflags-y += -DBUILD_MODULE_GROVE_LCD
-ccflags-y += -DBUILD_MODULE_SENSOR
-
 obj-y = main.o ../../src/zjs_ipm.o

--- a/arc/src/Makefile.base
+++ b/arc/src/Makefile.base
@@ -2,4 +2,9 @@ ccflags-y += ${PROJECTINCLUDE} \
 	-I$(ZEPHYR_BASE)/drivers \
 	-I$(src)/../../src \
 
+ccflags-y += -DBUILD_MODULE_AIO
+ccflags-y += -DBUILD_MODULE_I2C
+ccflags-y += -DBUILD_MODULE_GROVE_LCD
+ccflags-y += -DBUILD_MODULE_SENSOR
+
 obj-y = main.o ../../src/zjs_ipm.o

--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -366,7 +366,6 @@ static void handle_glcd(struct zjs_ipm_message* msg)
             glcd = device_get_binding(GROVE_LCD_NAME);
 
             if (!glcd) {
-                PRINT("failed to initialize Grove LCD\n");
                 error_code = ERROR_IPM_OPERATION_FAILED;
             } else {
                 DBG_PRINT("Grove LCD initialized\n");
@@ -477,7 +476,7 @@ static void send_sensor_data(enum sensor_channel channel,
 {
     struct zjs_ipm_message msg;
     msg.id = MSG_ID_SENSOR;
-    msg.type = TYPE_SENSOR_EVENT_VALUE_CHANGE;
+    msg.type = TYPE_SENSOR_EVENT_READING_CHANGE;
     msg.flags = 0;
     msg.user_data = NULL;
     msg.error_code = ERROR_IPM_NONE;

--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -432,7 +432,7 @@ static void handle_glcd(struct zjs_ipm_message* msg)
 #endif
 
 #ifdef	BUILD_MODULE_SENSOR
-#ifndef DEBUG_BUILD
+#ifdef DEBUG_BUILD
 static inline int sensor_value_snprintf(char *buf, size_t len,
                                         const struct sensor_value *val)
 {
@@ -485,7 +485,7 @@ static void send_sensor_data(enum sensor_channel channel,
     zjs_ipm_send(MSG_ID_SENSOR, &msg);
 }
 
-#define ABS(x) ((x) > 0) ? (x) : -(x)
+#define ABS(x) ((x) >= 0) ? (x) : -(x)
 
 static double convert_sensor_value(const struct sensor_value *val)
 {
@@ -545,7 +545,7 @@ static void process_accel_data(struct device *dev)
     dval[2] = convert_sensor_value(&val[2]);
 
     if (dval[0] == 0 && dval[1] == 0 && dval[2] == 0) {
-        // FIXME: BUG? why sometimes it reports 0, 0, 0 on all axis
+        // FIXME: BUG? why sometimes it reports 0, 0, 0 on all axes
         return;
     }
 
@@ -585,9 +585,9 @@ static void process_gyro_data(struct device *dev)
     dval[1] = convert_sensor_value(&val[1]);
     dval[2] = convert_sensor_value(&val[2]);
 
-    if (ABS(dval[0] - gyro_last_value[0]) > 0 ||
-        ABS(dval[1] - gyro_last_value[1]) > 0 ||
-        ABS(dval[2] - gyro_last_value[2]) > 0) {
+    if (dval[0] != gyro_last_value[0] ||
+        dval[1] != gyro_last_value[1] ||
+        dval[2] != gyro_last_value[2]) {
         union sensor_reading reading;
         reading.x = dval[0];
         reading.y = dval[1];

--- a/samples/Accelerometer.js
+++ b/samples/Accelerometer.js
@@ -1,21 +1,21 @@
 // Copyright (c) 2016, Intel Corporation.
 
-// Test code to use the AccelerometerSensor (subclass of Generic Sensor) API
+// Test code to use the Accelerometer (subclass of Generic Sensor) API
 // to communicate with the BMI160 inertia sensor on the Arduino 101
 // and obtaining information about acceleration applied to the X, Y and Z axis
-console.log("Acclerometer test...");
+console.log("Accelerometer test...");
 
 
-var sensor = new AccelerometerSensor({
+var sensor = new Accelerometer({
     includeGravity: false, // true is not supported, will throw error
-    frequency: 60
+    frequency: 50
 });
 
 sensor.onchange = function(event) {
     console.log("acceleration (m/s^2): " +
-          " x=" + event.reading.accelerationX +
-          " y=" + event.reading.accelerationY +
-          " z=" + event.reading.accelerationZ);
+                " x=" + event.reading.x +
+                " y=" + event.reading.y +
+                " z=" + event.reading.z);
 };
 
 sensor.onstatechange = function(event) {

--- a/samples/Accelerometer.js
+++ b/samples/Accelerometer.js
@@ -22,8 +22,9 @@ sensor.onstatechange = function(event) {
     console.log("state: " + event);
 };
 
-sensor.onerrorchange = function(error) {
-    console.log("error: " + error);
+sensor.onerror = function(event) {
+    console.log("error: " + event.error.name +
+                " - " + event.error.message);
 };
 
 sensor.start();

--- a/samples/Accelerometer.js
+++ b/samples/Accelerometer.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2016, Intel Corporation.
+
+// Test code to use the AccelerometerSensor (subclass of Generic Sensor) API
+// to communicate with the BMI160 inertia sensor on the Arduino 101
+// and obtaining information about acceleration applied to the X, Y and Z axis
+console.log("Acclerometer test...");
+
+
+var sensor = new AccelerometerSensor({
+    includeGravity: false, // true is not supported, will throw error
+    frequency: 60
+});
+
+sensor.onchange = function(event) {
+    console.log("acceleration (m/s^2): " +
+          " x=" + event.reading.accelerationX +
+          " y=" + event.reading.accelerationY +
+          " z=" + event.reading.accelerationZ);
+};
+
+sensor.onstatechange = function(event) {
+    console.log("state: " + event);
+};
+
+sensor.onerrorchange = function(error) {
+    console.log("error: " + error);
+};
+
+sensor.start();

--- a/samples/Gyroscope.js
+++ b/samples/Gyroscope.js
@@ -3,16 +3,16 @@
 // Test code to use the Gyroscope (subclass of Generic Sensor) API
 // to communicate with the BMI160 inertia sensor on the Arduino 101
 // and monitor the rate of rotation around the the X, Y and Z axis
-print("Gyroscope test...");
+console.log("Gyroscope test...");
 
 
 var sensor = new Gyroscope();
 
 sensor.onchange = function(event) {
-    print("rotation (rad/s): " +
-          " x=" + event.reading.rotationRateX +
-          " y=" + event.reading.rotationRateY +
-          " z=" + event.reading.rotationRateZ);
+    console.log("rotation (rad/s): " +
+                " x=" + event.reading.x +
+                " y=" + event.reading.y +
+                " z=" + event.reading.z);
 };
 
 sensor.onstatechange = function(event) {

--- a/samples/Gyroscope.js
+++ b/samples/Gyroscope.js
@@ -19,8 +19,9 @@ sensor.onstatechange = function(event) {
     console.log("state: " + event);
 };
 
-sensor.onerrorchange = function(error) {
-    console.log("error: " + error);
+sensor.onerror = function(event) {
+    console.log("error: " + event.error.name +
+                " - " + event.error.message);
 };
 
 sensor.start();

--- a/samples/Gyroscope.js
+++ b/samples/Gyroscope.js
@@ -1,0 +1,26 @@
+// Copyright (c) 2016, Intel Corporation.
+
+// Test code to use the Gyroscope (subclass of Generic Sensor) API
+// to communicate with the BMI160 inertia sensor on the Arduino 101
+// and monitor the rate of rotation around the the X, Y and Z axis
+print("Gyroscope test...");
+
+
+var sensor = new Gyroscope();
+
+sensor.onchange = function(event) {
+    print("rotation (rad/s): " +
+          " x=" + event.reading.rotationRateX +
+          " y=" + event.reading.rotationRateY +
+          " z=" + event.reading.rotationRateZ);
+};
+
+sensor.onstatechange = function(event) {
+    console.log("state: " + event);
+};
+
+sensor.onerrorchange = function(error) {
+    console.log("error: " + error);
+};
+
+sensor.start();

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -162,7 +162,7 @@ if [ $? -eq 0 ] && [[ $MODULE != *"BUILD_MODULE_BUFFER"* ]]; then
     >&2 echo Using module: Buffer
     MODULES+=" -DBUILD_MODULE_BUFFER"
 fi
-sensor=$(grep -E AccelerometerSensor\|Gyroscope  $SCRIPT)
+sensor=$(grep -E Accelerometer\|Gyroscope  $SCRIPT)
 if [ $? -eq 0 ]; then
     >&2 echo Using module: Sensor
     MODULES+=" -DBUILD_MODULE_SENSOR"

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -162,6 +162,11 @@ if [ $? -eq 0 ] && [[ $MODULE != *"BUILD_MODULE_BUFFER"* ]]; then
     >&2 echo Using module: Buffer
     MODULES+=" -DBUILD_MODULE_BUFFER"
 fi
+sensor=$(grep -E AccelerometerSensor\|Gyroscope  $SCRIPT)
+if [ $? -eq 0 ]; then
+    >&2 echo Using module: Sensor
+    MODULES+=" -DBUILD_MODULE_SENSOR"
+fi
 
 console=$(grep console $SCRIPT)
 if [ $? -eq 0 ] && [[ $MODULE != *"BUILD_MODULE_CONSOLE"* ]]; then

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -166,6 +166,14 @@ sensor=$(grep -E Accelerometer\|Gyroscope  $SCRIPT)
 if [ $? -eq 0 ]; then
     >&2 echo Using module: Sensor
     MODULES+=" -DBUILD_MODULE_SENSOR"
+    echo "CONFIG_SPI=y" >> arc/prj.conf.tmp
+    echo "CONFIG_SENSOR=y" >> arc/prj.conf.tmp
+    echo "CONFIG_BMI160=y" >> arc/prj.conf.tmp
+    echo "CONFIG_BMI160_INIT_PRIORITY=80" >> arc/prj.conf.tmp
+    echo "CONFIG_BMI160_NAME=\"bmi160\"" >> arc/prj.conf.tmp
+    echo "CONFIG_BMI160_SPI_PORT_NAME=\"SPI_1\"" >> arc/prj.conf.tmp
+    echo "CONFIG_BMI160_SLAVE=1" >> arc/prj.conf.tmp
+    echo "CONFIG_BMI160_SPI_BUS_FREQ=88" >> arc/prj.conf.tmp
 fi
 
 console=$(grep console $SCRIPT)

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -48,8 +48,9 @@ obj-y += main.o \
 # skip for now for frdm_k64f
 ifneq ($(BOARD), frdm_k64f)
 obj-y += zjs_aio.o \
+         zjs_grove_lcd.o \
          zjs_i2c.o \
-         zjs_grove_lcd.o
+         zjs_sensor.o
 endif
 
 obj-$(CONFIG_BOARD_ARDUINO_101) += \
@@ -65,6 +66,7 @@ ccflags-y += -DBUILD_MODULE_GPIO -DBUILD_MODULE_PWM -DBUILD_MODULE_UART
 ccflags-y += -DBUILD_MODULE_BLE -DBUILD_MODULE_AIO -DBUILD_MODULE_A101
 ccflags-y += -DBUILD_MODULE_TIMER -DBUILD_MODULE_BUFFER
 ccflags-y += -DBUILD_MODULE_GROVE_LCD -DBUILD_MODULE_I2C
+ccflags-y += -DBUILD_MODULE_SENSOR
 export JERRY_INCLUDE = $(JERRY_BASE)/jerry-core/
 obj-y += ashell/
 endif

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@
 #include "zjs_console.h"
 #include "zjs_event.h"
 #include "zjs_modules.h"
+#include "zjs_sensor.h"
 #include "zjs_timers.h"
 #include "zjs_util.h"
 #ifdef BUILD_MODULE_OCF
@@ -94,6 +95,9 @@ int main(int argc, char *argv[])
 #endif
 #ifdef BUILD_MODULE_BUFFER
     zjs_buffer_init();
+#endif
+#ifdef BUILD_MODULE_SENSOR
+    zjs_sensor_init();
 #endif
     zjs_init_callbacks();
 

--- a/src/main.c
+++ b/src/main.c
@@ -23,7 +23,9 @@
 #include "zjs_console.h"
 #include "zjs_event.h"
 #include "zjs_modules.h"
+#ifdef BUILD_MODULE_SENSOR
 #include "zjs_sensor.h"
+#endif
 #include "zjs_timers.h"
 #include "zjs_util.h"
 #ifdef BUILD_MODULE_OCF

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -4,15 +4,27 @@
 #define __zjs_ipm_h__
 
 #include <ipm.h>
+#ifdef BUILD_MODULE_SENSOR
+#include <sensor.h>
+#endif
 
 #define IPM_CHANNEL_X86_TO_ARC                             0x01
 #define IPM_CHANNEL_ARC_TO_X86                             0x02
 
 // Message IDs
 #define MSG_ID_DONE                                        0x00
+#ifdef BUILD_MODULE_AIO
 #define MSG_ID_AIO                                         0x01
+#endif
+#ifdef BUILD_MODULE_I2C
 #define MSG_ID_I2C                                         0x02
+#endif
+#ifdef BUILD_MODULE_GROVE_LCD
 #define MSG_ID_GLCD                                        0x03
+#endif
+#ifdef BUILD_MODULE_SENSOR
+#define MSG_ID_SENSOR                                      0x04
+#endif
 
 // Message flags
 enum {
@@ -26,10 +38,12 @@ enum {
 #define ERROR_IPM_NOT_SUPPORTED                            0x0001
 #define ERROR_IPM_INVALID_PARAMETER                        0x0002
 #define ERROR_IPM_OPERATION_FAILED                         0x0003
+#define ERROR_IPM_OPERATION_DENIED                         0x0004
 
 // Message Types
 
 // AIO
+#ifdef BUILD_MODULE_AIO
 #define TYPE_AIO_OPEN                                      0x0000
 #define TYPE_AIO_PIN_READ                                  0x0001
 #define TYPE_AIO_PIN_ABORT                                 0x0002
@@ -37,16 +51,20 @@ enum {
 #define TYPE_AIO_PIN_SUBSCRIBE                             0x0004
 #define TYPE_AIO_PIN_UNSUBSCRIBE                           0x0005
 #define TYPE_AIO_PIN_EVENT_VALUE_CHANGE                    0x0006
+#endif
 
 // I2C
+#ifdef BUILD_MODULE_I2C
 #define TYPE_I2C_OPEN                                      0x0010
 #define TYPE_I2C_WRITE                                     0x0011
 #define TYPE_I2C_WRITE_BIT                                 0x0012
 #define TYPE_I2C_READ                                      0x0013
 #define TYPE_I2C_TRANSFER                                  0x0014
 #define TYPE_I2C_BURST_READ                                0x0015
+#endif
 
 // GROVE_LCD
+#ifdef BUILD_MODULE_GROVE_LCD
 #define TYPE_GLCD_INIT                                     0x0020
 #define TYPE_GLCD_PRINT                                    0x0021
 #define TYPE_GLCD_CLEAR                                    0x0022
@@ -59,7 +77,16 @@ enum {
 #define TYPE_GLCD_SET_DISPLAY_STATE                        0x0029
 #define TYPE_GLCD_SET_INPUT_STATE                          0x002A
 #define TYPE_GLCD_GET_INPUT_STATE                          0x002B
+#endif
 
+// SENSOR
+#ifdef BUILD_MODULE_SENSOR
+#define TYPE_SENSOR_INIT                                   0x0030
+#define TYPE_SENSOR_START                                  0x0031
+#define TYPE_SENSOR_STOP                                   0x0032
+#define TYPE_SENSOR_EVENT_STATE_CHANGE                     0x0033
+#define TYPE_SENSOR_EVENT_VALUE_CHANGE                     0x0034
+#endif
 
 typedef struct zjs_ipm_message {
     uint32_t id;
@@ -69,13 +96,14 @@ typedef struct zjs_ipm_message {
     uint32_t error_code;
 
     union {
-        // AIO
+#ifdef BUILD_MODULE_AIO
         struct aio_data {
             uint32_t pin;
             uint32_t value;
         } aio;
+#endif
 
-        // I2C
+#ifdef BUILD_MODULE_I2C
         struct i2c_data {
             uint8_t bus;
             uint8_t speed;
@@ -84,8 +112,9 @@ typedef struct zjs_ipm_message {
             uint8_t *data;
             uint32_t length;
         } i2c;
+#endif
 
-        // GROVE_LCD
+#ifdef BUILD_MODULE_GROVE_LCD
         struct glcd_data {
             uint8_t value;
             uint8_t col;
@@ -95,6 +124,15 @@ typedef struct zjs_ipm_message {
             uint8_t color_b;
             void *buffer;
         } glcd;
+#endif
+
+#ifdef BUILD_MODULE_SENSOR
+        struct sensor_data {
+            enum sensor_channel channel;
+            uint32_t frequency;
+            double value[3];
+        } sensor;
+#endif
     } data;
 } zjs_ipm_message_t;
 

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -13,18 +13,10 @@
 
 // Message IDs
 #define MSG_ID_DONE                                        0x00
-#ifdef BUILD_MODULE_AIO
 #define MSG_ID_AIO                                         0x01
-#endif
-#ifdef BUILD_MODULE_I2C
 #define MSG_ID_I2C                                         0x02
-#endif
-#ifdef BUILD_MODULE_GROVE_LCD
 #define MSG_ID_GLCD                                        0x03
-#endif
-#ifdef BUILD_MODULE_SENSOR
 #define MSG_ID_SENSOR                                      0x04
-#endif
 
 // Message flags
 enum {
@@ -43,7 +35,6 @@ enum {
 // Message Types
 
 // AIO
-#ifdef BUILD_MODULE_AIO
 #define TYPE_AIO_OPEN                                      0x0000
 #define TYPE_AIO_PIN_READ                                  0x0001
 #define TYPE_AIO_PIN_ABORT                                 0x0002
@@ -51,20 +42,16 @@ enum {
 #define TYPE_AIO_PIN_SUBSCRIBE                             0x0004
 #define TYPE_AIO_PIN_UNSUBSCRIBE                           0x0005
 #define TYPE_AIO_PIN_EVENT_VALUE_CHANGE                    0x0006
-#endif
 
 // I2C
-#ifdef BUILD_MODULE_I2C
 #define TYPE_I2C_OPEN                                      0x0010
 #define TYPE_I2C_WRITE                                     0x0011
 #define TYPE_I2C_WRITE_BIT                                 0x0012
 #define TYPE_I2C_READ                                      0x0013
 #define TYPE_I2C_TRANSFER                                  0x0014
 #define TYPE_I2C_BURST_READ                                0x0015
-#endif
 
 // GROVE_LCD
-#ifdef BUILD_MODULE_GROVE_LCD
 #define TYPE_GLCD_INIT                                     0x0020
 #define TYPE_GLCD_PRINT                                    0x0021
 #define TYPE_GLCD_CLEAR                                    0x0022
@@ -77,16 +64,13 @@ enum {
 #define TYPE_GLCD_SET_DISPLAY_STATE                        0x0029
 #define TYPE_GLCD_SET_INPUT_STATE                          0x002A
 #define TYPE_GLCD_GET_INPUT_STATE                          0x002B
-#endif
 
 // SENSOR
-#ifdef BUILD_MODULE_SENSOR
 #define TYPE_SENSOR_INIT                                   0x0030
 #define TYPE_SENSOR_START                                  0x0031
 #define TYPE_SENSOR_STOP                                   0x0032
 #define TYPE_SENSOR_EVENT_STATE_CHANGE                     0x0033
 #define TYPE_SENSOR_EVENT_READING_CHANGE                   0x0034
-#endif
 
 typedef struct zjs_ipm_message {
     uint32_t id;
@@ -96,14 +80,13 @@ typedef struct zjs_ipm_message {
     uint32_t error_code;
 
     union {
-#ifdef BUILD_MODULE_AIO
+        // AIO
         struct aio_data {
             uint32_t pin;
             uint32_t value;
         } aio;
-#endif
 
-#ifdef BUILD_MODULE_I2C
+        // I2C
         struct i2c_data {
             uint8_t bus;
             uint8_t speed;
@@ -112,9 +95,8 @@ typedef struct zjs_ipm_message {
             uint8_t *data;
             uint32_t length;
         } i2c;
-#endif
 
-#ifdef BUILD_MODULE_GROVE_LCD
+        // GROVE_LCD
         struct glcd_data {
             uint8_t value;
             uint8_t col;
@@ -124,9 +106,8 @@ typedef struct zjs_ipm_message {
             uint8_t color_b;
             void *buffer;
         } glcd;
-#endif
 
-#ifdef BUILD_MODULE_SENSOR
+        // SENSOR
         struct sensor_data {
             enum sensor_channel channel;
             uint32_t frequency;
@@ -142,7 +123,6 @@ typedef struct zjs_ipm_message {
                 double dval;
             } reading;
         } sensor;
-#endif
     } data;
 } zjs_ipm_message_t;
 

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -4,9 +4,7 @@
 #define __zjs_ipm_h__
 
 #include <ipm.h>
-#ifdef BUILD_MODULE_SENSOR
 #include <sensor.h>
-#endif
 
 #define IPM_CHANNEL_X86_TO_ARC                             0x01
 #define IPM_CHANNEL_ARC_TO_X86                             0x02

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -131,6 +131,16 @@ typedef struct zjs_ipm_message {
             enum sensor_channel channel;
             uint32_t frequency;
             double value[3];
+            union sensor_reading {
+                // x y z axis for Accelerometer and Gyroscope
+                struct {
+                    double x;
+                    double y;
+                    double z;
+                };
+                // single value sensors eg. ambient light
+                double dval;
+            } reading;
         } sensor;
 #endif
     } data;

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -38,7 +38,7 @@ enum {
 #define ERROR_IPM_NOT_SUPPORTED                            0x0001
 #define ERROR_IPM_INVALID_PARAMETER                        0x0002
 #define ERROR_IPM_OPERATION_FAILED                         0x0003
-#define ERROR_IPM_OPERATION_DENIED                         0x0004
+#define ERROR_IPM_OPERATION_NOT_ALLOWED                    0x0004
 
 // Message Types
 

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -85,7 +85,7 @@ enum {
 #define TYPE_SENSOR_START                                  0x0031
 #define TYPE_SENSOR_STOP                                   0x0032
 #define TYPE_SENSOR_EVENT_STATE_CHANGE                     0x0033
-#define TYPE_SENSOR_EVENT_VALUE_CHANGE                     0x0034
+#define TYPE_SENSOR_EVENT_READING_CHANGE                   0x0034
 #endif
 
 typedef struct zjs_ipm_message {

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -1,0 +1,511 @@
+// Copyright (c) 2016, Intel Corporation.
+#ifdef BUILD_MODULE_SENSOR
+#ifndef QEMU_BUILD
+#ifndef ZJS_LINUX_BUILD
+// Zephyr includes
+#include <zephyr.h>
+#endif
+
+#include <string.h>
+
+// ZJS includes
+#include "zjs_sensor.h"
+#include "zjs_callbacks.h"
+#include "zjs_ipm.h"
+#include "zjs_util.h"
+
+#define ZJS_SENSOR_TIMEOUT_TICKS                      500
+
+static struct nano_sem sensor_sem;
+
+enum sensor_state {
+    SENSOR_STATE_IDLE,
+    SENSOR_STATE_ACTIVATING,
+    SENSOR_STATE_ACTIVATED,
+    SENSOR_STATE_ERRORED,
+};
+
+typedef struct sensor_handle {
+    int32_t id;
+    enum sensor_channel channel;
+    enum sensor_state state;
+    double sensor_value[3];
+    jerry_value_t sensor_obj;
+    struct sensor_handle *next;
+} sensor_handle_t;
+
+static sensor_handle_t *accel_handle = NULL;
+static sensor_handle_t *gyro_handle = NULL;
+
+static sensor_handle_t *zjs_sensor_alloc_handle(enum sensor_channel channel)
+{
+    size_t size = sizeof(sensor_handle_t);
+    sensor_handle_t *handle = zjs_malloc(size);
+    if (handle) {
+        memset(handle, 0, size);
+    }
+
+    // append to the list
+    sensor_handle_t **head = NULL;
+    if (channel == SENSOR_CHAN_ACCEL_ANY) {
+        head = &accel_handle;
+    }
+    else if (channel == SENSOR_CHAN_GYRO_ANY) {
+        head = &gyro_handle;
+    } else {
+        PRINT("zjs_sensor_alloc_handle: invalid channel\n");
+        zjs_free(handle);
+        return NULL;
+    }
+
+    while (*head != NULL) {
+        head = &(*head)->next;
+    }
+    *head = handle;
+
+    return handle;
+}
+
+static void zjs_sensor_free_handles(sensor_handle_t *handle)
+{
+    sensor_handle_t *tmp;
+    while (handle != NULL) {
+        tmp = handle;
+        handle = handle->next;
+        jerry_release_value(tmp->sensor_obj);
+        zjs_free(tmp);
+    }
+}
+
+static bool zjs_sensor_ipm_send_sync(zjs_ipm_message_t* send,
+                                     zjs_ipm_message_t* result)
+{
+    send->id = MSG_ID_SENSOR;
+    send->flags = 0 | MSG_SYNC_FLAG;
+    send->user_data = (void *)result;
+    send->error_code = ERROR_IPM_NONE;
+
+    if (zjs_ipm_send(MSG_ID_SENSOR, send) != 0) {
+        PRINT("zjs_sensor_ipm_send_sync: failed to send message\n");
+        return false;
+    }
+
+    // block until reply or timeout, we shouldn't see the ARC
+    // time out, if the ARC response comes back after it
+    // times out, it could pollute the result on the stack
+    if (!nano_sem_take(&sensor_sem, ZJS_SENSOR_TIMEOUT_TICKS)) {
+        PRINT("zjs_sensor_ipm_send_sync: FATAL ERROR, ipm timed out\n");
+        return false;
+    }
+
+    return true;
+}
+
+static int zjs_sensor_call_remote_function(zjs_ipm_message_t* send)
+{
+    zjs_ipm_message_t reply;
+    if (!zjs_sensor_ipm_send_sync(send, &reply)) {
+        return zjs_error("zjs_sensor_call_remote_function: ipm message failed or timed out!");
+    }
+    if (reply.error_code != ERROR_IPM_NONE) {
+        PRINT("zjs_sensor_call_remote_function: error code: %lu\n",
+              reply.error_code);
+    }
+    return reply.error_code;
+}
+
+static enum sensor_state zjs_sensor_get_state(jerry_value_t obj)
+{
+    const int BUFLEN = 20;
+    char buffer[BUFLEN];
+    if (zjs_obj_get_string(obj, "state", buffer, BUFLEN)) {
+        if (!strcmp(buffer, "idle"))
+            return SENSOR_STATE_IDLE;
+        if (!strcmp(buffer, "activating"))
+            return SENSOR_STATE_ACTIVATING;
+        if (!strcmp(buffer, "activated"))
+            return SENSOR_STATE_ACTIVATED;
+        if (!strcmp(buffer, "errored"))
+            return SENSOR_STATE_ERRORED;
+    }
+
+    PRINT("zjs_sensor_get_state: state not set\n");
+    jerry_value_t state = jerry_create_string("errored");
+    zjs_set_property(obj, "state", state);
+    jerry_release_value(state);
+    return SENSOR_STATE_ERRORED;
+}
+
+static void zjs_sensor_set_state(jerry_value_t obj, enum sensor_state state)
+{
+    enum sensor_state old_state = zjs_sensor_get_state(obj);
+    if (old_state == state) {
+        return;
+    }
+
+    // update state property and trigger onstatechange event
+    jerry_value_t new_state;
+    switch(state) {
+    case SENSOR_STATE_IDLE:
+        new_state = jerry_create_string("idle");
+        break;
+    case SENSOR_STATE_ACTIVATING:
+        new_state = jerry_create_string("activating");
+        break;
+    case SENSOR_STATE_ACTIVATED:
+        new_state = jerry_create_string("activated");
+        break;
+    case SENSOR_STATE_ERRORED:
+        new_state = jerry_create_string("errored");
+        break;
+    }
+    zjs_set_property(obj, "state", new_state);
+
+    jerry_value_t func = zjs_get_property(obj, "onstatechange");
+    if (jerry_value_is_function(func)) {
+        // if onstatechange exists, call it
+        jerry_value_t rval = jerry_call_function(func, obj, &new_state, 1);
+        if (jerry_value_has_error_flag(rval)) {
+            PRINT("zjs_sensor_set_state: error calling onstatechange\n");
+        }
+        jerry_release_value(rval);
+    }
+    jerry_release_value(func);
+
+    if (old_state == SENSOR_STATE_ACTIVATING &&
+        state == SENSOR_STATE_ACTIVATED) {
+        func = zjs_get_property(obj, "onactivate");
+        if (jerry_value_is_function(func)) {
+            // if onactivate exists, call it
+            jerry_value_t rval = jerry_call_function(func, obj, NULL, 0);
+            if (jerry_value_has_error_flag(rval)) {
+                PRINT("zjs_sensor_set_state: error calling onactivate\n");
+            }
+            jerry_release_value(rval);
+        }
+        jerry_release_value(func);
+    }
+    jerry_release_value(new_state);
+}
+
+static void zjs_sensor_update_reading(jerry_value_t obj,
+                                      enum sensor_channel channel,
+                                      double value[])
+{
+    // update reading property and trigger onchange event
+    double x = value[0];
+    double y = value[1];
+    double z = value[2];
+    jerry_value_t x_val = jerry_create_number(x);
+    jerry_value_t y_val = jerry_create_number(y);
+    jerry_value_t z_val = jerry_create_number(z);
+    jerry_value_t reading_obj = jerry_create_object();
+    if (channel == SENSOR_CHAN_ACCEL_ANY) {
+        zjs_set_property(reading_obj, "accelerationX", x_val);
+        zjs_set_property(reading_obj, "accelerationY", y_val);
+        zjs_set_property(reading_obj, "accelerationZ", z_val);
+    } else if (channel == SENSOR_CHAN_GYRO_ANY) {
+        zjs_set_property(reading_obj, "rotationRateX", x_val);
+        zjs_set_property(reading_obj, "rotationRateY", y_val);
+        zjs_set_property(reading_obj, "rotationRateZ", z_val);
+    }
+    zjs_set_property(obj, "reading", reading_obj);
+    jerry_value_t func = zjs_get_property(obj, "onchange");
+    if (jerry_value_is_function(func)) {
+        jerry_value_t event = jerry_create_object();
+        // if onchange exists, call it
+        zjs_set_property(event, "reading", reading_obj);
+        jerry_value_t rval = jerry_call_function(func, obj, &event, 1);
+        if (jerry_value_has_error_flag(rval)) {
+            PRINT("zjs_sensor_update_reading: error calling onchange\n");
+        }
+        jerry_release_value(rval);
+        jerry_release_value(event);
+    }
+    jerry_release_value(func);
+    jerry_release_value(x_val);
+    jerry_release_value(y_val);
+    jerry_release_value(z_val);
+    jerry_release_value(reading_obj);
+}
+
+static void zjs_sensor_trigger_error(jerry_value_t obj,
+                                     const char *error_type)
+{
+    zjs_sensor_set_state(obj, SENSOR_STATE_ERRORED);
+    jerry_value_t func = zjs_get_property(obj, "onerror");
+    if (jerry_value_is_function(func)) {
+        // if onerror exists, call it
+        jerry_value_t event = jerry_create_string(error_type);
+        jerry_value_t rval = jerry_call_function(func, obj, &event, 1);
+        if (jerry_value_has_error_flag(rval)) {
+            PRINT("zjs_sensor_trigger_error: error calling onerrorhange\n");
+        }
+        jerry_release_value(rval);
+        jerry_release_value(event);
+    }
+    jerry_release_value(func);
+}
+
+static void zjs_sensor_onchange_c_callback(void *h)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    if (!handle) {
+        PRINT("zjs_sensor_onchange_c_callback: handle not found\n");
+        return;
+    }
+    zjs_sensor_update_reading(handle->sensor_obj,
+                              handle->channel,
+                              handle->sensor_value);
+}
+
+static void zjs_sensor_signal_callbacks(sensor_handle_t *handle, double value[])
+{
+    if (!handle)
+        return;
+
+    // iterate all sensor instances to update readings and trigger event
+    for (sensor_handle_t *h = handle; h; h = h->next) {
+        memcpy(h->sensor_value, value, sizeof(double) * 3);
+        zjs_signal_callback(h->id);
+    }
+}
+
+static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *data)
+{
+    if (id != MSG_ID_SENSOR)
+        return;
+
+    zjs_ipm_message_t *msg = (zjs_ipm_message_t*)(*(uintptr_t *)data);
+    if ((msg->flags & MSG_SYNC_FLAG) == MSG_SYNC_FLAG) {
+        zjs_ipm_message_t *result = (zjs_ipm_message_t*)msg->user_data;
+        // synchrounus ipm, copy the results
+        if (result) {
+            memcpy(result, msg, sizeof(zjs_ipm_message_t));
+        }
+        // un-block sync api
+        nano_isr_sem_give(&sensor_sem);
+    } else if (msg->type == TYPE_SENSOR_EVENT_VALUE_CHANGE) {
+        // value change event, copy the data, and signal event callback
+        if (msg->data.sensor.channel == SENSOR_CHAN_ACCEL_ANY) {
+            zjs_sensor_signal_callbacks(accel_handle, msg->data.sensor.value);
+        }
+        else if (msg->data.sensor.channel == SENSOR_CHAN_GYRO_ANY) {
+            zjs_sensor_signal_callbacks(gyro_handle, msg->data.sensor.value);
+        } else {
+            PRINT("ipm_msg_receive_callback: unsupported sensor type\n");
+        }
+    } else {
+        PRINT("ipm_msg_receive_callback: unsupported message received\n");
+    }
+}
+
+static void zjs_sensor_callback_free(uintptr_t handle)
+{
+    zjs_free((sensor_handle_t *)handle);
+}
+
+static jerry_value_t zjs_sensor_start(const jerry_value_t function_obj,
+                                      const jerry_value_t this,
+                                      const jerry_value_t argv[],
+                                      const jerry_length_t argc)
+{
+    // requires: this is a Sensor object from takes no args
+    //  effects: activates the sensor and start monitoring changes
+    uintptr_t ptr;
+    sensor_handle_t *handle = NULL;
+    if (jerry_get_object_native_handle(this, &ptr)) {
+         handle = (sensor_handle_t *)ptr;
+         if (!handle) {
+             return zjs_error("zjs_sensor_start: cannot find handle");
+         }
+    }
+
+    enum sensor_state state = zjs_sensor_get_state(this);
+    if (state != SENSOR_STATE_IDLE && state != SENSOR_STATE_ERRORED) {
+        return zjs_error("zjs_sensor_start: invalid state");
+    }
+
+    zjs_sensor_set_state(this, SENSOR_STATE_ACTIVATING);
+    zjs_ipm_message_t send;
+    send.type = TYPE_SENSOR_START;
+    send.data.sensor.channel = handle->channel;
+    int error = zjs_sensor_call_remote_function(&send);
+    if (error != ERROR_IPM_NONE) {
+        if (error == ERROR_IPM_OPERATION_DENIED) {
+            zjs_sensor_trigger_error(this, "NotAllowedError");
+        }
+        else {
+            // throw exception for all other errors
+            return zjs_error("zjs_sensor_start: operation failed");
+        }
+    }
+    zjs_sensor_set_state(this, SENSOR_STATE_ACTIVATED);
+    return ZJS_UNDEFINED;
+}
+
+static jerry_value_t zjs_sensor_stop(const jerry_value_t function_obj,
+                                     const jerry_value_t this,
+                                     const jerry_value_t argv[],
+                                     const jerry_length_t argc)
+{
+    // requires: this is a Sensor object from takes no args
+    //  effects: de-activates the sensor and stop monitoring changes
+    uintptr_t ptr;
+    sensor_handle_t *handle = NULL;
+    if (jerry_get_object_native_handle(this, &ptr)) {
+         handle = (sensor_handle_t *)ptr;
+         if (!handle) {
+             return zjs_error("zjs_sensor_stop: cannot find handle");
+         }
+    }
+
+    enum sensor_state state = zjs_sensor_get_state(this);
+    if (state == SENSOR_STATE_IDLE || state == SENSOR_STATE_ERRORED) {
+        return zjs_error("zjs_sensor_stop: invalid state");
+    }
+
+    zjs_ipm_message_t send;
+    send.type = TYPE_SENSOR_STOP;
+    send.data.sensor.channel = handle->channel;
+    int error = zjs_sensor_call_remote_function(&send);
+    if (error != ERROR_IPM_NONE) {
+        // throw exception for all other errors
+        return zjs_error("zjs_sensor_start: operation failed");
+    }
+    jerry_value_t reading_val = jerry_create_null();
+    zjs_set_property(this, "reading", reading_val);
+    jerry_release_value(reading_val);
+    zjs_sensor_set_state(this, SENSOR_STATE_IDLE);
+    return ZJS_UNDEFINED;
+}
+
+static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
+                                       const jerry_value_t this,
+                                       const jerry_value_t argv[],
+                                       const jerry_length_t argc,
+                                       enum sensor_channel channel)
+{
+    double frequency = 50; // default frequency
+    if (argc >= 1) {
+        if (!jerry_value_is_object(argv[0]))
+            return zjs_error("zjs_sensor_create: invalid argument");
+
+        jerry_value_t options = argv[0];
+
+        double option_freq;
+        if (zjs_obj_get_double(options, "frequency", &option_freq)) {
+            // TODO: figure out a list of frequencies we can support
+            // and have Zephyr trigger value changes instead of
+            // polling on the ARC.
+            // For now, frequency is ignored,  we just report new event
+            // as soon as we detect a value change.
+            if (option_freq <= 0) {
+                PRINT("zjs_sensor_create: invalid frequency, default to 50hz\n");
+            } else {
+                frequency = option_freq;
+            }
+        } else {
+            PRINT("zjs_sensor_create: frequency not found, default to 50hz\n");
+        }
+
+        if (channel == SENSOR_CHAN_ACCEL_ANY) {
+            bool option_gravity;
+            if (zjs_obj_get_boolean(options, "includeGravity", &option_gravity) &&
+                option_gravity) {
+                // TODO: find out if BMI160 can be configured to include gravity
+                PRINT("zjs_sensor_create: includeGravity is not supported\n");
+            }
+        }
+    }
+
+    zjs_ipm_message_t send;
+    send.type = TYPE_SENSOR_INIT;
+    jerry_value_t result = zjs_sensor_call_remote_function(&send);
+    if (jerry_value_has_error_flag(result)) {
+        return result;
+    }
+
+    // initialize object and default values
+    jerry_value_t sensor_obj = jerry_create_object();
+    jerry_value_t frequency_val = jerry_create_number(frequency);
+    jerry_value_t state_val = jerry_create_string("idle");
+    jerry_value_t reading_val = jerry_create_null();
+    zjs_set_property(sensor_obj, "frequency", frequency_val);
+    zjs_set_property(sensor_obj, "state", state_val);
+    zjs_set_property(sensor_obj, "reading", reading_val);
+    jerry_release_value(frequency_val);
+    jerry_release_value(state_val);
+    jerry_release_value(reading_val);
+
+    zjs_obj_add_function(sensor_obj, zjs_sensor_start, "start");
+    zjs_obj_add_function(sensor_obj, zjs_sensor_stop, "stop");
+
+    sensor_handle_t* handle = zjs_sensor_alloc_handle(channel);
+    handle->id = zjs_add_c_callback(handle, zjs_sensor_onchange_c_callback);
+    handle->channel = channel;
+    handle->sensor_obj = sensor_obj;
+
+    // watch for the object getting garbage collected, and clean up
+    jerry_set_object_native_handle(sensor_obj, (uintptr_t)handle,
+                                   zjs_sensor_callback_free);
+
+    return sensor_obj;
+}
+
+static jerry_value_t zjs_accel_create(const jerry_value_t function_obj,
+                                      const jerry_value_t this,
+                                      const jerry_value_t argv[],
+                                      const jerry_length_t argc)
+{
+    // requires: arg 0 is an object containing sensor options:
+    //             frequency (double) - sampling frequency, default to 60
+    //             includeGravity (bool) - whether you want gravity included
+    //  effects: Creates a AccelerometerSensor object to the local sensor
+    return zjs_sensor_create(function_obj,
+                             this,
+                             argv,
+                             argc,
+                             SENSOR_CHAN_ACCEL_ANY);
+}
+
+static jerry_value_t zjs_gyro_create(const jerry_value_t function_obj,
+                                     const jerry_value_t this,
+                                     const jerry_value_t argv[],
+                                     const jerry_length_t argc)
+{
+    // requires: arg 0 is an object containing sensor options:
+    //             frequency (double) - sampling frequency, default to 50
+    //  effects: Creates a Gyroscope object to the local sensor
+    return zjs_sensor_create(function_obj,
+                             this,
+                             argv,
+                             argc,
+                             SENSOR_CHAN_GYRO_ANY);
+}
+
+void zjs_sensor_init()
+{
+    zjs_ipm_init();
+    zjs_ipm_register_callback(MSG_ID_SENSOR, ipm_msg_receive_callback);
+
+    nano_sem_init(&sensor_sem);
+
+    jerry_value_t global_obj = jerry_get_global_object();
+    zjs_obj_add_function(global_obj, zjs_accel_create, "AccelerometerSensor");
+    zjs_obj_add_function(global_obj, zjs_gyro_create, "Gyroscope");
+    jerry_release_value(global_obj);
+}
+
+void zjs_sensor_cleanup()
+{
+    if (accel_handle) {
+        zjs_sensor_free_handles(accel_handle);
+    }
+    if (gyro_handle) {
+        zjs_sensor_free_handles(gyro_handle);
+    }
+}
+
+#endif // QEMU_BUILD
+#endif // BUILD_MODULE_SENSOR

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -251,7 +251,7 @@ static void zjs_sensor_trigger_error(jerry_value_t obj,
     jerry_release_value(func);
 }
 
-static void zjs_sensor_onchange_c_callback(void *h)
+static void zjs_sensor_onchange_c_callback(void *h, void *argv)
 {
     sensor_handle_t *handle = (sensor_handle_t *)h;
     if (!handle) {
@@ -272,7 +272,7 @@ static void zjs_sensor_signal_callbacks(sensor_handle_t *handle,
     // iterate all sensor instances to update readings and trigger event
     for (sensor_handle_t *h = handle; h; h = h->next) {
         memcpy(&h->reading, &reading, sizeof(reading));
-        zjs_signal_callback(h->id);
+        zjs_signal_callback(h->id, NULL, 0);
     }
 }
 

--- a/src/zjs_sensor.h
+++ b/src/zjs_sensor.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2016, Intel Corporation.
+
+#ifndef __zjs_sensor_h__
+#define __zjs_sensor_h__
+
+#include "jerry-api.h"
+
+void zjs_sensor_init();
+
+#endif  // __zjs_sensor_h__


### PR DESCRIPTION
Initial implementation for the W3C Generic Sensor API and add
support for the Accelerometer and Gyroscope sensors using
the BMI160 inertia sensor built-in on the Arduino 101,
the current implementation is polling from the ARC and channeling
the data back to X86.

Also adding two sample JS code testing both APIs.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>