### PR TITLE
[performance] New module implementing performance counter API.

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -14,6 +14,7 @@ CORE_SRC = 	src/main.c \
 			src/zjs_event.c \
 			src/zjs_linux_time.c \
 			src/zjs_modules.c \
+			src/zjs_performance.c \
 			src/zjs_script.c \
 			src/zjs_script_gen.c \
 			src/zjs_timers.c \
@@ -30,7 +31,8 @@ JERRY_LIB_PATH = 	-L$(JERRY_BASE)/build/lib/
 
 LINUX_FLAGS = -std=gnu99 -Wpointer-sign
 
-LINUX_DEFINES = -DZJS_LINUX_BUILD -DBUILD_MODULE_EVENTS -DBUILD_MODULE_CONSOLE
+LINUX_DEFINES = -DZJS_LINUX_BUILD -DBUILD_MODULE_EVENTS -DBUILD_MODULE_CONSOLE \
+		-DBUILD_MODULE_PERFORMANCE
 
 ifeq ($(VARIANT), debug)
 LINUX_DEFINES += -DDEBUG_BUILD

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,4 +29,6 @@ General
 -------
 [Buffer](./buffer.md)
 
+[Performance](./performance.md)
+
 [Timers](./timers.md)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,58 @@
+ZJS API for Benchmarking
+========================
+
+* [Introduction](#introduction)
+* [Web IDL](#web-idl)
+* [API Documentation](#api-documentation)
+* [Sample Apps](#sample-apps)
+
+Introduction
+------------
+"Performance" module implements a subset of "High Resolution Time" specification
+from W3C, intended primarily for benchmarking purposes. The key point of this
+module is that it is very light-weight by implementing just one function
+(unlike for example Date object).
+
+Web IDL
+-------
+This IDL provides an overview of the interface; see below for documentation of
+specific API functions.
+
+```javascript
+double now();
+```
+
+API Documentation
+-----------------
+### now
+
+`now();
+`
+
+The module exposes just one function, `now()`. It returns current time in
+milliseconds, as a floating-point number, since an arbitrary point in
+time. It is thus not useful as an absolute value, but subtracting values
+from two calls will give a time duration between these two calls.
+
+As the value returned is floating point, it may have higher resolution
+than a millisecond. However, the actual resolution depends on a platform
+and its configuration. For example, default Zephyr configuration for
+many boards provides resolution of only ones or tens of milliseconds.
+
+The intended usage of this function is for benchmarking and other testing
+and development needs.
+
+
+Examples
+--------
+
+    var performance = require("performance");
+
+    t = performance.now()
+    do_long_operation();
+    console.log("Long operation took:", performance.now() - t, "ms");
+
+
+Sample Apps
+-----------
+* [Performance module unit test](../tests/test-performance.js)

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -41,6 +41,11 @@ if [ $? -eq 0 ]; then
     MODULES+=" -DBUILD_MODULE_GPIO"
     echo "CONFIG_GPIO=y" >> prj.conf.tmp
 fi
+check_for_require performance
+if [ $? -eq 0 ]; then
+    >&2 echo Using module: Performance
+    MODULES+=" -DBUILD_MODULE_PERFORMANCE"
+fi
 check_for_require pwm
 if [ $? -eq 0 ]; then
     >&2 echo Using module: PWM

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -26,6 +26,7 @@ obj-y += main.o \
          zjs_event.o \
          zjs_gpio.o \
          zjs_modules.o \
+         zjs_performance.o \
          zjs_promise.o \
          zjs_pwm.o \
          zjs_script.o \

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -10,6 +10,7 @@
 // ZJS includes
 #include "zjs_event.h"
 #include "zjs_modules.h"
+#include "zjs_performance.h"
 #include "zjs_util.h"
 
 #ifndef ZJS_LINUX_BUILD
@@ -70,6 +71,9 @@ module_t zjs_modules_array[] = {
 
 #ifdef BUILD_MODULE_EVENTS
     { "events", zjs_event_init },
+#endif
+#ifdef BUILD_MODULE_PERFORMANCE
+    { "performance", zjs_performance_init },
 #endif
 };
 

--- a/src/zjs_performance.c
+++ b/src/zjs_performance.c
@@ -1,0 +1,32 @@
+// Copyright (c) 2016, Linaro Limited.
+#ifdef BUILD_MODULE_PERFORMANCE
+
+// ZJS includes
+#include "zjs_util.h"
+
+static jerry_value_t zjs_performance_now(const jerry_value_t function_obj,
+                                         const jerry_value_t this,
+                                         const jerry_value_t argv[],
+                                         const jerry_length_t argc)
+{
+    if (argc != 0)
+        return zjs_error("performance.now: no args expected");
+#ifdef ZJS_LINUX_BUILD
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    uint64_t useconds = (uint64_t)tv.tv_sec * 1000000 + tv.tv_usec;
+#else
+    uint64_t useconds = (uint64_t)sys_tick_get() * (unsigned)sys_clock_us_per_tick;
+#endif
+    return jerry_create_number((double)useconds / 1000);
+}
+
+jerry_value_t zjs_performance_init()
+{
+    // create global performance object
+    jerry_value_t performance_obj = jerry_create_object();
+    zjs_obj_add_function(performance_obj, zjs_performance_now, "now");
+    return performance_obj;
+}
+
+#endif // BUILD_MODULE_PERFORMANCE

--- a/src/zjs_performance.h
+++ b/src/zjs_performance.h
@@ -1,0 +1,10 @@
+// Copyright (c) 2016, Intel Corporation.
+
+#ifndef __zjs_performance_h__
+#define __zjs_performance_h__
+
+#include "jerry-api.h"
+
+jerry_value_t zjs_performance_init();
+
+#endif  // __zjs_performance_h__

--- a/tests/test-performance.js
+++ b/tests/test-performance.js
@@ -1,0 +1,24 @@
+var performance = require("performance");
+
+var total = 0;
+var passed = 0;
+
+function assert(actual, description) {
+    total += 1;
+    var label = "\033[1m\033[31mFAIL\033[0m";
+    if (actual === true) {
+        passed += 1;
+        label = "\033[1m\033[32mPASS\033[0m";
+    }
+    console.log(label + " - " + description);
+}
+
+var before = performance.now();
+
+setTimeout(function() {
+    var after = performance.now();
+    var diff = after - before;
+    // Allow for some jitter, especially on Linux
+    assert(diff >= 989 && diff <= 1011, "performance.now() result over known delay");
+    console.log("TOTAL: " + passed + " of " + total + " passed");
+}, 1000);


### PR DESCRIPTION
~~~
Based on recent W3C API, formally defined in https://www.w3.org/TR/hr-time/
and informally in
https://developer.mozilla.org/en-US/docs/Web/API/Performance/now . As the
last link suggests, real-world usage boils down to just:

    t = performance.now();

even though formal spec defines more properties for "performance" object.

As defined in the spec for a browser, "performance" is a property of
global window object and thus implicitly present into context of a JS
script. We however define it as a module, so usage pattern is:

    var performance = require("performance");
    t = performance.now();

The returned value is a floating-point number of milliseconds since
arbitrary point in time. This means that its absolute value is
meaningless and only difference between 2 values make sense (and
represent time duration between calls which produced these 2 values).
As the returned value is a floating-point number, it may have higher
resolution than a millisecond (using fractional part). The actual
resolution however depends on a particular Zephyr board, and some
boards provide resolution only of 10 milliseconds.

This module is intended for benchmarking, and in extreme cases, for
synchronous delays, etc. Supported both in Linux and Zephyr builds.
A testcase is included.
~~~