### PR TITLE
[docs] Add I2C API docs to the list of APIs (#387)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,6 +11,8 @@ I/O
 
 [PWM](./pwm.md)
 
+[I2C](./i2c.md)
+
 Communications
 --------------
 [BLE](./ble.md)


### PR DESCRIPTION
Cherry-pick of 66292ff6985cb0cbe7aa6f2b600c57700f43b5a6