### PR TITLE
[build] Adding configuration file support for the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ clean: update
 	@rm -f prj.conf
 	@rm -f prj.conf.tmp
 	@rm -f prj.mdef
+	@rm -f zjs.conf.tmp
 
 .PHONY: pristine
 pristine:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ OCF_ROOT ?= deps/iotivity-constrained
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 JS ?= samples/HelloWorld.js
 VARIANT ?= release
+
+# if no config file passed use the ashell default
+ifeq ($(DEV), ashell)
+	CONFIG ?= fragments/zjs.conf.dev
+endif
+
 # Dump memory information: on = print allocs, full = print allocs + dump pools
 TRACE ?= off
 # Print callback statistics during runtime

--- a/Makefile
+++ b/Makefile
@@ -64,11 +64,14 @@ else
 	@cat fragments/prj.mdef.base >> prj.mdef
 	@cat fragments/prj.mdef.heap >> prj.mdef
 endif
-	@echo "ccflags-y += $(shell ./scripts/analyze.sh $(BOARD) $(JS))" | tee -a src/Makefile arc/src/Makefile
+
+	@echo "ccflags-y += $(shell ./scripts/analyze.sh $(BOARD) $(JS) $(CONFIG))" | tee -a src/Makefile arc/src/Makefile
+
 	@# Add the include for the OCF Makefile only if the script is using OCF
 	@if grep BUILD_MODULE_OCF src/Makefile; then \
 		echo "include \$$(ZJS_BASE)/Makefile.ocf_zephyr" >> src/Makefile; \
 	fi
+	@sed -i '/This is a generated file/r./zjs.conf.tmp' src/Makefile
 
 .PHONY: all
 all: zephyr arc

--- a/fragments/zjs.conf.dev
+++ b/fragments/zjs.conf.dev
@@ -1,17 +1,17 @@
-# To include a module remove the # in front of it
+# To force inclusion of a module remove the # in front of it
 
+ZJS_AIO=y
+ZJS_ARDUINO101_PINS=y
+ZJS_BLE=y
+ZJS_BUFFER=y
+ZJS_CONSOLE=y
 ZJS_EVENTS=y
-#ZJS_OCF=y
 ZJS_GPIO=y
+#ZJS_GROVE_LCD=y
+ZJS_I2C=y
+#ZJS_OCF=y
 #ZJS_PERFORMANCE=y
 ZJS_PWM=y
-ZJS_UART=y
-ZJS_BLE=y
-ZJS_AIO=y
-ZJS_I2C=y
-#ZJS_GROVE_LCD=y
-ZJS_ARDUINO101_PINS=y
-ZJS_TIMERS=y
-ZJS_BUFFER=y
 #ZJS_SENSOR=y
-ZJS_CONSOLE=y
+ZJS_TIMERS=y
+ZJS_UART=y

--- a/fragments/zjs.conf.dev
+++ b/fragments/zjs.conf.dev
@@ -1,0 +1,17 @@
+# To include a module remove the # in front of it
+
+ZJS_EVENTS=y
+#ZJS_OCF=y
+ZJS_GPIO=y
+#ZJS_PERFORMANCE=y
+ZJS_PWM=y
+ZJS_UART=y
+ZJS_BLE=y
+ZJS_AIO=y
+ZJS_I2C=y
+#ZJS_GROVE_LCD=y
+ZJS_ARDUINO101_PINS=y
+ZJS_TIMERS=y
+ZJS_BUFFER=y
+#ZJS_SENSOR=y
+ZJS_CONSOLE=y

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -74,6 +74,7 @@ function check_config_file()
             return 1
         fi
     fi
