### PR TITLE
[JerryScript] Optimize build with LTO and All-in-one flags

### DIFF
--- a/Makefile.app
+++ b/Makefile.app
@@ -1,6 +1,12 @@
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 
+EXT_JERRY_FLAGS ?= -DENABLE_ALL_IN_ONE=ON
+
+ifneq ($(BOARD), frdm_k64f)
+EXT_JERRY_FLAGS += -DENABLE_LTO=ON
+endif
+
 $(KBUILD_ZEPHYR_APP):
 	@echo "Building" $@
-	make -C $(JERRY_BASE) -f targets/zephyr/Makefile.zephyr BOARD=$(BOARD) jerry
+	make -C $(JERRY_BASE) -f targets/zephyr/Makefile.zephyr BOARD=$(BOARD) EXT_JERRY_FLAGS="$(EXT_JERRY_FLAGS)" jerry
 	cp $(JERRY_BASE)/build/$(BOARD)/obj-$(BOARD)/lib/$@ $(O)


### PR DESCRIPTION
This will further reduce final build size by 5-6k, the
default Zephyr target in JerryScript do not have these
enabled.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>