### PR TITLE
[Makefile] Don't force BOARD=qemu_x86 for "qemu".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ generate: $(JS) setup
 # Run QEMU target
 .PHONY: qemu
 qemu: $(PRE_ACTION) analyze generate
-	make -f Makefile.zephyr BOARD=qemu_x86 KERNEL=$(KERNEL) MEM_STATS=$(MEM_STATS) CB_STATS=$(CB_STATS) qemu
+	make -f Makefile.zephyr KERNEL=$(KERNEL) MEM_STATS=$(MEM_STATS) CB_STATS=$(CB_STATS) qemu
 
 # Builds ARC binary
 .PHONY: arc


### PR DESCRIPTION
This allows to build QEMU target for BOARD=qemu_cortex_m3, and in future,
for other QEMU target. This however now requires explicit BOARD when
build for x86:

make BOARD=qemu_x86 qemu

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>