+    return 1;
 }
 
 check_for_js_require

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -63,16 +63,12 @@ function check_for_require()
 
 function check_config_file()
 {
-    # effects: checks $1 for uncommented module to inclue from #CONFIG
-    #          If found, it will be put in zjs.conf.tmp and appended to src/Makefile
+    # effects: checks $1 for uncommented module to include from #CONFIG
+    #          If found, it will be put in zjs.conf.tmp and inserted into src/Makefile
 
     if [ -n "$CONFIG" ]; then
-        rval=$(grep -v '^#' < $CONFIG | grep $1='y\|m' | xargs)
-        if [ "$rval" ]; then
-            return 0
-        else
-            return 1
-        fi
+       grep -v '^#' < $CONFIG | grep $1='y\|m' >> /dev/null
+        return $?
     fi
     return 1;
 }

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -154,6 +154,8 @@ if check_for_require ble || check_config_file ZJS_BLE; then
     echo "CONFIG_BLUETOOTH_SMP=y" >> prj.conf.tmp
     echo "CONFIG_BLUETOOTH_PERIPHERAL=y" >> prj.conf.tmp
     echo "CONFIG_BLUETOOTH_GATT_DYNAMIC_DB=y" >> prj.conf.tmp
+    MODULES+=" -DBUILD_MODULE_EVENTS"
+    echo "export ZJS_EVENTS=y" >> zjs.conf.tmp
     echo "export ZJS_BLE=y" >> zjs.conf.tmp
 fi
 

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -23,9 +23,17 @@ fi
 MODULES=''
 BOARD=$1
 SCRIPT=$2
+CONFIG=$3
 
 echo "# Modules found in $SCRIPT:" > prj.conf.tmp
 echo "# Modules found in $SCRIPT:" > arc/prj.conf.tmp
+tmpstr="# ZJS flags set by analyze.js"
+
+if [ -n "$CONFIG" ]; then
+    tmpstr+=" and $CONFIG"
+fi
+
+echo $tmpstr > zjs.conf.tmp
 
 function check_for_js_require()
 {
@@ -53,15 +61,30 @@ function check_for_require()
     return $?
 }
 
+function check_config_file()
+{
+    # effects: checks $1 for uncommented module to inclue from #CONFIG
+    #          If found, it will be put in zjs.conf.tmp and appended to src/Makefile
+
+    if [ -n "$CONFIG" ]; then
+        rval=$(grep -v '^#' < $CONFIG | grep $1='y\|m' | xargs)
+        if [ "$rval" ]; then
+            return 0
+        else
+            return 1
+        fi
+    fi
+}
+
 check_for_js_require
 
-check_for_require events
-if [ $? -eq 0 ]; then
+if check_for_require events || check_config_file ZJS_EVENTS; then
     >&2 echo Using module: Events
     MODULES+=" -DBUILD_MODULE_EVENTS"
+    echo "export ZJS_EVENTS=y" >> prj.conf.tmp
 fi
-check_for_require ocf
-if [ $? -eq 0 ]; then
+
+if check_for_require ocf || check_config_file ZJS_OCF; then
     >&2 echo Using module: OCF
     MODULES+=" -DBUILD_MODULE_OCF"
     echo "CONFIG_NETWORKING_WITH_IPV6=y" >> prj.conf.tmp
@@ -77,27 +100,30 @@ if [ $? -eq 0 ]; then
     echo "CONFIG_IP_BUF_RX_SIZE=5" >> prj.conf.tmp
     echo "CONFIG_IP_BUF_TX_SIZE=5" >> prj.conf.tmp
     echo "CONFIG_NET_MAX_CONTEXTS=9" >> prj.conf.tmp
+    echo "export ZJS_OCF=y" >> zjs.conf.tmp
 fi
-check_for_require gpio
-if [ $? -eq 0 ]; then
-    >&2 echo Using module: GPIO
+
+if check_for_require gpio || check_config_file ZJS_GPIO; then
     MODULES+=" -DBUILD_MODULE_GPIO"
     echo "CONFIG_GPIO=y" >> prj.conf.tmp
+    echo "export ZJS_GPIO=y" >> zjs.conf.tmp
 fi
-check_for_require performance
-if [ $? -eq 0 ]; then
+
+if check_for_require performance || check_config_file ZJS_PERFORMANCE; then
     >&2 echo Using module: Performance
     MODULES+=" -DBUILD_MODULE_PERFORMANCE"
+    echo "export ZJS_PERFORMANCE=y" >> zjs.conf.tmp
 fi
-check_for_require pwm
-if [ $? -eq 0 ]; then
+
+if check_for_require pwm || check_config_file ZJS_PWM; then
     >&2 echo Using module: PWM
     MODULES+=" -DBUILD_MODULE_PWM"
     echo "CONFIG_PWM=y" >> prj.conf.tmp
     echo "CONFIG_PWM_QMSI_NUM_PORTS=4" >> prj.conf.tmp
