### PR TITLE
[callbacks] optimized callbacks

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -19,7 +19,7 @@ static struct nano_sem aio_sem;
 
 typedef struct aio_handle {
     jerry_value_t pin_obj;
-    int32_t callback_id;
+    int16_t callback_id;
     double value;
     jerry_value_t jvalue;
 } aio_handle_t;

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -19,7 +19,7 @@ static struct nano_sem aio_sem;
 
 typedef struct aio_handle {
     jerry_value_t pin_obj;
-    int16_t callback_id;
+    zjs_callback_id callback_id;
     double value;
     jerry_value_t jvalue;
 } aio_handle_t;

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -31,7 +31,7 @@
 struct nano_sem zjs_ble_nano_sem;
 
 typedef struct ble_handle {
-    int16_t id;
+    zjs_callback_id id;
     jerry_value_t js_callback;
     const void *buffer;
     uint16_t buffer_size;
@@ -40,12 +40,12 @@ typedef struct ble_handle {
 } ble_handle_t;
 
 typedef struct ble_notify_handle {
-    int16_t id;
+    zjs_callback_id id;
     jerry_value_t js_callback;
 } ble_notify_handle_t;
 
 typedef struct ble_event_handle {
-    int16_t id;
+    zjs_callback_id id;
     jerry_value_t arg;
 } ble_event_handle_t;
 

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -31,7 +31,7 @@
 struct nano_sem zjs_ble_nano_sem;
 
 typedef struct ble_handle {
-    int32_t id;
+    int16_t id;
     jerry_value_t js_callback;
     const void *buffer;
     uint16_t buffer_size;
@@ -40,12 +40,12 @@ typedef struct ble_handle {
 } ble_handle_t;
 
 typedef struct ble_notify_handle {
-    int32_t id;
+    int16_t id;
     jerry_value_t js_callback;
 } ble_notify_handle_t;
 
 typedef struct ble_event_handle {
-    int32_t id;
+    int16_t id;
     jerry_value_t arg;
 } ble_event_handle_t;
 

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -30,33 +30,32 @@
 
 #define CALLBACK_TYPE_JS    0
 #define CALLBACK_TYPE_C     1
+#define JS_TYPE_SINGLE      0
+#define JS_TYPE_LIST        1
 
 #define CB_LIST_MULTIPLIER  4
 
+#define ONCE_BIT    0
+#define TYPE_BIT    1
+#define JS_TYPE_BIT 2
+#define GET_ONCE(f)     (f & (1 << ONCE_BIT))
+#define GET_TYPE(f)     (f & (1 << TYPE_BIT))
+#define GET_JS_TYPE(f)  (f & (1 << JS_TYPE_BIT))
+
 struct zjs_callback_t {
+    int16_t id;
     void* handle;
+    uint8_t flags;      // holds once and type bits
     zjs_post_callback_func post;
-    jerry_value_t js_func;
     jerry_value_t this;
-    uint8_t once;
-    int max_funcs;
-    int num_funcs;
-    jerry_value_t* func_list;
-};
-
-struct zjs_c_callback_t {
-    void* handle;
-    zjs_c_callback_func function;
-};
-
-struct zjs_callback_map {
-    int32_t id;
-    uint8_t type;
+    uint8_t max_funcs;
+    uint8_t num_funcs;
     union {
-        struct zjs_callback_t* js;
-        struct zjs_c_callback_t* c;
+        jerry_value_t* func_list;
+        zjs_c_callback_func function;
     };
 };
+
 #ifdef ZJS_LINUX_BUILD
 static uint8_t args_buffer[ZJS_CALLBACK_BUF_SIZE];
 static struct zjs_port_ring_buf ring_buffer;
@@ -65,17 +64,17 @@ SYS_RING_BUF_DECLARE_POW2(ring_buffer, 10);
 #endif
 static uint8_t ring_buf_initialized = 1;
 
-static int32_t cb_limit = INITIAL_CALLBACK_SIZE;
-static int32_t cb_size = 0;
-static struct zjs_callback_map** cb_map = NULL;
+static int16_t cb_limit = INITIAL_CALLBACK_SIZE;
+static int16_t cb_size = 0;
+static struct zjs_callback_t** cb_map = NULL;
 
-static int32_t new_id(void)
+static int16_t new_id(void)
 {
-    int32_t id = 0;
+    int16_t id = 0;
     if (cb_size >= cb_limit) {
         cb_limit += CB_CHUNK_SIZE;
-        size_t size = sizeof(struct zjs_callback_map *) * cb_limit;
-        struct zjs_callback_map** new_map = zjs_malloc(size);
+        size_t size = sizeof(struct zjs_callback_t *) * cb_limit;
+        struct zjs_callback_t** new_map = zjs_malloc(size);
         if (!new_map) {
             DBG_PRINT("error allocating space for new callback map\n");
             return -1;
@@ -83,7 +82,7 @@ static int32_t new_id(void)
         DBG_PRINT("callback list size too small, increasing by %d\n",
                   CB_CHUNK_SIZE);
         memset(new_map, 0, size);
-        memcpy(new_map, cb_map, sizeof(struct zjs_callback_map *) * cb_size);
+        memcpy(new_map, cb_map, sizeof(struct zjs_callback_t *) * cb_size);
         zjs_free(cb_map);
         cb_map = new_map;
     }
@@ -96,9 +95,9 @@ static int32_t new_id(void)
 void zjs_init_callbacks(void)
 {
     if (!cb_map) {
-        size_t size = sizeof(struct zjs_callback_map *) *
+        size_t size = sizeof(struct zjs_callback_t *) *
             INITIAL_CALLBACK_SIZE;
-        cb_map = (struct zjs_callback_map**)zjs_malloc(size);
+        cb_map = (struct zjs_callback_t**)zjs_malloc(size);
         if (!cb_map) {
             DBG_PRINT("error allocating space for CB map\n");
             return;
@@ -112,40 +111,34 @@ void zjs_init_callbacks(void)
     return;
 }
 
-void zjs_edit_js_func(int32_t id, jerry_value_t func)
+void zjs_edit_js_func(int16_t id, jerry_value_t func)
 {
     if (id != -1) {
-        jerry_release_value(cb_map[id]->js->js_func);
-        cb_map[id]->js->js_func = jerry_acquire_value(func);
+        jerry_release_value(cb_map[id]->func_list[0]);
+        cb_map[id]->func_list[0] = jerry_acquire_value(func);
     }
 }
 
-void zjs_edit_callback_handle(int32_t id, void* handle)
+void zjs_edit_callback_handle(int16_t id, void* handle)
 {
-    if (id != -1) {
-        if (cb_map[id]->type == CALLBACK_TYPE_JS) {
-            if (cb_map[id]->js) {
-                cb_map[id]->js->handle = handle;
-            }
-        } else {
-            cb_map[id]->c->handle = handle;
-        }
+    if (id != -1 && cb_map[id]) {
+        cb_map[id]->handle = handle;
     }
 }
 
-bool zjs_remove_callback_list_func(int32_t id, jerry_value_t js_func)
+bool zjs_remove_callback_list_func(int16_t id, jerry_value_t js_func)
 {
-    if (id != -1 && cb_map[id] && cb_map[id]->js) {
+    if (id != -1 && cb_map[id]) {
         int i;
-        for (i = 0; i < cb_map[id]->js->num_funcs; ++i) {
-            if (js_func == cb_map[id]->js->func_list[i]) {
+        for (i = 0; i < cb_map[id]->num_funcs; ++i) {
+            if (js_func == cb_map[id]->func_list[i]) {
                 int j;
-                jerry_release_value(cb_map[id]->js->func_list[i]);
-                for (j = i; j < cb_map[id]->js->num_funcs - 1; ++j) {
-                    cb_map[id]->js->func_list[j] = cb_map[id]->js->func_list[j + 1];
+                jerry_release_value(cb_map[id]->func_list[i]);
+                for (j = i; j < cb_map[id]->num_funcs - 1; ++j) {
+                    cb_map[id]->func_list[j] = cb_map[id]->func_list[j + 1];
                 }
-                cb_map[id]->js->num_funcs--;
-                cb_map[id]->js->func_list[cb_map[id]->js->num_funcs] = 0;
+                cb_map[id]->num_funcs--;
+                cb_map[id]->func_list[cb_map[id]->num_funcs] = 0;
                 return true;
             }
         }
@@ -153,93 +146,87 @@ bool zjs_remove_callback_list_func(int32_t id, jerry_value_t js_func)
     return false;
 }
 
-int zjs_get_num_callbacks(int32_t id)
+int zjs_get_num_callbacks(int16_t id)
 {
-    if (id != -1) {
-        if (cb_map[id] && cb_map[id]->js) {
-            return cb_map[id]->js->num_funcs;
-        }
+    if (id != -1 && cb_map[id]) {
+        return cb_map[id]->num_funcs;
     }
     return 0;
 }
 
-jerry_value_t* zjs_get_callback_func_list(int32_t id, int* count)
+jerry_value_t* zjs_get_callback_func_list(int16_t id, int* count)
 {
     if (id != -1) {
-        if (cb_map[id] && cb_map[id]->js) {
-            *count = cb_map[id]->js->num_funcs;
-            return cb_map[id]->js->func_list;
+        if (cb_map[id]) {
+            *count = cb_map[id]->num_funcs;
+            return cb_map[id]->func_list;
         }
     }
     return NULL;
 }
 
-int32_t zjs_add_callback_list(jerry_value_t js_func,
+int16_t zjs_add_callback_list(jerry_value_t js_func,
                               jerry_value_t this,
                               void* handle,
                               zjs_post_callback_func post,
-                              int32_t id)
+                              int16_t id)
 {
     if (id != -1) {
-        if (cb_map[id] && cb_map[id]->js && cb_map[id]->js->func_list) {
+        if (cb_map[id] && cb_map[id]->func_list) {
             // The function list is full, allocate more space, copy the existing
             // list, and add the new function
-            if (cb_map[id]->js->num_funcs == cb_map[id]->js->max_funcs - 1) {
+            if (cb_map[id]->num_funcs == cb_map[id]->max_funcs - 1) {
                 int i;
                 jerry_value_t* new_list = zjs_malloc((sizeof(jerry_value_t) *
-                        (cb_map[id]->js->max_funcs + CB_LIST_MULTIPLIER)));
-                for (i = 0; i < cb_map[id]->js->num_funcs; ++i) {
-                    new_list[i] = cb_map[id]->js->func_list[i];
+                        (cb_map[id]->max_funcs + CB_LIST_MULTIPLIER)));
+                for (i = 0; i < cb_map[id]->num_funcs; ++i) {
+                    new_list[i] = cb_map[id]->func_list[i];
                 }
-                new_list[cb_map[id]->js->num_funcs] = jerry_acquire_value(js_func);
+                new_list[cb_map[id]->num_funcs] = jerry_acquire_value(js_func);
 
-                cb_map[id]->js->max_funcs += CB_LIST_MULTIPLIER;
-                zjs_free(cb_map[id]->js->func_list);
-                cb_map[id]->js->func_list = new_list;
+                cb_map[id]->max_funcs += CB_LIST_MULTIPLIER;
+                zjs_free(cb_map[id]->func_list);
+                cb_map[id]->func_list = new_list;
             } else {
                 // Add function to list
-                cb_map[id]->js->func_list[cb_map[id]->js->num_funcs] =
+                cb_map[id]->func_list[cb_map[id]->num_funcs] =
                         jerry_acquire_value(js_func);
             }
             // If not already set, set the handle/pre/post provided. These will
             // only be set once, when the list is created.
-            if (!cb_map[id]->js->handle) {
-                cb_map[id]->js->handle = handle;
+            if (!cb_map[id]->handle) {
+                cb_map[id]->handle = handle;
             }
-            if (!cb_map[id]->js->post) {
-                cb_map[id]->js->post = post;
+            if (!cb_map[id]->post) {
+                cb_map[id]->post = post;
             }
-            cb_map[id]->js->num_funcs++;
+            cb_map[id]->num_funcs++;
             return cb_map[id]->id;
         } else {
             DBG_PRINT("list handle was NULL\n");
             return -1;
         }
     } else {
-        struct zjs_callback_map* new_cb = zjs_malloc(sizeof(struct zjs_callback_map));
+        struct zjs_callback_t* new_cb = zjs_malloc(sizeof(struct zjs_callback_t));
         if (!new_cb) {
             DBG_PRINT("error allocating space for new callback\n");
             return -1;
         }
-        new_cb->js = zjs_malloc(sizeof(struct zjs_callback_t));
-        if (!new_cb->js) {
-            DBG_PRINT("error allocating space for new callback\n");
-            zjs_free(new_cb);
-            return -1;
-        }
-        new_cb->type = CALLBACK_TYPE_JS;
+        memset(new_cb, 0, sizeof(struct zjs_callback_t));
+
+        new_cb->flags |= (CALLBACK_TYPE_JS << TYPE_BIT);
         new_cb->id = new_id();
-        new_cb->js->this = jerry_acquire_value(this);
-        new_cb->js->post = post;
-        new_cb->js->handle = handle;
-        new_cb->js->max_funcs = CB_LIST_MULTIPLIER;
-        new_cb->js->num_funcs = 1;
-        new_cb->js->func_list = zjs_malloc(sizeof(jerry_value_t) * CB_LIST_MULTIPLIER);
-        if (!new_cb->js->func_list) {
+        new_cb->this = jerry_acquire_value(this);
+        new_cb->post = post;
+        new_cb->handle = handle;
+        new_cb->max_funcs = CB_LIST_MULTIPLIER;
+        new_cb->num_funcs = 1;
+        new_cb->func_list = zjs_malloc(sizeof(jerry_value_t) * CB_LIST_MULTIPLIER);
+        if (!new_cb->func_list) {
             DBG_PRINT("could not allocate function list\n");
             return -1;
         }
-        new_cb->js->func_list[0] = jerry_acquire_value(js_func);
+        new_cb->func_list[0] = jerry_acquire_value(js_func);
         cb_map[new_cb->id] = new_cb;
         if (new_cb->id >= cb_size - 1) {
             cb_size++;
@@ -248,33 +235,33 @@ int32_t zjs_add_callback_list(jerry_value_t js_func,
     }
 }
 
-int32_t add_callback(jerry_value_t js_func,
+int16_t add_callback(jerry_value_t js_func,
                      jerry_value_t this,
                      void* handle,
                      zjs_post_callback_func post,
                      uint8_t once)
 {
-    struct zjs_callback_map* new_cb = zjs_malloc(sizeof(struct zjs_callback_map));
+    struct zjs_callback_t* new_cb = zjs_malloc(sizeof(struct zjs_callback_t));
     if (!new_cb) {
         DBG_PRINT("error allocating space for new callback\n");
         return -1;
     }
-    new_cb->js = zjs_malloc(sizeof(struct zjs_callback_t));
-    if (!new_cb->js) {
-        DBG_PRINT("error allocating space for new callback\n");
-        zjs_free(new_cb);
-        return -1;
-    }
-    new_cb->type = CALLBACK_TYPE_JS;
+    memset(new_cb, 0, sizeof(struct zjs_callback_t));
+
+    new_cb->flags |= (CALLBACK_TYPE_JS << TYPE_BIT);
+    new_cb->flags |= ((once) ? 1 : 0 << ONCE_BIT);
     new_cb->id = new_id();
-    new_cb->js->js_func = jerry_acquire_value(js_func);
-    new_cb->js->this = jerry_acquire_value(this);
-    new_cb->js->post = post;
-    new_cb->js->handle = handle;
-    new_cb->js->func_list = NULL;
-    new_cb->js->max_funcs = 0;
-    new_cb->js->num_funcs = 0;
-    new_cb->js->once = once;
+    // For a single callback, instead of allocating for just one function, we
+    // can use the pointer to hold the function since it will never grow
+    jerry_value_t func_val = jerry_acquire_value(js_func);
+    memcpy(&new_cb->func_list, &func_val, sizeof(jerry_value_t));
+    //new_cb->func_list = zjs_malloc(sizeof(jerry_value_t));
+    //new_cb->func_list[0] = jerry_acquire_value(js_func);
+    new_cb->this = jerry_acquire_value(this);
+    new_cb->post = post;
+    new_cb->handle = handle;
+    new_cb->max_funcs = 1;
+    new_cb->num_funcs = 1;
 
     // Add callback to list
     cb_map[new_cb->id] = new_cb;
@@ -288,7 +275,7 @@ int32_t add_callback(jerry_value_t js_func,
     return new_cb->id;
 }
 
-int32_t zjs_add_callback(jerry_value_t js_func,
+int16_t zjs_add_callback(jerry_value_t js_func,
                          jerry_value_t this,
                          void* handle,
                          zjs_post_callback_func post)
@@ -296,7 +283,7 @@ int32_t zjs_add_callback(jerry_value_t js_func,
     return add_callback(js_func, this, handle, post, 0);
 }
 
-int32_t zjs_add_callback_once(jerry_value_t js_func,
+int16_t zjs_add_callback_once(jerry_value_t js_func,
                               jerry_value_t this,
                               void* handle,
                               zjs_post_callback_func post)
@@ -304,23 +291,18 @@ int32_t zjs_add_callback_once(jerry_value_t js_func,
     return add_callback(js_func, this, handle, post, 1);
 }
 
-void zjs_remove_callback(int32_t id)
+void zjs_remove_callback(int16_t id)
 {
     if (id != -1 && cb_map[id]) {
-        if (cb_map[id]->type == CALLBACK_TYPE_JS && cb_map[id]->js) {
-            if (cb_map[id]->js->func_list) {
+        if (GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_JS) {
+            if (cb_map[id]->func_list) {
                 int i;
-                for (i = 0; i < cb_map[id]->js->num_funcs; ++i) {
-                    jerry_release_value(cb_map[id]->js->func_list[i]);
+                for (i = 0; i < cb_map[id]->num_funcs; ++i) {
+                    jerry_release_value(cb_map[id]->func_list[i]);
                 }
-                zjs_free(cb_map[id]->js->func_list);
-            } else {
-                jerry_release_value(cb_map[id]->js->js_func);
+                zjs_free(cb_map[id]->func_list);
             }
-            jerry_release_value(cb_map[id]->js->this);
-            zjs_free(cb_map[id]->js);
-        } else if (cb_map[id]->c) {
-            zjs_free(cb_map[id]->c);
+            jerry_release_value(cb_map[id]->this);
         }
         zjs_free(cb_map[id]);
         cb_map[id] = NULL;
@@ -328,7 +310,7 @@ void zjs_remove_callback(int32_t id)
     }
 }
 
-void zjs_signal_callback(int32_t id, void* args, uint32_t size)
+void zjs_signal_callback(int16_t id, void* args, uint32_t size)
 {
     DBG_PRINT("pushing item to ring buffer. id=%li, args=%p, size=%lu\n", id, args, size);
     int ret = zjs_port_ring_buf_put(&ring_buffer,
@@ -341,23 +323,20 @@ void zjs_signal_callback(int32_t id, void* args, uint32_t size)
     }
 }
 
-int32_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback)
+int16_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback)
 {
-    struct zjs_callback_map* new_cb = zjs_malloc(sizeof(struct zjs_callback_map));
+    struct zjs_callback_t* new_cb = zjs_malloc(sizeof(struct zjs_callback_t));
     if (!new_cb) {
         DBG_PRINT("error allocating space for new callback\n");
         return -1;
     }
-    new_cb->c = zjs_malloc(sizeof(struct zjs_c_callback_t));
-    if (!new_cb->c) {
-        DBG_PRINT("error allocating space for new callback\n");
-        zjs_free(new_cb);
-        return -1;
-    }
-    new_cb->type = CALLBACK_TYPE_C;
+    memset(new_cb, 0, sizeof(struct zjs_callback_t));
+
+    new_cb->flags |= (CALLBACK_TYPE_C << TYPE_BIT);
+    new_cb->flags |= (0 << ONCE_BIT);
     new_cb->id = new_id();
-    new_cb->c->function = callback;
-    new_cb->c->handle = handle;
+    new_cb->function = callback;
+    new_cb->handle = handle;
 
     // Add callback to list
     cb_map[new_cb->id] = new_cb;
@@ -397,38 +376,39 @@ void print_callbacks(void)
 #define print_callbacks() do {} while (0)
 #endif
 
-void zjs_call_callback(int32_t id, void* data, uint32_t sz)
+void zjs_call_callback(int16_t id, void* data, uint32_t sz)
 {
     if (id <= cb_size && cb_map[id]) {
-        if (cb_map[id]->type == CALLBACK_TYPE_JS) {
-            if (cb_map[id]->js->func_list == NULL && jerry_value_is_function(cb_map[id]->js->js_func)) {
-                jerry_value_t ret_val;
-                // Single function callback
-                ret_val = jerry_call_function(cb_map[id]->js->js_func, cb_map[id]->js->this, data, sz);
+        if (GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_JS) {
+            // Function list callback
+            int i;
+            jerry_value_t ret_val;
 
-                if (cb_map[id]->js->post) {
-                    cb_map[id]->js->post(cb_map[id]->js->handle, &ret_val);
-                }
-                if (cb_map[id]->js->once) {
-                    zjs_remove_callback(id);
+            if (GET_JS_TYPE(cb_map[id]->flags) == JS_TYPE_SINGLE) {
+                jerry_value_t func_val;
+                // for single functions, the value is stored in the pointers
+                // address space.
+                memcpy(&func_val, &cb_map[id]->func_list, sizeof(jerry_value_t));
+                ret_val = jerry_call_function(func_val, cb_map[id]->this, data, sz);
+                if (jerry_value_has_error_flag(ret_val)) {
+                    DBG_PRINT("callback %ld returned an error for function\n", id);
                 }
             } else {
-                // Function list callback
-                int i;
-                jerry_value_t ret_val;
-
-                for (i = 0; i < cb_map[id]->js->num_funcs; ++i) {
-                    ret_val = jerry_call_function(cb_map[id]->js->func_list[i], cb_map[id]->js->this, data, sz);
+                for (i = 0; i < cb_map[id]->num_funcs; ++i) {
+                    ret_val = jerry_call_function(cb_map[id]->func_list[i], cb_map[id]->this, data, sz);
                     if (jerry_value_has_error_flag(ret_val)) {
                         DBG_PRINT("callback %ld returned an error for function[%i]\n", id, i);
                     }
                 }
-                if (cb_map[id]->js->post) {
-                    cb_map[id]->js->post(cb_map[id]->js->handle, &ret_val);
-                }
             }
-        } else if (cb_map[id]->type == CALLBACK_TYPE_C && cb_map[id]->c->function) {
-            cb_map[id]->c->function(cb_map[id]->c->handle, data);
+            if (cb_map[id]->post) {
+                cb_map[id]->post(cb_map[id]->handle, &ret_val);
+            }
+            if (GET_ONCE(cb_map[id]->flags)) {
+                zjs_remove_callback(id);
+            }
+        } else if (GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_C && cb_map[id]->function) {
+            cb_map[id]->function(cb_map[id]->handle, data);
         }
     } else {
         ERR_PRINT("callback does not exist: %ld\n", id);

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -5,6 +5,12 @@
 
 #include "jerry-api.h"
 
+#ifdef ZJS_32_BIT_CALLBACK_ID
+typedef int32_t zjs_callback_id;
+#else
+typedef int16_t zjs_callback_id;
+#endif
+
 /*
  * Function that will be called BEFORE the JS function is called.
  * This should return an array of jerry_value_t's that contain
@@ -47,7 +53,7 @@ void zjs_init_callbacks(void);
  *
  * @return              Number of functions in the callback list
  */
-int zjs_get_num_callbacks(int16_t id);
+int zjs_get_num_callbacks(zjs_callback_id id);
 
 /*
  * Get the list of callback functions in a callback list
@@ -57,7 +63,7 @@ int zjs_get_num_callbacks(int16_t id);
  *
  * @return              Array of functions
  */
-jerry_value_t* zjs_get_callback_func_list(int16_t id, int* count);
+jerry_value_t* zjs_get_callback_func_list(zjs_callback_id id, int* count);
 
 /*
  * Remove a function from a list of callbacks
@@ -67,7 +73,7 @@ jerry_value_t* zjs_get_callback_func_list(int16_t id, int* count);
  *
  * @return              True if function was removed, false if it did not exist
  */
-bool zjs_remove_callback_list_func(int16_t id, jerry_value_t js_func);
+bool zjs_remove_callback_list_func(zjs_callback_id id, jerry_value_t js_func);
 
 /*
  * Create/add a function to a callback list. If the 'id' parameter is -1, a new
@@ -81,11 +87,11 @@ bool zjs_remove_callback_list_func(int16_t id, jerry_value_t js_func);
  *
  * @return              New callback ID for this list (or existing ID)
  */
-int16_t zjs_add_callback_list(jerry_value_t js_func,
-                              jerry_value_t this,
-                              void* handle,
-                              zjs_post_callback_func post,
-                              int16_t id);
+zjs_callback_id zjs_add_callback_list(jerry_value_t js_func,
+                                      jerry_value_t this,
+                                      void* handle,
+                                      zjs_post_callback_func post,
+                                      zjs_callback_id id);
 
 /*
  * Add/register a callback function
@@ -96,10 +102,10 @@ int16_t zjs_add_callback_list(jerry_value_t js_func,
  *
  * @return              ID associated with this callback, use this ID to reference this CB
  */
-int16_t zjs_add_callback(jerry_value_t js_func,
-                         jerry_value_t this,
-                         void* handle,
-                         zjs_post_callback_func post);
+zjs_callback_id zjs_add_callback(jerry_value_t js_func,
+                                 jerry_value_t this,
+                                 void* handle,
+                                 zjs_post_callback_func post);
 
 /*
  * Add a JS callback that will only get called once. After it is called it will
@@ -111,10 +117,10 @@ int16_t zjs_add_callback(jerry_value_t js_func,
  *
  * @return              ID associated with this callback, use this ID to reference this CB
  */
-int16_t zjs_add_callback_once(jerry_value_t js_func,
-                              jerry_value_t this,
-                              void* handle,
-                              zjs_post_callback_func post);
+zjs_callback_id zjs_add_callback_once(jerry_value_t js_func,
+                                      jerry_value_t this,
+                                      void* handle,
+                                      zjs_post_callback_func post);
 
 /*
  * Change a callbacks JS function
@@ -122,7 +128,7 @@ int16_t zjs_add_callback_once(jerry_value_t js_func,
  * @param id            ID of callback
  * @param func          New JS function
  */
-void zjs_edit_js_func(int16_t id, jerry_value_t func);
+void zjs_edit_js_func(zjs_callback_id id, jerry_value_t func);
 
 /*
  * Change a callback ID's native handle
@@ -130,7 +136,7 @@ void zjs_edit_js_func(int16_t id, jerry_value_t func);
  * @param id            ID of callback
  * @param handle        New callback handle
  */
-void zjs_edit_callback_handle(int16_t id, void* handle);
+void zjs_edit_callback_handle(zjs_callback_id id, void* handle);
 
 /*
  * Remove a function that was registered by zjs_add_callback(). If you remove a
@@ -139,7 +145,7 @@ void zjs_edit_callback_handle(int16_t id, void* handle);
  *
  * @param id            ID returned from zjs_add_callback
  */
-void zjs_remove_callback(int16_t id);
+void zjs_remove_callback(zjs_callback_id id);
 
 /*
  * Signal the system to make a callback. The callback will not be called
@@ -154,7 +160,7 @@ void zjs_remove_callback(int16_t id);
  * @param args          Arguments given to the JS/C callback
  * @param size          Size of arguments (in bytes)
  */
-void zjs_signal_callback(int16_t id, void* args, uint32_t size);
+void zjs_signal_callback(zjs_callback_id id, void* args, uint32_t size);
 
 /*
  * Add/register a C callback
@@ -164,7 +170,7 @@ void zjs_signal_callback(int16_t id, void* args, uint32_t size);
  *
  * @return              ID for the C callback
  */
-int16_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback);
+zjs_callback_id zjs_add_c_callback(void* handle, zjs_c_callback_func callback);
 
 /*
  * Call a callback immediately. This should only be used when absolutely needed
@@ -176,7 +182,7 @@ int16_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback);
  * @param data          Callback arguments
  * @param sz            Size of callback arguments in bytes
  */
-void zjs_call_callback(int16_t id, void* data, uint32_t sz);
+void zjs_call_callback(zjs_callback_id id, void* data, uint32_t sz);
 
 /*
  * Service the callback module. Any callback's that have been signaled will

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -47,7 +47,7 @@ void zjs_init_callbacks(void);
  *
  * @return              Number of functions in the callback list
  */
-int zjs_get_num_callbacks(int32_t id);
+int zjs_get_num_callbacks(int16_t id);
 
 /*
  * Get the list of callback functions in a callback list
@@ -57,7 +57,7 @@ int zjs_get_num_callbacks(int32_t id);
  *
  * @return              Array of functions
  */
-jerry_value_t* zjs_get_callback_func_list(int32_t id, int* count);
+jerry_value_t* zjs_get_callback_func_list(int16_t id, int* count);
 
 /*
  * Remove a function from a list of callbacks
@@ -67,7 +67,7 @@ jerry_value_t* zjs_get_callback_func_list(int32_t id, int* count);
  *
  * @return              True if function was removed, false if it did not exist
  */
-bool zjs_remove_callback_list_func(int32_t id, jerry_value_t js_func);
+bool zjs_remove_callback_list_func(int16_t id, jerry_value_t js_func);
 
 /*
  * Create/add a function to a callback list. If the 'id' parameter is -1, a new
@@ -81,11 +81,11 @@ bool zjs_remove_callback_list_func(int32_t id, jerry_value_t js_func);
  *
  * @return              New callback ID for this list (or existing ID)
  */
-int32_t zjs_add_callback_list(jerry_value_t js_func,
+int16_t zjs_add_callback_list(jerry_value_t js_func,
                               jerry_value_t this,
                               void* handle,
                               zjs_post_callback_func post,
-                              int32_t id);
+                              int16_t id);
 
 /*
  * Add/register a callback function
@@ -96,7 +96,7 @@ int32_t zjs_add_callback_list(jerry_value_t js_func,
  *
  * @return              ID associated with this callback, use this ID to reference this CB
  */
-int32_t zjs_add_callback(jerry_value_t js_func,
+int16_t zjs_add_callback(jerry_value_t js_func,
                          jerry_value_t this,
                          void* handle,
                          zjs_post_callback_func post);
@@ -111,7 +111,7 @@ int32_t zjs_add_callback(jerry_value_t js_func,
  *
  * @return              ID associated with this callback, use this ID to reference this CB
  */
-int32_t zjs_add_callback_once(jerry_value_t js_func,
+int16_t zjs_add_callback_once(jerry_value_t js_func,
                               jerry_value_t this,
                               void* handle,
                               zjs_post_callback_func post);
@@ -122,7 +122,7 @@ int32_t zjs_add_callback_once(jerry_value_t js_func,
  * @param id            ID of callback
  * @param func          New JS function
  */
-void zjs_edit_js_func(int32_t id, jerry_value_t func);
+void zjs_edit_js_func(int16_t id, jerry_value_t func);
 
 /*
  * Change a callback ID's native handle
@@ -130,7 +130,7 @@ void zjs_edit_js_func(int32_t id, jerry_value_t func);
  * @param id            ID of callback
  * @param handle        New callback handle
  */
-void zjs_edit_callback_handle(int32_t id, void* handle);
+void zjs_edit_callback_handle(int16_t id, void* handle);
 
 /*
  * Remove a function that was registered by zjs_add_callback(). If you remove a
@@ -139,7 +139,7 @@ void zjs_edit_callback_handle(int32_t id, void* handle);
  *
  * @param id            ID returned from zjs_add_callback
  */
-void zjs_remove_callback(int32_t id);
+void zjs_remove_callback(int16_t id);
 
 /*
  * Signal the system to make a callback. The callback will not be called
@@ -154,7 +154,7 @@ void zjs_remove_callback(int32_t id);
  * @param args          Arguments given to the JS/C callback
  * @param size          Size of arguments (in bytes)
  */
-void zjs_signal_callback(int32_t id, void* args, uint32_t size);
+void zjs_signal_callback(int16_t id, void* args, uint32_t size);
 
 /*
  * Add/register a C callback
@@ -164,7 +164,7 @@ void zjs_signal_callback(int32_t id, void* args, uint32_t size);
  *
  * @return              ID for the C callback
  */
-int32_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback);
+int16_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback);
 
 /*
  * Call a callback immediately. This should only be used when absolutely needed
@@ -176,7 +176,7 @@ int32_t zjs_add_c_callback(void* handle, zjs_c_callback_func callback);
  * @param data          Callback arguments
  * @param sz            Size of callback arguments in bytes
  */
-void zjs_call_callback(int32_t id, void* data, uint32_t sz);
+void zjs_call_callback(int16_t id, void* data, uint32_t sz);
 
 /*
  * Service the callback module. Any callback's that have been signaled will

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -41,7 +41,7 @@ struct gpio_handle {
     uint32_t pin;                   // Pin associated with this handle
     uint32_t devnum;
     uint32_t value;                 // Value of the pin
-    int16_t callbackId;             // ID for the C callback
+    zjs_callback_id callbackId;             // ID for the C callback
     jerry_value_t pin_obj;          // Pin object returned from open()
     jerry_value_t onchange_func;    // Function registered to onChange
     jerry_value_t* open_ret_args;

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -41,7 +41,7 @@ struct gpio_handle {
     uint32_t pin;                   // Pin associated with this handle
     uint32_t devnum;
     uint32_t value;                 // Value of the pin
-    int32_t callbackId;             // ID for the C callback
+    int16_t callbackId;             // ID for the C callback
     jerry_value_t pin_obj;          // Pin object returned from open()
     jerry_value_t onchange_func;    // Function registered to onChange
     jerry_value_t* open_ret_args;

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -9,10 +9,10 @@
 struct promise {
     uint8_t then_set;           // then() function has been set
     jerry_value_t then;         // Function registered from then()
-    int16_t then_id;            // Callback ID for then JS callback
+    zjs_callback_id then_id;    // Callback ID for then JS callback
     uint8_t catch_set;          // catch() function has been set
     jerry_value_t catch;        // Function registered from catch()
-    int16_t catch_id;           // Callback ID for catch JS callback
+    zjs_callback_id catch_id;   // Callback ID for catch JS callback
     jerry_value_t this;         // 'this' object for this promise
     void* user_handle;
     zjs_post_promise_func post;

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -9,10 +9,10 @@
 struct promise {
     uint8_t then_set;           // then() function has been set
     jerry_value_t then;         // Function registered from then()
-    int32_t then_id;            // Callback ID for then JS callback
+    int16_t then_id;            // Callback ID for then JS callback
     uint8_t catch_set;          // catch() function has been set
     jerry_value_t catch;        // Function registered from catch()
-    int32_t catch_id;           // Callback ID for catch JS callback
+    int16_t catch_id;           // Callback ID for catch JS callback
     jerry_value_t this;         // 'this' object for this promise
     void* user_handle;
     zjs_post_promise_func post;

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -23,7 +23,7 @@ typedef struct zjs_timer {
     jerry_value_t* argv;
     uint32_t argc;
     uint32_t interval;
-    int16_t callback_id;
+    zjs_callback_id callback_id;
     bool repeat;
     bool completed;
     struct zjs_timer *next;

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -23,7 +23,7 @@ typedef struct zjs_timer {
     jerry_value_t* argv;
     uint32_t argc;
     uint32_t interval;
-    int32_t callback_id;
+    int16_t callback_id;
     bool repeat;
     bool completed;
     struct zjs_timer *next;

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -49,7 +49,7 @@ static struct device* uart_dev = NULL;
 // global ID but the UART API's do not let you add a "handle" that is
 // available when the ISR is called. For this reason we must make it global.
 // Other modules would include this handle when setting up the ISR e.g. GPIO
-static int32_t read_id = -1;
+static int16_t read_id = -1;
 // TX interrupt handled
 static volatile bool tx = false;
 // RX interrupt handled

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -49,7 +49,7 @@ static struct device* uart_dev = NULL;
 // global ID but the UART API's do not let you add a "handle" that is
 // available when the ISR is called. For this reason we must make it global.
 // Other modules would include this handle when setting up the ISR e.g. GPIO
-static int16_t read_id = -1;
+static zjs_callback_id read_id = -1;
 // TX interrupt handled
 static volatile bool tx = false;
 // RX interrupt handled


### PR DESCRIPTION
 - Removed the union of C/JS structs so callbacks only do 1 allocation
 - Changed callback ID's to int16_t's instead of int32_t's
 - Changed all modules using calbacks to use int16_t's

Signed-off-by: James Prestwood <james.prestwood@intel.com>