### PR TITLE
[general] Print ERR_PRINT messages in release builds

### DIFF
--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -24,7 +24,9 @@ int zjs_get_ms(void);
 
 #else
 #define DBG_PRINT(fmat ...) do {} while(0);
-#define ERR_PRINT(fmat ...) do {} while(0);
+#define ERR_PRINT \
+    ZJS_PRINT("[ERROR] %s:%d %s(): ", __FILE__, __LINE__, __func__); \
+    ZJS_PRINT
 #endif
 
 // TODO: We should instead have a macro that changes in debug vs. release build,


### PR DESCRIPTION
We don't want to miss errors when we're in release builds. Things for
debug only belong in DBG_PRINT.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>