+    echo "export ZJS_PWM=y" >> zjs.conf.tmp
 fi
-check_for_require uart
-if [ $? -eq 0 ]; then
+
+if check_for_require uart || check_config_file ZJS_UART; then
     >&2 echo Using module: UART
     if [ $BOARD = "arduino_101" ]; then
         echo "CONFIG_GPIO=y" >> prj.conf.tmp
@@ -113,9 +139,10 @@ if [ $? -eq 0 ]; then
     echo "CONFIG_UART_INTERRUPT_DRIVEN=y" >> prj.conf.tmp
     MODULES+=" -DBUILD_MODULE_UART"
     MODULES+=" -DBUILD_MODULE_BUFFER"
+    echo "export ZJS_UART=y" >> zjs.conf.tmp
 fi
-check_for_require ble
-if [ $? -eq 0 ]; then
+
+if check_for_require ble || check_config_file ZJS_BLE; then
     >&2 echo Using module: BLE
     MODULES+=" -DBUILD_MODULE_BLE"
     echo "CONFIG_BLUETOOTH=y" >> prj.conf.tmp
@@ -124,35 +151,40 @@ if [ $? -eq 0 ]; then
     echo "CONFIG_BLUETOOTH_SMP=y" >> prj.conf.tmp
     echo "CONFIG_BLUETOOTH_PERIPHERAL=y" >> prj.conf.tmp
     echo "CONFIG_BLUETOOTH_GATT_DYNAMIC_DB=y" >> prj.conf.tmp
+    echo "export ZJS_BLE=y" >> zjs.conf.tmp
 fi
-check_for_require aio
-if [ $? -eq 0 ]; then
+
+if check_for_require aio || check_config_file ZJS_AIO; then
     >&2 echo Using module: AIO
     MODULES+=" -DBUILD_MODULE_AIO"
     echo "CONFIG_ADC=y" >> arc/prj.conf.tmp
     echo "CONFIG_ADC_DEBUG=y" >> arc/prj.conf.tmp
+    echo "export ZJS_AIO=y" >> zjs.conf.tmp
 fi
-check_for_require i2c
-if [ $? -eq 0 ]; then
+
+if check_for_require i2c || check_config_file ZJS_I2C; then
     >&2 echo Using module: I2C
     MODULES+=" -DBUILD_MODULE_I2C"
     >&2 echo Using module: Buffer
     MODULES+=" -DBUILD_MODULE_BUFFER"
     echo "CONFIG_I2C=y" >> arc/prj.conf.tmp
+    echo "export ZJS_I2C=y" >> zjs.conf.tmp
 fi
-check_for_require grove_lcd
-if [ $? -eq 0 ]; then
+
+if check_for_require grove_lcd || check_config_file ZJS_GROVE_LCD; then
     >&2 echo Using module: Grove LCD
     MODULES+=" -DBUILD_MODULE_GROVE_LCD"
     echo "CONFIG_I2C=y" >> arc/prj.conf.tmp
     echo "CONFIG_GROVE=y" >> arc/prj.conf.tmp
     echo "CONFIG_GROVE_LCD_RGB=y" >> arc/prj.conf.tmp
     echo "CONFIG_GROVE_LCD_RGB_INIT_PRIORITY=90" >> arc/prj.conf.tmp
+    echo "export ZJS_GROVE_LCD=y" >> zjs.conf.tmp
 fi
-check_for_require arduino101_pins
-if [ $? -eq 0 ]; then
+
+if check_for_require arduino101_pins || check_config_file ZJS_ARDUINO101_PINS; then
     >&2 echo Using module: A101 Pins
     MODULES+=" -DBUILD_MODULE_A101"
+    echo "export ZJS_ARDUINO101_PINS=y" >> zjs.conf.tmp
 fi
 
 interval=$(grep setInterval $SCRIPT)
@@ -173,6 +205,7 @@ buffer=$(grep Buffer\([0-9]*\) $SCRIPT)
 if [ $? -eq 0 ] && [[ $MODULE != *"BUILD_MODULE_BUFFER"* ]]; then
     >&2 echo Using module: Buffer
     MODULES+=" -DBUILD_MODULE_BUFFER"
