### PR TITLE
[tests] test-performance.js: Bump delta to 21ms.

### DIFF
--- a/tests/test-performance.js
+++ b/tests/test-performance.js
@@ -19,6 +19,6 @@ setTimeout(function() {
     var after = performance.now();
     var diff = after - before;
     // Allow for some jitter, especially on Linux
-    assert(diff >= 989 && diff <= 1011, "performance.now() result over known delay");
+    assert(diff >= 979 && diff <= 1021, "performance.now() result over known delay");
     console.log("TOTAL: " + passed + " of " + total + " passed");
 }, 1000);


### PR DESCRIPTION
With upgrade to Zephyr 1.6 and refactors on Zephyr.js side, we're now
seeing delta of 20ms on both arduino_101 and frdm_k64f.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>