### PR TITLE
[travis] Add tests so that all modules get built

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,20 @@ before_script: >
 
 script: >
   if [ "$TARGET" == "zephyr" ]; then
-    banner "Test 1/3" &&
+    banner "Test 1/7" &&
     make V=1 &&
-    banner "Test 2/3" &&
+    banner "Test 2/7" &&
     make V=1 JS=samples/TrafficLight.js &&
-    banner "Test 3/3" &&
-    make V=1 JS=samples/I2C.js
+    banner "Test 3/7" &&
+    make V=1 JS=samples/PWM.js &&
+    banner "Test 4/7" &&
+    make V=1 JS=samples/I2C.js &&
+    banner "Test 5/7" &&
+    make V=1 JS=samples/UART.js &&
+    banner "Test 6/7" &&
+    make V=1 JS=samples/tests/Events.js &&
+    banner "Test 7/7" &&
+    make V=1 JS=tests/test-performance.js
   elif [ "$TARGET" == "zephyr-large" ]; then
     banner "Test 1/1" &&
     make V=1 JS=samples/WebBluetoothGroveLcdDemo.js

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -32,7 +32,7 @@ function check_for_require()
 
 check_for_require events
 if [ $? -eq 0 ]; then
-    >&2 echo Using module: EVENTS
+    >&2 echo Using module: Events
     MODULES+=" -DBUILD_MODULE_EVENTS"
 fi
 check_for_require gpio
@@ -102,7 +102,7 @@ if [ $? -eq 0 ]; then
 fi
 check_for_require grove_lcd
 if [ $? -eq 0 ]; then
-    >&2 echo Using module: GROVE_LCD
+    >&2 echo Using module: Grove LCD
     MODULES+=" -DBUILD_MODULE_GROVE_LCD"
 fi
 check_for_require arduino101_pins


### PR DESCRIPTION
James had a good point that we could have a simple test that just
requires everything; but this seemed more fun for the moment. Maybe
we could even generate that test from the module list to keep from
missing any? Needs a bit more thought.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>