+    echo "export ZJS_BUFFER=y" >> zjs.conf.tmp
 fi
 sensor=$(grep -E Accelerometer\|Gyroscope $SCRIPT)
 if [ $? -eq 0 ]; then
@@ -195,6 +228,7 @@ if [ $? -eq 0 ]; then
         echo "CONFIG_BMI160_SPI_BUS_FREQ=88" >> arc/prj.conf.tmp
         echo "CONFIG_BMI160_TRIGGER=y" >> arc/prj.conf.tmp
         echo "CONFIG_BMI160_TRIGGER_OWN_THREAD=y" >> arc/prj.conf.tmp
+	echo "export ZJS_SENSOR=y" >> zjs.conf.tmp
     fi
 fi
 
@@ -202,6 +236,8 @@ console=$(grep console $SCRIPT)
 if [ $? -eq 0 ] && [[ $MODULE != *"BUILD_MODULE_CONSOLE"* ]]; then
     >&2 echo Using module: Console
     MODULES+=" -DBUILD_MODULE_CONSOLE"
+    echo "export ZJS_CONSOLE=y" >> zjs.conf.tmp
 fi
 
+echo "# ---------------------------" >> zjs.conf.tmp
 echo $MODULES

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -82,7 +82,7 @@ check_for_js_require
 if check_for_require events || check_config_file ZJS_EVENTS; then
     >&2 echo Using module: Events
     MODULES+=" -DBUILD_MODULE_EVENTS"
-    echo "export ZJS_EVENTS=y" >> prj.conf.tmp
+    echo "export ZJS_EVENTS=y" >> zjs.conf.tmp
 fi
 
 if check_for_require ocf || check_config_file ZJS_OCF; then
@@ -140,6 +140,8 @@ if check_for_require uart || check_config_file ZJS_UART; then
     echo "CONFIG_UART_INTERRUPT_DRIVEN=y" >> prj.conf.tmp
     MODULES+=" -DBUILD_MODULE_UART"
     MODULES+=" -DBUILD_MODULE_BUFFER"
+    MODULES+=" -DBUILD_MODULE_EVENTS"
+    echo "export ZJS_EVENTS=y" >> zjs.conf.tmp
     echo "export ZJS_UART=y" >> zjs.conf.tmp
 fi
 

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -69,11 +69,6 @@ obj-$(CONFIG_BOARD_FRDM_K64F) += \
 
 ifeq ($(DEV), ashell)
 $(info Insecure Mode (development))
-ccflags-y += -DBUILD_MODULE_GPIO -DBUILD_MODULE_PWM -DBUILD_MODULE_UART
-ccflags-y += -DBUILD_MODULE_AIO -DBUILD_MODULE_A101
-ccflags-y += -DBUILD_MODULE_TIMER -DBUILD_MODULE_BUFFER
-ccflags-y += -DBUILD_MODULE_GROVE_LCD -DBUILD_MODULE_I2C
-ccflags-y += -DBUILD_MODULE_SENSOR
 export JERRY_INCLUDE = $(JERRY_BASE)/jerry-core/
 obj-y += ashell/
 endif

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -32,31 +32,32 @@ ccflags-y += -DZJS_PRINT_FLOATS
 endif
 
 obj-y += main.o \
-         zjs_ble.o \
          zjs_buffer.o \
          zjs_callbacks.o \
          zjs_console.o \
-         zjs_event.o \
-         zjs_gpio.o \
          zjs_modules.o \
-         zjs_performance.o \
-         zjs_ocf_client.o \
-         zjs_ocf_server.o \
-         zjs_ocf_common.o \
          zjs_promise.o \
-         zjs_pwm.o \
          zjs_script.o \
          zjs_script_gen.o \
          zjs_timers.o \
-         zjs_uart.o \
          zjs_util.o
+
+obj-$(ZJS_GPIO) += zjs_gpio.o
+obj-$(ZJS_BLE) += zjs_ble.o
+obj-$(ZJS_PWM) += zjs_pwm.o
+obj-$(ZJS_PERFORMANCE) += zjs_performance.o
+obj-$(ZJS_UART) += zjs_uart.o
+obj-$(ZJS_EVENTS) += zjs_event.o
+obj-$(ZJS_OCF) += zjs_ocf_client.o \
+                  zjs_ocf_server.o \
+                  zjs_ocf_common.o \
 
 # skip for now for frdm_k64f
 ifneq ($(BOARD), frdm_k64f)
