### PR TITLE
[travis] Fix git check to use rev-list to be sure it finds a good commit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script: >
   elif [ "$TARGET" == "git-check" ]; then
     # check for any new trailing whitespace since the first fetched commit
     banner "git check" &&
-    git diff --check HEAD~49
+    git diff --check $(git rev-list HEAD | tail -1)
   else
     banner "Test 1/1" &&
     make V=1 $TARGET;


### PR DESCRIPTION
The previous method using HEAD~49 was based on the checkout having gone
to a depth of 50, but under certain circumstances it could fail as it did
for the test build of e9b8279 apparently.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>