### PR TITLE
[aio] Use prototype inheritance to implement AIO functions

### DIFF
--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -130,7 +130,6 @@ void javascript_eval_code(const char *source_buffer)
     jerry_release_value(ret_val);
 }
 
-
 void restore_zjs_api() {
 #ifdef ZJS_POOL_CONFIG
     zjs_init_mem_pools();
@@ -161,6 +160,7 @@ void javascript_stop()
     zjs_timers_cleanup();
     zjs_ipm_free_callbacks();
     zjs_buffer_cleanup();
+    zjs_modules_cleanup();
     jerry_cleanup();
 
     restore_zjs_api();

--- a/src/zjs_aio.h
+++ b/src/zjs_aio.h
@@ -5,6 +5,10 @@
 
 #include "jerry-api.h"
 
+/** Initialize the aio module, or reinitialize after cleanup */
 jerry_value_t zjs_aio_init();
+
+/** Release resources held by the aio module */
+void zjs_aio_cleanup();
 
 #endif  // __zjs_aio_h__

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -42,6 +42,7 @@ typedef struct module {
     jerry_value_t instance;
 } module_t;
 
+// init function is required, cleanup is optional in these entries
 module_t zjs_modules_array[] = {
 #ifndef ZJS_LINUX_BUILD
 #ifndef QEMU_BUILD
@@ -180,7 +181,9 @@ void zjs_modules_cleanup()
     for (int i = 0; i < modcount; i++) {
         module_t *mod = &zjs_modules_array[i];
         if (mod->instance) {
-            mod->cleanup();
+            if (mod->cleanup) {
+                mod->cleanup();
+            }
             jerry_release_value(mod->instance);
             mod->instance = 0;
         }

--- a/src/zjs_modules.h
+++ b/src/zjs_modules.h
@@ -11,10 +11,10 @@
 
 #define NUM_SERVICE_ROUTINES 3
 
-typedef jerry_value_t (*initcb_t)();
 typedef void (*zjs_service_routine)(void* handle);
 
 void zjs_modules_init();
+void zjs_modules_cleanup();
 void zjs_register_service_routine(void* handle, zjs_service_routine func);
 void zjs_service_routines(void);
 


### PR DESCRIPTION
Also, add a spot for a cleanup function to be registered with modules
that will be called by a new zjs_modules_cleanup function. Currently,
this is called only in ashell.

Also, fix what appeared to be a bug where module instances weren't
being released.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>