### PR TITLE
[build] Added flag to toggle print float flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ TRACE ?= off
 MALLOC ?= pool
 # Print callback statistics during runtime
 CB_STATS ?= off
+# Print floats (uses -u _printf_float flag). This is a workaround on the A101
+# otherwise floats will not print correctly. It does use ~11k extra ROM though
+PRINT_FLOAT ?= off
 # Make target (linux or zephyr)
 # MAKECMDGOALS is a Make variable that is set to the target your building for.
 TARGET = $(MAKECMDGOALS)
@@ -37,7 +40,12 @@ endif
 # Build for zephyr, default target
 .PHONY: zephyr
 zephyr: $(PRE_ACTION) analyze generate
-	@make -f Makefile.zephyr BOARD=$(BOARD) KERNEL=$(KERNEL) VARIANT=$(VARIANT) MEM_STATS=$(MEM_STATS) CB_STATS=$(CB_STATS)
+	@make -f Makefile.zephyr	BOARD=$(BOARD) \
+					KERNEL=$(KERNEL) \
+					VARIANT=$(VARIANT) \
+					MEM_STATS=$(MEM_STATS) \
+					CB_STATS=$(CB_STATS) \
+					PRINT_FLOAT=$(PRINT_FLOAT)
 
 # Give an error if we're asked to create the JS file
 $(JS):

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -63,7 +63,8 @@ LINUX_DEFINES +=	-DZJS_LINUX_BUILD \
 			-DBUILD_MODULE_OCF \
 			-DBUILD_MODULE_EVENTS \
 			-DBUILD_MODULE_PERFORMANCE \
-			-DBUILD_MODULE_CONSOLE
+			-DBUILD_MODULE_CONSOLE \
+			-DZJS_PRINT_FLOATS
 
 LINUX_FLAGS += 	-fno-asynchronous-unwind-tables \
 		-fno-omit-frame-pointer \

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -1,8 +1,6 @@
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 OCF_ROOT ?= deps/iotivity-constrained
 
-export LDFLAGS += -u _printf_float
-
 ccflags-y += -Wall -Werror
 
 # Select extended ANSI C/POSIX function set in recent Newlib versions
@@ -23,6 +21,11 @@ endif
 
 ifeq ($(CB_STATS), on)
 ccflags-y += -DZJS_PRINT_CALLBACK_STATS
+endif
+
+ifeq ($(PRINT_FLOAT), on)
+export LDFLAGS += -u _printf_float
+ccflags-y += -DZJS_PRINT_FLOATS
 endif
 
 obj-y += main.o \

--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -55,8 +55,13 @@ static jerry_value_t do_print(const jerry_value_t function_obj,
         } else if (jerry_value_is_number(argv[i])) {
             int type = is_int(argv[i]);
             if (type == IS_NUMBER) {
+#ifdef ZJS_PRINT_FLOATS
                 double num = jerry_get_number_value(argv[i]);
                 fprintf(out, "%f ", num);
+#else
+                int32_t num = (int32_t)jerry_get_number_value(argv[i]);
+                fprintf(out, "[Float ~%li] ", num);
+#endif
             } else if (type == IS_UINT) {
                 uint32_t num = (uint32_t)jerry_get_number_value(argv[i]);
                 fprintf(out, "%lu ", num);


### PR DESCRIPTION
 - To print floats on the A101, a flag had to be used which added
   ~11k to our ROM footprint. This adds a compile time option to
   enable this flag. It is disabled by default so if a float is
   printed it will approximate the value e.g.

   [Float ~42]

   instead of (with the flag enabled):

   42.424242

Signed-off-by: James Prestwood <james.prestwood@intel.com>