-obj-y += zjs_aio.o \
-         zjs_grove_lcd.o \
-         zjs_i2c.o \
-         zjs_sensor.o
+	obj-$(ZJS_AIO) += zjs_aio.o
+	obj-$(ZJS_GROVE_LCD) += zjs_grove_lcd.o
+	obj-$(ZJS_I2C) += zjs_i2c.o
+	obj-$(ZJS_SENSOR) += zjs_sensor.o
 endif
 
 obj-$(CONFIG_BOARD_ARDUINO_101) += \

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -42,12 +42,12 @@ obj-y += main.o \
          zjs_timers.o \
          zjs_util.o
 
+obj-$(ZJS_EVENTS) += zjs_event.o
 obj-$(ZJS_GPIO) += zjs_gpio.o
 obj-$(ZJS_BLE) += zjs_ble.o
 obj-$(ZJS_PWM) += zjs_pwm.o
 obj-$(ZJS_PERFORMANCE) += zjs_performance.o
 obj-$(ZJS_UART) += zjs_uart.o
-obj-$(ZJS_EVENTS) += zjs_event.o
 obj-$(ZJS_OCF) += zjs_ocf_client.o \
                   zjs_ocf_server.o \
                   zjs_ocf_common.o \

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -50,7 +50,7 @@ obj-$(ZJS_PERFORMANCE) += zjs_performance.o
 obj-$(ZJS_UART) += zjs_uart.o
 obj-$(ZJS_OCF) += zjs_ocf_client.o \
                   zjs_ocf_server.o \
-                  zjs_ocf_common.o \
+                  zjs_ocf_common.o
 
 # skip for now for frdm_k64f
 ifneq ($(BOARD), frdm_k64f)

--- a/zjs.conf
+++ b/zjs.conf
@@ -1,0 +1,17 @@
+# To include a module remove the # in front of it
+
+#ZJS_EVENTS=y
+#ZJS_OCF=y
+#ZJS_GPIO=y
+#ZJS_PERFORMANCE=y
+#ZJS_PWM=y
+#ZJS_UART=y
+#ZJS_BLE=y
+#ZJS_AIO=y
+#ZJS_I2C=y
+#ZJS_GROVE_LCD=y
+#ZJS_ARDUINO101_PINS=y
+#ZJS_TIMERS=y
+#ZJS_BUFFER=y
+#ZJS_SENSOR=y
+#ZJS_CONSOLE=y

--- a/zjs.conf
+++ b/zjs.conf
@@ -1,17 +1,17 @@
-# To include a module remove the # in front of it
+# To force inclusion of a module remove the # in front of it
 
+#ZJS_AIO=y
+#ZJS_ARDUINO101_PINS=y
+#ZJS_BLE=y
+#ZJS_BUFFER=y
+#ZJS_CONSOLE=y
 #ZJS_EVENTS=y
-#ZJS_OCF=y
 #ZJS_GPIO=y
+#ZJS_GROVE_LCD=y
+#ZJS_I2C=y
+#ZJS_OCF=y
 #ZJS_PERFORMANCE=y
 #ZJS_PWM=y
-#ZJS_UART=y
-#ZJS_BLE=y
-#ZJS_AIO=y
-#ZJS_I2C=y
-#ZJS_GROVE_LCD=y
-#ZJS_ARDUINO101_PINS=y
-#ZJS_TIMERS=y
-#ZJS_BUFFER=y
 #ZJS_SENSOR=y
-#ZJS_CONSOLE=y
+#ZJS_TIMERS=y
+#ZJS_UART=y


### PR DESCRIPTION
Now make can be given CONFIG=zjs.conf (or whatever file you choose)
to indicate you want certain modules to be built in.  This allows
you to build modules that aren't included in your Javascript file.
This will also allow us to build ashell, linux, etc with only the
modules we want rather than all of them.  In the future we can
remove the #ifdef BUILD_MODULE* from the src files as they simply
won't be included in the build rather than commented out.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>