### PR TITLE
[modules] Add support for Node.js modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ dfu-all: dfu dfu-arc
 .PHONY: generate
 generate: $(JS) setup
 	@echo Creating C string from JS application...
-	@./scripts/convert.sh $(JS) src/zjs_script_gen.c
+	@./scripts/convert.sh /tmp/zjs.js src/zjs_script_gen.c
 
 # Run QEMU target
 .PHONY: qemu

--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,11 @@ dfu-all: dfu dfu-arc
 .PHONY: generate
 generate: $(JS) setup
 	@echo Creating C string from JS application...
+ifeq ($(TARGET), linux)
+	@./scripts/convert.sh $(JS) src/zjs_script_gen.c
+else
 	@./scripts/convert.sh /tmp/zjs.js src/zjs_script_gen.c
-
+endif
 # Run QEMU target
 .PHONY: qemu
 qemu: $(PRE_ACTION) analyze generate

--- a/modules/BMP280.js
+++ b/modules/BMP280.js
@@ -1,0 +1,105 @@
+// Copyright (c) 2016, Intel Corporation.
+// JavaScript library for the BMP280 sensor
+
+function BMP280() {
+
+    // API object
+    var bmp280API = {};
+
+    var i2c = require("i2c");
+    bmp280API.i2cDevice = i2c.open({ bus: 0, speed: 100 });
+
+    var bmp280 = {
+        ADDRESS: 0x77,
+        NORMAL_MODE: 0x03,
+        REGISTER_DIG_T1: 0x88, // Unsigned Short
+        REGISTER_DIG_T2: 0x8A, // Signed Short
+        REGISTER_DIG_T3: 0x8C, // Signed Short
+        REGISTER_CHIPID: 0xD0,
+        REGISTER_CONTROL: 0xF4,
+        REGISTER_CONFIG: 0xF5,
+        REGISTER_TEMPDATA: 0xFA, // Signed 20bit. Always positive
+        STANDBY: 2 << 5,
+        FILTER: 0x00,
+        SPI_3W_DISABLE: 0x00,
+        PRESS_OVER: 1 << 2,
+        TEMP_OVER: 1 << 5
+    }
+
+    var dig_T1;
+    var dig_T2;
+    var dig_T3;
+
+    function uint16toInt16(value) {
+        if ((value & 0x8000) > 0) {
+            value = value - 0x10000;
+        }
+        return value;
+    }
+
+    bmp280API.readCoefficients = function() {
+        // These need to be read as a burst read in order to get accurate numbers,
+        // so dig_TAll contains dig_T1 through dig_T3
+        var dig_TAll = this.i2cDevice.burstRead(bmp280.ADDRESS, 24,
+                                                bmp280.REGISTER_DIG_T1);
+        dig_T1 = dig_TAll.readUInt16LE();
+        dig_T2 = dig_TAll.readUInt16LE(2);
+        dig_T3 = dig_TAll.readUInt16LE(4);
+
+        // Convert these to signed
+        dig_T1 = uint16toInt16(dig_T1);
+        dig_T2 = uint16toInt16(dig_T2);
+        dig_T3 = uint16toInt16(dig_T3);
+    }
+
+    bmp280API.readTemperature = function() {
+        // Read the raw temperature value.
+        var tempBuffer = this.i2cDevice.burstRead(bmp280.ADDRESS, 4,
+                                                  bmp280.REGISTER_TEMPDATA);
+        // Get the number from the buffer object
+        var tempDec = tempBuffer.readUInt32BE();
+
+        // Selects the first 20 bits of 32 bit integer and maintains the sign
+        tempDec >>>= 12;
+
+        // Convert raw temperature to Celsius using the algorithm found here
+        // https://www.bosch-sensortec.com/bst/products/all_products/bmp280
+        var var1 = (((tempDec >> 3) - (dig_T1 << 1)) * (dig_T2)) >> 11;
+        var var2 = (((((tempDec >> 4) - (dig_T1)) * ((tempDec >> 4) - (dig_T1))) >> 12) *
+                    (dig_T3)) >> 14;
+
+        var t_fine = var1 + var2;
+        var T = ((t_fine * 5 + 128) >> 8) / 100 ;
+
+        return T;
+    }
+
+    function init() {
+        var reader = bmp280API.i2cDevice.read(bmp280.ADDRESS, 1,
+                                              bmp280.REGISTER_CHIPID);
+
+        // Check that we have a BMP280 on the I2C bus
+        if (reader.toString('hex') !== "58")
+            print("BMP280 not found! ChipId " + reader.toString('hex') !== "58");
+
+        // Setup BMP280 sensor
+        bmp280API.readCoefficients();
+
+        bmp280API.i2cDevice.write(bmp280.ADDRESS,
+                                  new Buffer([bmp280.REGISTER_CONTROL,
+                                  bmp280.PRESS_OVER |
+                                  bmp280.TEMP_OVER |
+                                  bmp280.NORMAL_MODE]));
+
+        bmp280API.i2cDevice.write(bmp280.ADDRESS,
+                                  new Buffer([bmp280.REGISTER_CONFIG,
+                                  bmp280.STANDBY |
+                                  bmp280.FILTER |
+                                  bmp280.SPI_3W_DISABLE]));
+    }
+
+    init();
+    return bmp280API;
+};
+
+module.exports.BMP280 = new BMP280();

