### PR TITLE
[buffer] Use prototype inheritance to implement Buffer functions

### DIFF
--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -150,9 +150,10 @@ void javascript_stop()
     parsed_code = 0;
 
     /* Cleanup engine */
-    jerry_cleanup();
-    zjs_ipm_free_callbacks();
     zjs_timers_cleanup();
+    zjs_ipm_free_callbacks();
+    zjs_buffer_cleanup()
+    jerry_cleanup();
 
     restore_zjs_api();
 }

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -15,6 +15,7 @@
 #include "zjs_buffer.h"
 
 static zjs_buffer_t *zjs_buffers = NULL;
+static jerry_value_t zjs_buffer_prototype;
 
 // TODO: this could probably be replaced more efficiently now that there is a
 //   get_native_handle API
@@ -367,19 +368,8 @@ jerry_value_t zjs_buffer_create(uint32_t size)
     buf_item->next = zjs_buffers;
     zjs_buffers = buf_item;
 
+    jerry_set_prototype(buf_obj, zjs_buffer_prototype);
     zjs_obj_add_number(buf_obj, size, "length");
-    zjs_obj_add_function(buf_obj, zjs_buffer_read_uint8, "readUInt8");
-    zjs_obj_add_function(buf_obj, zjs_buffer_write_uint8, "writeUInt8");
-    zjs_obj_add_function(buf_obj, zjs_buffer_read_uint16_be, "readUInt16BE");
-    zjs_obj_add_function(buf_obj, zjs_buffer_write_uint16_be, "writeUInt16BE");
-    zjs_obj_add_function(buf_obj, zjs_buffer_read_uint16_le, "readUInt16LE");
-    zjs_obj_add_function(buf_obj, zjs_buffer_write_uint16_le, "writeUInt16LE");
-    zjs_obj_add_function(buf_obj, zjs_buffer_read_uint32_be, "readUInt32BE");
-    zjs_obj_add_function(buf_obj, zjs_buffer_write_uint32_be, "writeUInt32BE");
-    zjs_obj_add_function(buf_obj, zjs_buffer_read_uint32_le, "readUInt32LE");
-    zjs_obj_add_function(buf_obj, zjs_buffer_write_uint32_le, "writeUInt32LE");
-    zjs_obj_add_function(buf_obj, zjs_buffer_to_string, "toString");
-    zjs_obj_add_function(buf_obj, zjs_buffer_write_string, "write");
 
     // TODO: sign up to get callback when the object is freed, then free the
     //   buffer and remove it from the list
@@ -457,5 +447,28 @@ void zjs_buffer_init()
     jerry_value_t global_obj = jerry_get_global_object();
     zjs_obj_add_function(global_obj, zjs_buffer, "Buffer");
     jerry_release_value(global_obj);
+
+    zjs_native_func_t array[] = {
+        { zjs_buffer_read_uint8, "readUInt8" },
+        { zjs_buffer_write_uint8, "writeUInt8" },
+        { zjs_buffer_read_uint16_be, "readUInt16BE" },
+        { zjs_buffer_write_uint16_be, "writeUInt16BE" },
+        { zjs_buffer_read_uint16_le, "readUInt16LE" },
+        { zjs_buffer_write_uint16_le, "writeUInt16LE" },
+        { zjs_buffer_read_uint32_be, "readUInt32BE" },
+        { zjs_buffer_write_uint32_be, "writeUInt32BE" },
+        { zjs_buffer_read_uint32_le, "readUInt32LE" },
+        { zjs_buffer_write_uint32_le, "writeUInt32LE" },
+        { zjs_buffer_to_string, "toString" },
+        { zjs_buffer_write_string, "write" },
+        { NULL, NULL }
+    };
+    zjs_buffer_prototype = jerry_create_object();
+    zjs_obj_add_functions(zjs_buffer_prototype, array);
+}
+
+void zjs_buffer_cleanup()
+{
+    jerry_release_value(zjs_buffer_prototype);
 }
 #endif // BUILD_MODULE_BUFFER

--- a/src/zjs_buffer.h
+++ b/src/zjs_buffer.h
@@ -5,7 +5,11 @@
 
 #include "jerry-api.h"
 
+/** Initialize the buffer module, or reinitialize after cleanup */
 void zjs_buffer_init();
+
+/** Release resources held by the buffer module */
+void zjs_buffer_cleanup();
 
 typedef struct zjs_buffer {
     jerry_value_t obj;

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -24,6 +24,17 @@ jerry_value_t zjs_get_property(const jerry_value_t obj, const char *name)
     return rval;
 }
 
+void zjs_obj_add_functions(jerry_value_t obj, zjs_native_func_t *funcs)
+{
+    // requires: obj is an existing JS object
+    //           funcs is an array of zjs_native_func_t structs, terminated by a
+    //             struct with a NULL function field
+    //  effects: adds all of the described functions to obj with given names
+    for (zjs_native_func_t *map = funcs; map->function; map++) {
+        zjs_obj_add_function(obj, map->function, map->name);
+    }
+}
+
 void zjs_obj_add_boolean(jerry_value_t obj, bool flag, const char *name)
 {
     // requires: obj is an existing JS object

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -43,6 +43,18 @@ void zjs_set_property(const jerry_value_t obj, const char *str,
                       const jerry_value_t prop);
 jerry_value_t zjs_get_property (const jerry_value_t obj, const char *str);
 
+typedef struct zjs_native_func {
+    void *function;
+    const char *name;
+} zjs_native_func_t;
+
+/**
+ * Add a series of functions described in array funcs to obj
+ * @param obj    JerryScript object to add the functions to
+ * @param funcs  Array of zjs_native_func_t, terminated with {NULL, NULL}
+ */
+void zjs_obj_add_functions(jerry_value_t obj, zjs_native_func_t *funcs);
+
 void zjs_obj_add_boolean(jerry_value_t obj, bool flag, const char *name);
 void zjs_obj_add_function(jerry_value_t obj, void *function, const char *name);
 void zjs_obj_add_object(jerry_value_t parent, jerry_value_t child,


### PR DESCRIPTION
This should save lots of runtime JS memory when there are multiple
buffers instantiated because only the single prototype needs to contain
the mappings to native API functions. I'd like to measure how much this
saves but expect we should replicate it across all APIs.

Also, added a zjs_obj_add_functions (plural) API to simplify creating a
large batch of native API mappings for an object.

Also, reorder cleanup for ashell so that jerry_cleanup() is the final
step and should leave the JS memory in its pristine state.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>