### PR TITLE
[timers] Changing how timers are released

### DIFF
--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -152,7 +152,7 @@ void javascript_stop()
     /* Cleanup engine */
     jerry_cleanup();
     zjs_ipm_free_callbacks();
-    zjs_timers_free_timers();
+    zjs_timers_cleanup();
 
     restore_zjs_api();
 }

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -152,6 +152,7 @@ void javascript_stop()
     /* Cleanup engine */
     jerry_cleanup();
     zjs_ipm_free_callbacks();
+    zjs_timers_free_timers();
 
     restore_zjs_api();
 }

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -93,10 +93,9 @@ static bool delete_timer(int32_t id)
     for (zjs_timer_t **ptm = &zjs_timers; *ptm; ptm = &(*ptm)->next) {
         zjs_timer_t *tm = *ptm;
         if (id == tm->callback_id) {
-            int i;
             zjs_port_timer_stop(&tm->timer);
             *ptm = tm->next;
-            for (i = 0; i < tm->argc; ++i) {
+            for (int i = 0; i < tm->argc; ++i) {
                 jerry_release_value(tm->argv[i]);
             }
             zjs_remove_callback(tm->callback_id);
@@ -108,9 +107,19 @@ static bool delete_timer(int32_t id)
     return false;
 }
 
-static void zjs_timer_free_cb(uintptr_t handle)
+void zjs_timers_free_timers()
 {
-    delete_timer(((zjs_timer_t *)handle)->callback_id);
+    while (zjs_timers) {
+        zjs_timer_t *tm = zjs_timers;
+        zjs_port_timer_stop(&tm->timer);
+        zjs_timers = tm->next;
+        for (int i = 0; i < tm->argc; ++i) {
+            jerry_release_value(tm->argv[i]);
+        }
+        zjs_remove_callback(tm->callback_id);
+        zjs_free(tm->argv);
+        zjs_free(tm);
+    }
 }
 
 static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
@@ -131,7 +140,7 @@ static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
     zjs_timer_t* handle = add_timer(interval, callback, this, repeat, argv, argc - 2);
     if (handle->callback_id == -1)
         return zjs_error("native_set_interval_handler: timer alloc failed");
-    jerry_set_object_native_handle(timer_obj, (uintptr_t)handle, zjs_timer_free_cb);
+    jerry_set_object_native_handle(timer_obj, (uintptr_t)handle, NULL);
 
     return timer_obj;
 }

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -107,17 +107,17 @@ static bool delete_timer(int32_t id)
     return false;
 }
 
-void zjs_timers_free_timers()
+void zjs_timers_cleanup()
 {
     while (zjs_timers) {
-        zjs_timer_t *tm = zjs_timers;
-        zjs_port_timer_stop(&tm->timer);
-        zjs_timers = tm->next;
         for (int i = 0; i < tm->argc; ++i) {
             jerry_release_value(tm->argv[i]);
         }
+        zjs_timer_t *tm = zjs_timers;
+        zjs_port_timer_stop(&tm->timer);
         zjs_remove_callback(tm->callback_id);
         zjs_free(tm->argv);
+        zjs_timers = tm->next;
         zjs_free(tm);
     }
 }

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -110,10 +110,10 @@ static bool delete_timer(int32_t id)
 void zjs_timers_cleanup()
 {
     while (zjs_timers) {
+        zjs_timer_t *tm = zjs_timers;
         for (int i = 0; i < tm->argc; ++i) {
             jerry_release_value(tm->argv[i]);
         }
-        zjs_timer_t *tm = zjs_timers;
         zjs_port_timer_stop(&tm->timer);
         zjs_remove_callback(tm->callback_id);
         zjs_free(tm->argv);

--- a/src/zjs_timers.h
+++ b/src/zjs_timers.h
@@ -5,5 +5,6 @@
 
 void zjs_timers_process_events();
 void zjs_timers_init();
+void zjs_timers_free_timers();
 
 #endif  // __zjs_timers_h__

--- a/src/zjs_timers.h
+++ b/src/zjs_timers.h
@@ -5,6 +5,7 @@
 
 void zjs_timers_process_events();
 void zjs_timers_init();
-void zjs_timers_free_timers();
+// Stops and frees all timers
+void zjs_timers_cleanup();
 
 #endif  // __zjs_timers_h__


### PR DESCRIPTION
Because ZJS implements its own version of setInterval,
the new code to release global objects had a unintended
effect of causing timers that didn't save the return to
be garbage collected after the first call. Now instead
of relying on JerryScript to GC our timers, we will clear
them ourself when jerry_cleanup runs.