--- a/modules/BMP280.js
+++ b/modules/BMP280.js
@@ -9,7 +9,7 @@ function BMP280() {
     var i2c = require("i2c");
     bmp280API.i2cDevice = i2c.open({ bus: 0, speed: 100 });
 
-    var bmp280 = {
+    bmp280API.bmp280Addrs = {
         ADDRESS: 0x77,
         NORMAL_MODE: 0x03,
         REGISTER_DIG_T1: 0x88, // Unsigned Short
@@ -40,8 +40,8 @@ function BMP280() {
     bmp280API.readCoefficients = function() {
         // These need to be read as a burst read in order to get accurate numbers,
         // so dig_TAll contains dig_T1 through dig_T3
-        var dig_TAll = this.i2cDevice.burstRead(bmp280.ADDRESS, 24,
-                                                bmp280.REGISTER_DIG_T1);
+        var dig_TAll = this.i2cDevice.burstRead(this.bmp280Addrs.ADDRESS, 24,
+                                                this.bmp280Addrs.REGISTER_DIG_T1);
         dig_T1 = dig_TAll.readUInt16LE();
         dig_T2 = dig_TAll.readUInt16LE(2);
         dig_T3 = dig_TAll.readUInt16LE(4);
@@ -54,8 +54,8 @@ function BMP280() {
 
     bmp280API.readTemperature = function() {
         // Read the raw temperature value.
-        var tempBuffer = this.i2cDevice.burstRead(bmp280.ADDRESS, 4,
-                                                  bmp280.REGISTER_TEMPDATA);
+        var tempBuffer = this.i2cDevice.burstRead(this.bmp280Addrs.ADDRESS, 4,
+                                                  this.bmp280Addrs.REGISTER_TEMPDATA);
         // Get the number from the buffer object
         var tempDec = tempBuffer.readUInt32BE();
 
@@ -74,31 +74,6 @@ function BMP280() {
         return T;
     }
 
-    function init() {
-        var reader = bmp280API.i2cDevice.read(bmp280.ADDRESS, 1,
-                                              bmp280.REGISTER_CHIPID);
-
-        // Check that we have a BMP280 on the I2C bus
-        if (reader.toString('hex') !== "58")
-            print("BMP280 not found! ChipId " + reader.toString('hex') !== "58");
-
-        // Setup BMP280 sensor
-        bmp280API.readCoefficients();
-
-        bmp280API.i2cDevice.write(bmp280.ADDRESS,
-                                  new Buffer([bmp280.REGISTER_CONTROL,
-                                  bmp280.PRESS_OVER |
-                                  bmp280.TEMP_OVER |
-                                  bmp280.NORMAL_MODE]));
-
-        bmp280API.i2cDevice.write(bmp280.ADDRESS,
-                                  new Buffer([bmp280.REGISTER_CONFIG,
-                                  bmp280.STANDBY |
-                                  bmp280.FILTER |
-                                  bmp280.SPI_3W_DISABLE]));
-    }
-
-    init();
     return bmp280API;
 };
 

--- a/modules/GroveLCD.js
+++ b/modules/GroveLCD.js
@@ -1,0 +1,164 @@
+// Copyright (c) 2016, Intel Corporation.
+// JavaScript library for the Grove LCD
+
+function GroveLCD() {
+
+    // API object
+    var groveLCDAPI = {};
+
+    var i2c = require("i2c");
+    groveLCDAPI.i2cDevice = i2c.open({ bus: 0, speed: 100 });
+
+    var glcd = {
+        DISPLAY_ADDR : 0x3E,
+        BACKLIGHT_ADDR : 0x62,
+        // Defines for the CMD_CURSOR_SHIFT
+        CS_DISPLAY_SHIFT : 1 << 3,
+        CS_RIGHT_SHIFT : 1 << 2,
+        // LCD Display Commands
+        CMD_SCREEN_CLEAR : 1 << 0,
+        CMD_CURSOR_RETURN : 1 << 1,
+        CMD_INPUT_SET : 1 << 2,
+        CMD_DISPLAY_SWITCH : 1 << 3,
+        CMD_CURSOR_SHIFT : 1 << 4,
+        CMD_FUNCTION_SET : 1 << 5,
+        CMD_SET_CGRAM_ADDR : 1 << 6,
+        CMD_SET_DDRAM_ADDR : 1 << 7,
+        // Defines for the LCD_FUNCTION_SET
+        FS_8BIT_MODE : 1 << 4,
+        FS_ROWS_2 : 1 << 3,
+        FS_ROWS_1 : 0 << 3,
+        FS_DOT_SIZE_BIG : 1 << 2,
+        FS_DOT_SIZE_LITTLE : 0 << 2,
+        // Defines for the CMD_DISPLAY_SWITCH options
+        DS_DISPLAY_ON : 1 << 2,
+        DS_DISPLAY_OFF : 0 << 2,
+        DS_CURSOR_ON : 1 << 1,
+        DS_CURSOR_OFF : 0 << 1,
+        DS_BLINK_ON : 1 << 0,
+        DS_BLINK_OFF : 0 << 0,
+        REGISTER_POWER : 0x08,
+        REGISTER_R : 0x04,
+        REGISTER_G : 0x03,
+        REGISTER_B : 0x02
+    };
+
+    groveLCDAPI.clear = function(col, row, numChar) {
+        // col = Column you want to start at
+        // row = Row you want to start at
+        // numChar = Number of chars to clear
+
+        if (numChar !== undefined && numChar < 1) {
+            // Can't clear zero or negative numbers of chars
+            console.log("GroveLCD.clear numChar must be greater than 0");
+            return;
+        }
+
+        if (col === undefined && row === undefined && numChar === undefined) {
+            // Clear the display completely if no args passed.
+            groveLCDAPI.i2cDevice.write(glcd.DISPLAY_ADDR,
+                                        new Buffer([0, glcd.CMD_SCREEN_CLEAR]));
+            return;
+        }
+        else if (col === undefined || row === undefined || numChar === undefined) {
+            // If any of the args undefined - print warning and return
+            console.log ("Missing args for GroveLCD.clear. Please pass col, row, numChar");
+            return;
+        }
+
+        // Move the cursor
+        this.resetCursor(col,row);
+
+        // Create blank space
+        var blanks = ' ';
+
+        for (var i = 0; i < numChar - 1; i++) {
+            blanks = blanks + ' ';
+        }
+
+        // Write blank space to LCD
+        this.writeText(blanks);
+    }
+
+    groveLCDAPI.resetCursor = function (col, row) {
+        // Reset the cursor position
+        row = row || 0;
+        col = col || 0;
+
+        if (row == 0) {
+            // Put the cursor on the first row at col
+            col |= 0x80;
+        } else {
+            // Put the cursor on the second row at col
+            col |= 0xC0;
+        }
+
+        this.i2cDevice.write(glcd.DISPLAY_ADDR,
+                             new Buffer([glcd.CMD_SET_DDRAM_ADDR, col]));
+    }
+
+    groveLCDAPI.setColor = function(colorObj) {
+        // Valid range for color is 0 - 255
+        // Write new color values
+        if (colorObj.blue && colorObj.blue > -1 && colorObj.blue < 256) {
+            this.i2cDevice.write(glcd.BACKLIGHT_ADDR,
+                                 new Buffer([glcd.REGISTER_B, blue]));
+        }
+        if (colorObj.red && colorObj.red > -1 && colorObj.red < 256) {
+            this.i2cDevice.write(glcd.BACKLIGHT_ADDR,
+                                 new Buffer([glcd.REGISTER_R, red]));
+        }
+        if (colorObj.green && colorObj.green > -1 && colorObj.green < 256) {
+            this.i2cDevice.write(glcd.BACKLIGHT_ADDR,
+                                 new Buffer([glcd.REGISTER_G, green]));
+        }
+    }
+
+
+    groveLCDAPI.writeText = function(word, col, row) {
+
+        if (col !== undefined && row !== undefined) {
+            // Move cursor to the specified location first
+            this.resetCursor(col, row);
+        }
+
+        var wordBuffer = new Buffer(word.length + 1);
+
+        // The first byte in the buffer is for the register address,
+        // which is where the word is going to be written to.
+        wordBuffer.writeUInt8(glcd.CMD_SET_CGRAM_ADDR, 0);
+
+        // Append the text we want to print after that
+        wordBuffer.write(word, 1);
+
+        // Write the buffer to I2C
+        this.i2cDevice.write(glcd.DISPLAY_ADDR, wordBuffer);
+    }
+
+    function init() {
+
+        // Clear the screen
+        groveLCDAPI.clear();
+
+        // Set our preferences for the Grove LCD
+        groveLCDAPI.i2cDevice.write(glcd.DISPLAY_ADDR,
+                                    new Buffer([0, glcd.CMD_FUNCTION_SET |
+                                    glcd.FS_ROWS_2 |
+                                    glcd.FS_DOT_SIZE_LITTLE |
+                                    glcd.FS_8BIT_MODE]));
+
+        groveLCDAPI.i2cDevice.write(glcd.DISPLAY_ADDR,
+                                    new Buffer([0, glcd.CMD_DISPLAY_SWITCH |
+                                    glcd.DS_DISPLAY_ON |
+                                    glcd.DS_CURSOR_OFF |
+                                    glcd.DS_BLINK_OFF]));
+
+        groveLCDAPI.resetCursor(0, 0);
+    }
+
+    init();
+
+    return groveLCDAPI;
+};
+
+module.exports.GroveLCD = new GroveLCD();

--- a/samples/I2CBMP280.js
+++ b/samples/I2CBMP280.js
@@ -25,8 +25,51 @@ var glcd = require("GroveLCD.js");
 var baseTemp = prevTemp = 25;
 var red = green = blue = 200;
 
-// Init the screen with text
-glcd.writeText("Temperature is ", 0, 0);
+function bmp280Init() {
+    var reader = bmp280.i2cDevice.read(bmp280.bmp280Addrs.ADDRESS, 1,
+                                          bmp280.bmp280Addrs.REGISTER_CHIPID);
+
+    // Check that we have a BMP280 on the I2C bus
+    if (reader.toString('hex') !== "58")
+        print("BMP280 not found! ChipId " + reader.toString('hex') !== "58");
+
+    // Setup BMP280 sensor
+    bmp280.readCoefficients();
+
+    bmp280.i2cDevice.write(bmp280.bmp280Addrs.ADDRESS,
+                              new Buffer([bmp280.bmp280Addrs.REGISTER_CONTROL,
+                              bmp280.bmp280Addrs.PRESS_OVER |
+                              bmp280.bmp280Addrs.TEMP_OVER |
+                              bmp280.bmp280Addrs.NORMAL_MODE]));
+
+    bmp280.i2cDevice.write(bmp280.bmp280Addrs.ADDRESS,
+                              new Buffer([bmp280.bmp280Addrs.REGISTER_CONFIG,
+                              bmp280.bmp280Addrs.STANDBY |
+                              bmp280.bmp280Addrs.FILTER |
+                              bmp280.bmp280Addrs.SPI_3W_DISABLE]));
+}
+
+function glcdInit() {
+
+    // Clear the screen
+    glcd.clear();
+
+    // Set our preferences for the Grove LCD
+    glcd.i2cDevice.write(glcd.glcdAddrs.DISPLAY_ADDR,
+                                new Buffer([0, glcd.glcdAddrs.CMD_FUNCTION_SET |
+                                glcd.glcdAddrs.FS_ROWS_2 |
+                                glcd.glcdAddrs.FS_DOT_SIZE_LITTLE |
+                                glcd.glcdAddrs.FS_8BIT_MODE]));
+
+    glcd.i2cDevice.write(glcd.glcdAddrs.DISPLAY_ADDR,
+                                new Buffer([0, glcd.glcdAddrs.CMD_DISPLAY_SWITCH |
+                                glcd.glcdAddrs.DS_DISPLAY_ON |
+                                glcd.glcdAddrs.DS_CURSOR_OFF |
+                                glcd.glcdAddrs.DS_BLINK_OFF]));
+
+    // Init the screen with text
+    glcd.writeText("Temperature is ", 0, 0);
+}
 
 function setColorFromTemperature(newTemp) {
     // If newTemp is higher than prevTemp change color to be
@@ -70,6 +113,9 @@ function readTemperature() {
     setColorFromTemperature(T);
     prevTemp = T;
 }
+
+bmp280Init();
+glcdInit();
 
 /* Loop read forever */
 

--- a/samples/I2CBMP280.js
+++ b/samples/I2CBMP280.js
@@ -17,8 +17,11 @@
 console.log("Starting I2C demo using BMP280 and Grove LCD");
 
 /* Globals */
+
+// Import JavaScript modules from 'modules' folder
 var bmp280 = require("BMP280.js");
 var glcd = require("GroveLCD.js");
+
 var baseTemp = prevTemp = 25;
 var red = green = blue = 200;
 

--- a/samples/I2CBMP280.js
+++ b/samples/I2CBMP280.js
@@ -30,8 +30,8 @@ function bmp280Init() {
                                           bmp280.bmp280Addrs.REGISTER_CHIPID);
 
     // Check that we have a BMP280 on the I2C bus
-    if (reader.toString('hex') !== "58")
-        print("BMP280 not found! ChipId " + reader.toString('hex') !== "58");
+    if (reader.toString("hex") !== "58")
+        print("BMP280 not found! ChipId " + reader.toString("hex") !== "58");
 
     // Setup BMP280 sensor
     bmp280.readCoefficients();
@@ -89,7 +89,7 @@ function setColorFromTemperature(newTemp) {
     }
 
     prevTemp = newTemp;
-    glcd.setColor({'red' : red, 'green' : green, 'blue' : blue});
+    glcd.setColor({"red" : red, "green" : green, "blue" : blue});
 }
 
 function readTemperature() {
@@ -97,7 +97,7 @@ function readTemperature() {
     var whole = T | 0;
     var dec = (T * 10) | 0;
     dec = dec - whole * 10;
-    var tempStr = whole  + '.' + dec + "C";
+    var tempStr = whole  + "." + dec + "C";
 
     // Draw icon for direction temp has changed
     if (prevTemp < T) {

--- a/samples/I2CBMP280.js
+++ b/samples/I2CBMP280.js
@@ -14,94 +14,20 @@
 //     - Wire SCL on the LCD and BMP280 to SCL on the Arduino 101
 //     - Wire power(5V) and ground accordingly
 
-var i2c = require("i2c");
-
-var bmp280 = {
-    BMP280_ADDRESS: 0x77,
-    BMP280_NORMAL_MODE: 0x03,
-    BMP280_REGISTER_DIG_T1: 0x88, // Unsigned Short
-    BMP280_REGISTER_DIG_T2: 0x8A, // Signed Short
-    BMP280_REGISTER_DIG_T3: 0x8C, // Signed Short
-    BMP280_REGISTER_CHIPID: 0xD0,
-    BMP280_REGISTER_CONTROL: 0xF4,
-    BMP280_REGISTER_CONFIG: 0xF5,
-    BMP280_REGISTER_TEMPDATA: 0xFA, // Signed 20bit. Always positive
-    BMP280_STANDBY: 2 << 5,
-    BMP280_FILTER: 0x00,
-    BMP280_SPI_3W_DISABLE: 0x00,
-    BMP280_PRESS_OVER: 1 << 2,
-    BMP280_TEMP_OVER: 1 << 5
-}
-
-var glcd = {
-    GROVE_LCD_DISPLAY_ADDR : 0x3E,
-    GROVE_RGB_BACKLIGHT_ADDR : 0x62,
-// Defines for the GLCD_CMD_CURSOR_SHIFT
-    GLCD_CS_DISPLAY_SHIFT : 1 << 3,
-    GLCD_CS_RIGHT_SHIFT : 1 << 2,
-// LCD Display Commands
-    GLCD_CMD_SCREEN_CLEAR : 1 << 0,
-    GLCD_CMD_CURSOR_RETURN : 1 << 1,
-    GLCD_CMD_INPUT_SET : 1 << 2,
-    GLCD_CMD_DISPLAY_SWITCH : 1 << 3,
-    GLCD_CMD_CURSOR_SHIFT : 1 << 4,
-    GLCD_CMD_FUNCTION_SET : 1 << 5,
-    GLCD_CMD_SET_CGRAM_ADDR : 1 << 6,
-    GLCD_CMD_SET_DDRAM_ADDR : 1 << 7,
-// Defines for the LCD_FUNCTION_SET
-    GLCD_FS_8BIT_MODE : 1 << 4,
-    GLCD_FS_ROWS_2 : 1 << 3,
-    GLCD_FS_ROWS_1 : 0 << 3,
-    GLCD_FS_DOT_SIZE_BIG : 1 << 2,
-    GLCD_FS_DOT_SIZE_LITTLE : 0 << 2,
-// Defines for the GLCD_CMD_DISPLAY_SWITCH options
-    GLCD_DS_DISPLAY_ON : 1 << 2,
-    GLCD_DS_DISPLAY_OFF : 0 << 2,
-    GLCD_DS_CURSOR_ON : 1 << 1,
-    GLCD_DS_CURSOR_OFF : 0 << 1,
-    GLCD_DS_BLINK_ON : 1 << 0,
-    GLCD_DS_BLINK_OFF : 0 << 0,
-    REGISTER_POWER : 0x08,
-    REGISTER_R : 0x04,
-    REGISTER_G : 0x03,
-    REGISTER_B : 0x02
-}
+console.log("Starting I2C demo using BMP280 and Grove LCD");
 
 /* Globals */
-var i2cDevice = i2c.open({ bus: 0, speed: 100 });
-var dig_T1;
-var dig_T2;
-var dig_T3;
+var bmp280 = require("BMP280.js");
+var glcd = require("GroveLCD.js");
 var baseTemp = prevTemp = 25;
-var firstRead = true;
 var red = green = blue = 200;
 
-function uint16toInt16(value) {
-    if ((value & 0x8000) > 0) {
-        value = value - 0x10000;
-    }
-    return value;
-}
-
-function resetCursor(col, row) {
-    // Reset the cursor position
-    row = row || 0;
-    col = col || 0;
-
-    if (row == 0) {
-        // Put the cursor on the first row at col
-        col |= 0x80;
-    } else {
-        // Put the cursor on the second row at col
-        col |= 0xC0;
-    }
-
-    // Write new cursor position via I2C
-    i2cDevice.write(glcd.GROVE_LCD_DISPLAY_ADDR,
-                    new Buffer([glcd.GLCD_CMD_SET_DDRAM_ADDR, col]));
-}
+// Init the screen with text
+glcd.writeText("Temperature is ", 0, 0);
 
 function setColorFromTemperature(newTemp) {
+    // If newTemp is higher than prevTemp change color to be
+    // more red.  If lower change it to be more blue.
     var diff = newTemp - baseTemp;
     var change = (diff > 0) ? (diff * 40) : (diff * -40);
     change = (change > 255) ? 255 : (change | 0);
@@ -117,127 +43,31 @@ function setColorFromTemperature(newTemp) {
     }
 
     prevTemp = newTemp;
-
-    // Valid range for color is 0 - 255
-    // Write new color values
-    i2cDevice.write(glcd.GROVE_RGB_BACKLIGHT_ADDR,
-                    new Buffer([glcd.REGISTER_B, blue]));
-    i2cDevice.write(glcd.GROVE_RGB_BACKLIGHT_ADDR,
-                    new Buffer([glcd.REGISTER_R, red]));
-    i2cDevice.write(glcd.GROVE_RGB_BACKLIGHT_ADDR,
-                    new Buffer([glcd.REGISTER_G, green]));
-}
-
-function writeText(word) {
-    var wordBuffer = new Buffer(word.length + 1);
-
-    // The first byte in the buffer is for the register address,
-    // which is where the word is going to be written to.
-    wordBuffer.writeUInt8(glcd.GLCD_CMD_SET_CGRAM_ADDR, 0);
-
-    // Append the text we want to print after that
-    wordBuffer.write(word, 1);
-
-    // Write the buffer to I2C
-    i2cDevice.write(glcd.GROVE_LCD_DISPLAY_ADDR, wordBuffer);
-}
-
-function init() {
-    var reader = i2cDevice.read(bmp280.BMP280_ADDRESS, 1,
-                                bmp280.BMP280_REGISTER_CHIPID);
-
-    // Check that we have a BMP280 on the I2C bus
-    if (reader.toString('hex') !== "58")
-        console.log("BMP280 not found! ChipId " + reader.toString('hex') !== "58");
-
-    readCoefficients();
-
-    /* Setup BMP280 sensor */
-    i2cDevice.write(bmp280.BMP280_ADDRESS,
-                    new Buffer([bmp280.BMP280_REGISTER_CONTROL,
-                                bmp280.BMP280_PRESS_OVER |
-                                bmp280.BMP280_TEMP_OVER |
-                                bmp280.BMP280_NORMAL_MODE]));
-
-    i2cDevice.write(bmp280.BMP280_ADDRESS,
-                    new Buffer([bmp280.BMP280_REGISTER_CONFIG,
-                                bmp280.BMP280_STANDBY |
-                                bmp280.BMP280_FILTER |
-                                bmp280.BMP280_SPI_3W_DISABLE]));
-
-    /* Setup Grove LCD */
-    // Clear the LCD
-    i2cDevice.write(glcd.GROVE_LCD_DISPLAY_ADDR,
-                    new Buffer([0, glcd.GLCD_CMD_SCREEN_CLEAR]));
-
-    // Set our preferences for the Grove LCD
-    i2cDevice.write(glcd.GROVE_LCD_DISPLAY_ADDR,
-                    new Buffer([0, glcd.GLCD_CMD_FUNCTION_SET |
-                                   glcd.GLCD_FS_ROWS_2 |
-                                   glcd.GLCD_FS_DOT_SIZE_LITTLE |
-                                   glcd.GLCD_FS_8BIT_MODE]));
-
-    i2cDevice.write(glcd.GROVE_LCD_DISPLAY_ADDR,
-                    new Buffer([0, glcd.GLCD_CMD_DISPLAY_SWITCH |
-                                   glcd.GLCD_DS_DISPLAY_ON |
-                                   glcd.GLCD_DS_CURSOR_OFF |
-                                   glcd.GLCD_DS_BLINK_OFF]));
-
-    resetCursor(0, 0);
-    writeText("Temperature is ");
-}
-
-function readCoefficients() {
-    // These need to be read as a burst read in order to get accurate numbers
-    dig_TAll = i2cDevice.burstRead(bmp280.BMP280_ADDRESS, 24,
-                                   bmp280.BMP280_REGISTER_DIG_T1);
-    dig_T1 = dig_TAll.readUInt16LE();
-    dig_T2 = dig_TAll.readUInt16LE(2);
-    dig_T3 = dig_TAll.readUInt16LE(4);
-
-    // Convert these to signed
-    dig_T1 = uint16toInt16(dig_T1);
-    dig_T2 = uint16toInt16(dig_T2);
-    dig_T3 = uint16toInt16(dig_T3);
+    glcd.setColor({'red' : red, 'green' : green, 'blue' : blue});
 }
 
 function readTemperature() {
-    // Read the raw temperature value.
-    var tempBuffer = i2cDevice.burstRead(bmp280.BMP280_ADDRESS, 4,
-                                         bmp280.BMP280_REGISTER_TEMPDATA);
-    // Get the number from the buffer object
-    var tempDec = tempBuffer.readUInt32BE();
-    //Select the first 20 bits of 32 bit integer and maintains the sign
-    tempDec >>>= 12;
-
-    // Convert raw temperature to Celsius using the algorithm found here
-    // https://www.bosch-sensortec.com/bst/products/all_products/bmp280
-    var var1 = (((tempDec >> 3) - (dig_T1 << 1)) * (dig_T2)) >> 11;
-    var var2 = (((((tempDec >> 4) - (dig_T1)) * ((tempDec >> 4) - (dig_T1))) >> 12) *
-                (dig_T3)) >> 14;
-
-    var t_fine = var1 + var2;
-    var T = ((t_fine * 5 + 128) >> 8) / 100 ;
-
-    console.log("Temp = " + T);
+    var T = bmp280.readTemperature();
     var whole = T | 0;
     var dec = (T * 10) | 0;
     dec = dec - whole * 10;
     var tempStr = whole  + '.' + dec + "C";
+
     // Draw icon for direction temp has changed
-    resetCursor(0, 1);
     if (prevTemp < T) {
-        writeText("+");
-    } else {
-        writeText("-");
+        glcd.writeText("+", 0, 1);
+    } else if (prevTemp > T) {
+        glcd.writeText("-", 0, 1);
     }
 
     // Write out the temp to the LCD
-    resetCursor(9, 1);
-    writeText(tempStr);
+    glcd.writeText(tempStr, 9, 1);
+
+    // Change the color based on new temp
     setColorFromTemperature(T);
     prevTemp = T;
 }
 
-init();
-setInterval(readTemperature, 10);
+/* Loop read forever */
+
+var timer = setInterval(readTemperature, 10);

--- a/src/main.c
+++ b/src/main.c
@@ -97,6 +97,14 @@ int main(int argc, char *argv[])
 #endif
     zjs_init_callbacks();
 
+    // Add module.exports to global namespace
+    jerry_value_t global_obj = jerry_get_global_object();
+    jerry_value_t modules_obj = jerry_create_object();
+    jerry_value_t exports_obj = jerry_create_object();
+
+    zjs_set_property(modules_obj, "exports", exports_obj);
+    zjs_set_property(global_obj, "module", modules_obj);
+
     // initialize modules
     zjs_modules_init();
 
@@ -118,8 +126,6 @@ int main(int argc, char *argv[])
             goto error;
         }
     }
-
-    jerry_value_t global_obj = jerry_get_global_object();
 
     // Todo: find a better solution to disable eval() in JerryScript.
     // For now, just inject our eval() function in the global space
@@ -145,6 +151,8 @@ int main(int argc, char *argv[])
     }
 
     jerry_release_value(global_obj);
+    jerry_release_value(modules_obj);
+    jerry_release_value(exports_obj);
     jerry_release_value(code_eval);
     jerry_release_value(result);
 


### PR DESCRIPTION
Users can now import Javascript modules using
var myObj = require("modulename.js");

A sample is also included to demonstrate how this is done.