### PR TITLE
[ashell] Updated fifo APIS & Refactor of acm into comms

### DIFF
--- a/src/ashell/Makefile
+++ b/src/ashell/Makefile
@@ -27,8 +27,8 @@ obj-y += jerry-code.o
 
 obj-y += ihex-handler.o
 
-obj-y += acm-uart.o
-obj-y += acm-shell.o
+obj-y += comms-uart.o
+obj-y += comms-shell.o
 obj-y += shell-state.o
 
 obj-y += ../../deps/ihex/kk_ihex_read.o

--- a/src/ashell/comms-shell.h
+++ b/src/ashell/comms-shell.h
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-#ifndef __acm_shell_h__
-#define __acm_shell_h__
+#ifndef __comms_shell_h__
+#define __comms_shell_h__
 
-void acm_set_prompt(const char *prompt);
-const char *acm_get_prompt();
+void comms_set_prompt(const char *prompt);
+const char *comms_get_prompt();
 
 /**
  * Callback function when a line arrives
@@ -37,4 +37,4 @@ bool ashell_check_parameter(const char *buf, const char parameter);
 uint32_t ashell_get_argc(const char *str, uint32_t nsize);
 const char *ashell_get_next_arg_s(const char *str, uint32_t nsize, char *str_arg, uint32_t max_arg_size, uint32_t *length);
 
-#endif  // __acm_shell_h__
+#endif  // __comms_shell_h__

--- a/src/ashell/comms-uart.h
+++ b/src/ashell/comms-uart.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef __acm_uart_h__
-#define __acm_uart_h__
+#ifndef __comms_uart_h__
+#define __comms_uart_h__
 
 /* Control characters */
 /* http://www.physics.udel.edu/~watson/scen103/ascii.html */
@@ -122,7 +122,7 @@ typedef void(*process_status_callback_t)(enum process_status_code status_code);
 /*
  * @brief Interfaces for the different uploaders and process handlers
  */
-struct acm_interface_cfg_data
+struct comms_interface_cfg_data
 {
     process_init_callback_t init_cb;
     process_close_callback_t close_cb;
@@ -135,31 +135,31 @@ struct acm_interface_cfg_data
  * @brief UART process data configuration
  *
  * The Application instantiates this with given parameters added
- * using the "acm_set_config" function.
+ * using the "comms_uart_set_config" function.
  *
  * This function can be called to swap between different states of the
  * data transactions.
  */
 
-struct acm_cfg_data
+struct comms_cfg_data
 {
     /* Callback to be notified on connection status change */
     process_status_callback_t cb_status;
-    struct acm_interface_cfg_data interface;
+    struct comms_interface_cfg_data interface;
 
     /* Callback to print debug data or state to the user */
     process_print_state_t print_state;
 };
 
-void acm_set_config(struct acm_cfg_data *config);
+void comms_uart_set_config(struct comms_cfg_data *config);
 
-void acm_print_status();
-void acm_clear();
+void comms_print_status();
+void comms_clear();
 
-void acm_println(const char *buf);
-void acm_write(const char *buf, int len);
-void acm_writec(char byte);
-void acm_print(const char *buf);
-void acm_printf(const char *format, ...);
+void comms_println(const char *buf);
+void comms_write_buf(const char *buf, int len);
+void comms_writec(char byte);
+void comms_print(const char *buf);
+void comms_printf(const char *format, ...);
 
-#endif  // __acm_uart_h__
+#endif  // __comms_uart_h__

--- a/src/ashell/file-utils.c
+++ b/src/ashell/file-utils.c
@@ -47,7 +47,6 @@ int fs_exist(const char *path)
 
 fs_file_t *fs_open_alloc(const char * filename, const char * mode)
 {
-    printk("[OPEN] %s\n", filename);
     int res;
 
     /* Delete file if exists */
@@ -83,7 +82,6 @@ ssize_t fs_size(fs_file_t *file)
 
 int fs_close_alloc(fs_file_t * fp)
 {
-    printk("[CLOSE]\n");
     int res = fs_close(fp);
     free(fp);
     return res;

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -42,7 +42,7 @@
 
 void jerry_port_default_set_log_level(jerry_log_level_t level); /** Inside jerry-port-default.h */
 
-#include "acm-uart.h"
+#include "comms-uart.h"
 
 static jerry_value_t parsed_code = 0;
 
@@ -180,43 +180,43 @@ int javascript_parse_code(const char *file_name, bool show_lines)
 
     ssize_t size = fs_size(fp);
     if (size == 0) {
-        acm_printf("[ERR] Empty file (%s)\n", file_name);
+        comms_printf("[ERR] Empty file (%s)\n", file_name);
         goto cleanup;
     }
 
     buf = (char *)malloc(size);
     if (buf == NULL) {
-        acm_printf("[ERR] Not enough memory for (%s)\n", file_name);
+        comms_printf("[ERR] Not enough memory for (%s)\n", file_name);
         goto cleanup;
     }
 
     ssize_t brw = fs_read(fp, buf, size);
 
     if (brw != size) {
-        acm_printf("[ERR] Failed loading code %s\n", file_name);
+        comms_printf("[ERR] Failed loading code %s\n", file_name);
         goto cleanup;
     }
 
     if (show_lines) {
-        acm_printf("[READ] %d\n", (int)brw);
+        comms_printf("[READ] %d\n", (int)brw);
 
         // Print buffer test
         int line = 0;
-        acm_println("[START]");
-        acm_printf("%5d  ", line++);
+        comms_println("[START]");
+        comms_printf("%5d  ", line++);
         for (int t = 0; t < brw; t++) {
             uint8_t byte = buf[t];
             if (byte == '\n' || byte == '\r') {
-                acm_write("\r\n", 2);
-                acm_printf("%5d  ", line++);
+                comms_write_buf("\r\n", 2);
+                comms_printf("%5d  ", line++);
             } else {
                 if (!isprint(byte)) {
-                    acm_printf("(%x)", byte);
+                    comms_printf("(%x)", byte);
                 } else
-                    acm_writec(byte);
+                    comms_writec(byte);
             }
         }
-        acm_println("[END]");
+        comms_println("[END]");
     }
 
     /* Setup Global scope code */

--- a/src/ashell/main-zephyr.c
+++ b/src/ashell/main-zephyr.c
@@ -23,7 +23,7 @@
 #include <drivers/console/uart_console.h>
 
 #include "jerry-api.h"
-#include "acm-uart.h"
+#include "comms-uart.h"
 
 #include "shell-state.h"
 
@@ -40,13 +40,13 @@ static int shell_cmd_version(int argc, char *argv[])
 static int shell_clear(int argc, char *argv[])
 {
     printk(ANSI_CLEAR);
-    acm_clear();
+    comms_clear();
     return 0;
 }
 
 static int shell_status(int argc, char *argv[])
 {
-    acm_print_status();
+    comms_print_status();
     return 0;
 }
 


### PR DESCRIPTION
- Changed nano_fifo to k_fifo apis

- Since we are working on getting webusb and bluetooth integrated
to upload the javascript code, acm_ doesn't make much sense anymore.

We are renaming the methods from acm into a generic communications 'comms',
so we also avoid clash with the acm driver methods.

Signed-off-by: Sergio Martinez <sergio.martinez.rodriguez@intel.com>