### PR TITLE
[scripts] New script 'trlite' to run Travis tests locally

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -4,6 +4,9 @@
 # Author: Geoff Gustafson <geoff@linux.intel.com>
 
 # trlite - a local version of the tests we run in Travis
+#   trlite [-v] [vmname]
+#
+#   -v turns on verbose output
 #   by default, runs all tests
 #   trlite 1 or trlite zephyr runs just VM #1 "zephyr" tests
 #   trlite 2 or trlite linux  runs just VM #2 "linux"  tests
@@ -15,6 +18,12 @@ if [ ! -d "$ZJS_BASE" ]; then
 fi
 
 TRLDIR=$ZJS_BASE/.trlite
+
+VERBOSE=
+if [ "$1" == "-v" ]; then
+   VERBOSE=V=1
+   shift
+fi
 
 # flags for running tests from the different VMs
 VM1=y
@@ -44,7 +53,7 @@ function try_command()
 {
     LABEL=$1
     shift
-    banner $LABEL
+    banner "$LABEL"
     if ! $*; then
         echo Error: Failed in $1!
         exit $?
@@ -58,26 +67,26 @@ function try_command()
 
 if [ "$VM1" == "y" ]; then
     # A101 build tests spanning all modules
-    try_command "helloworld" make V=1
-    try_command "traffic" make V=1 JS=samples/TrafficLight.js
-    try_command "pwm" make V=1 JS=samples/PWM.js
-    try_command "i2c" make V=1 JS=samples/I2C.js
-    try_command "uart" make V=1 JS=samples/UART.js
-    try_command "events" make V=1 JS=samples/tests/Events.js
-    try_command "perf" make V=1 JS=tests/test-performance.js
+    try_command "helloworld" make $VERBOSE
+    try_command "traffic" make $VERBOSE JS=samples/TrafficLight.js
+    try_command "pwm" make $VERBOSE JS=samples/PWM.js
+    try_command "i2c" make $VERBOSE JS=samples/I2C.js
+    try_command "uart" make $VERBOSE JS=samples/UART.js
+    try_command "events" make $VERBOSE JS=samples/tests/Events.js
+    try_command "perf" make $VERBOSE JS=tests/test-performance.js
 
     # k64f build tests
     git clean -dfx
-    try_command "k64f hello" make V=1 BOARD=frdm_k64f
+    try_command "k64f hello" make $VERBOSE BOARD=frdm_k64f
 
     # arc build tests
     git clean -dfx
-    try_command "arc" make V=1 arc
+    try_command "arc" make $VERBOSE arc
 
     # 256KB partition build tests
     git clean -dfx
     source zjs-env.sh 256
-    try_command "btgrove" make V=1 JS=samples/WebBluetoothGroveLcdDemo.js
+    try_command "btgrove" make $VERBOSE JS=samples/WebBluetoothGroveLcdDemo.js
 fi
 
 #
@@ -89,7 +98,7 @@ if [ "$VM2" == "y" ]; then
     try_command "git check" git diff --check $(git rev-list HEAD | tail -1)
 
     # linux build tests
-    try_command "linux" make V=1 linux
+    try_command "linux" make $VERBOSE linux
 
     # linux unit tests
     try_command "unit tests" ./outdir/linux/release/jslinux --unittest
@@ -102,7 +111,7 @@ fi
 if [ "$VM3" == "y" ]; then
     # ashell tests
     git clean -dfx
-    try_command "ashell" make V=1 DEV=ashell
+    try_command "ashell" make $VERBOSE DEV=ashell
 fi
 
 # clean up on success

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Copyright (c) 2016, Intel Corporation.
+# Author: Geoff Gustafson <geoff@linux.intel.com>
+
+# trlite - a local version of the tests we run in Travis
+#   by default, runs all tests
+#   trlite 1 or trlite zephyr runs just VM #1 "zephyr" tests
+#   trlite 2 or trlite linux  runs just VM #2 "linux"  tests
+#   trlite 3 or trlite ashell runs just VM #3 "ashell" tests
+
+if [ ! -d "$ZJS_BASE" ]; then
+   >&2 echo "ZJS_BASE not defined. You need to source zjs-env.sh."
+   exit 1
+fi
+
+TRLDIR=$ZJS_BASE/.trlite
+
+# flags for running tests from the different VMs
+VM1=y
+VM2=y
+VM3=y
+
+if [ "$1" == "1" -o "$1" == "zephyr" ]; then VM2=n; VM3=n; fi
+if [ "$1" == "2" -o "$1" == "linux" ]; then VM1=n; VM3=n; fi
+if [ "$1" == "3" -o "$1" == "ashell" ]; then VM1=n; VM2=n; fi
+
+rm -rf $TRLDIR
+git clone -l $ZJS_BASE $TRLDIR
+cd $TRLDIR/deps
+for i in */; do
+    git clone -l ../../deps/$i/.git $i
+done
+cd ..
+make update
+
+source zjs-env.sh
+source deps/zephyr/zephyr-env.sh
+
+# requires: first arg is a <=10-char label, second arg is command
+#  effects: runs banner with label, then runs the command; if it fails, prints
+#             label on the command line before exiting
+function try_command()
+{
+    LABEL=$1
+    shift
+    banner $LABEL
+    if ! $*; then
+        echo Error: Failed in $1!
+        exit $?
+    fi
+    echo Success: $LABEL
+}
+
+#
+# Tests from VM #1
+#
+
+if [ "$VM1" == "y" ]; then
+    # A101 build tests spanning all modules
+    try_command "helloworld" make V=1
+    try_command "traffic" make V=1 JS=samples/TrafficLight.js
+    try_command "pwm" make V=1 JS=samples/PWM.js
+    try_command "i2c" make V=1 JS=samples/I2C.js
+    try_command "uart" make V=1 JS=samples/UART.js
+    try_command "events" make V=1 JS=samples/tests/Events.js
+    try_command "perf" make V=1 JS=tests/test-performance.js
+
+    # k64f build tests
+    git clean -dfx
+    try_command "k64f hello" make V=1 BOARD=frdm_k64f
+
+    # arc build tests
+    git clean -dfx
+    try_command "arc" make V=1 arc
+
+    # 256KB partition build tests
+    git clean -dfx
+    source zjs-env.sh 256
+    try_command "btgrove" make V=1 JS=samples/WebBluetoothGroveLcdDemo.js
+fi
+
+#
+# Tests from VM #2
+#
+
+if [ "$VM2" == "y" ]; then
+    # git check
+    try_command "git check" git diff --check $(git rev-list HEAD | tail -1)
+
+    # linux build tests
+    try_command "linux" make V=1 linux
+
+    # linux unit tests
+    try_command "unit tests" ./outdir/linux/release/jslinux --unittest
+fi
+
+#
+# Tests from VM #3
+#
+
+if [ "$VM3" == "y" ]; then
+    # ashell tests
+    git clean -dfx
+    try_command "ashell" make V=1 DEV=ashell
+fi
+
+# clean up on success
+cd $ZJS_BASE
+rm -rf $TRLDIR


### PR DESCRIPTION
With no args, runs all the tests.
"trlite zephyr" runs just the VM #1 "zephyr" tests.
"trlite linux"  runs just the VM #2 "linux"  tests.
"trlite ashell" runs just the VM #3 "ashell" tests.
You can also just pass the VM# instead (1, 2, or 3).

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>