### PR TITLE
[docs] Add I2C API docs to the list of APIs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,6 +11,8 @@ I/O
 
 [PWM](./pwm.md)
 
+[I2C](./i2c.md)
+
 Communications
 --------------
 [BLE](./ble.md)


### PR DESCRIPTION
Signed-off-by: Francesco Balestrieri <francesco.balestrieri@intel.com>