### PR TITLE
[submodules] Ignore dirty trees or different commits in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,15 @@
 [submodule "deps/zephyr"]
 	path = deps/zephyr
 	url = https://gerrit.zephyrproject.org/r/zephyr
+    ignore = all
 [submodule "deps/jerryscript"]
 	path = deps/jerryscript
 	url = https://github.com/Samsung/jerryscript.git
+    ignore = all
 [submodule "deps/ihex"]
 	path = deps/ihex
 	url = https://github.com/arkku/ihex.git
 [submodule "deps/iotivity-constrained"]
 	path = deps/iotivity-constrained
 	url = https://gerrit.iotivity.org/gerrit/p/iotivity-constrained.git
+    ignore = all


### PR DESCRIPTION
If the user makes changes to e.g. their Zephyr subdirectory, this means
they will not be nagged about those changes when the look at git status.
This seems best because we frequently may have some instrumentation code
checked into Zephyr, and don't need to be constantly reminded.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>