### PR TITLE
[Snapshot] Enable snapshot build feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 BOARD ?= arduino_101
 UPDATE ?= exit
 
-# pass TRACE=y to trace malloc/free in the ZJS API
-TRACE ?= n
+# Dump memory information: on = print allocs, full = print allocs + dump pools
+TRACE ?= off
+# Generate and run snapshot as byte code instead of running JS directly
+SNAPSHOT ?= off
 
 ifndef ZJS_BASE
 $(error ZJS_BASE not defined. You need to source zjs-env.sh)
@@ -14,7 +16,12 @@ VARIANT ?= release
 # JerryScript options
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 EXT_JERRY_FLAGS ?= -DENABLE_ALL_IN_ONE=ON
-ifneq ($(BOARD), frdm_k64f)
+ifeq ($(SNAPSHOT), on)
+# ToDo - When Sergio's patch to JerryScript is merged,
+# change this to -DFEATURE_PARSER_DISABLE=ON instead
+EXT_JERRY_FLAGS += -DFEATURE_SNAPSHOT_EXEC=ON
+endif
+ifeq ($(BOARD), adrduino_101)
 EXT_JERRY_FLAGS += -DENABLE_LTO=ON
 endif
 
@@ -23,8 +30,6 @@ ifeq ($(DEV), ashell)
 	CONFIG ?= fragments/zjs.conf.dev
 endif
 
-# Dump memory information: on = print allocs, full = print allocs + dump pools
-TRACE ?= off
 # Print callback statistics during runtime
 CB_STATS ?= off
 # Print floats (uses -u _printf_float flag). This is a workaround on the A101
@@ -75,6 +80,9 @@ analyze: $(JS)
 	@cat arc/src/Makefile.base >> arc/src/Makefile
 	@if [ "$(TRACE)" = "on" ] || [ "$(TRACE)" = "full" ]; then \
 		echo "ccflags-y += -DZJS_TRACE_MALLOC" >> src/Makefile; \
+	fi
+	@if [ "$(SNAPSHOT)" = "on" ]; then \
+		echo "ccflags-y += -DZJS_SNAPSHOT_BUILD" >> src/Makefile; \
 	fi
 ifeq ($(DEV), ashell)
 	@cat fragments/prj.mdef.dev >> prj.mdef
@@ -161,6 +169,8 @@ clean: update
 	fi
 	make -f Makefile.linux clean
 	@rm -f src/*.o
+	@rm -f src/zjs_script_gen.c
+	@rm -f src/zjs_snapshot_gen.c
 	@rm -f src/Makefile
 	@rm -f arc/prj.conf
 	@rm -f arc/prj.conf.tmp
@@ -194,12 +204,22 @@ dfu-all: dfu dfu-arc
 # Generate the script file from the JS variable
 .PHONY: generate
 generate: $(JS) setup
+ifeq ($(SNAPSHOT), on)
+	@echo Building snapshot generator...
+	@if ! [ -e outdir/snapshot/snapshot ]; then \
+		make -f Makefile.snapshot; \
+	fi
+	@echo Creating snapshot byte code from JS application...
+	@outdir/snapshot/snapshot $(JS) src/zjs_snapshot_gen.c
+else
 	@echo Creating C string from JS application...
 ifeq ($(TARGET), linux)
 	@./scripts/convert.sh $(JS) src/zjs_script_gen.c
 else
 	@./scripts/convert.sh /tmp/zjs.js src/zjs_script_gen.c
 endif
+endif
+
 # Run QEMU target
 .PHONY: qemu
 qemu: zephyr

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifeq ($(SNAPSHOT), on)
 # change this to -DFEATURE_PARSER_DISABLE=ON instead
 EXT_JERRY_FLAGS += -DFEATURE_SNAPSHOT_EXEC=ON
 endif
-ifeq ($(BOARD), adrduino_101)
+ifeq ($(BOARD), arduino_101)
 EXT_JERRY_FLAGS += -DENABLE_LTO=ON
 endif
 

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -32,10 +32,15 @@ CORE_SRC +=	src/zjs_buffer.c \
 		src/zjs_ocf_server.c \
 		src/zjs_promise.c \
 		src/zjs_script.c \
-		src/zjs_script_gen.c \
 		src/zjs_timers.c \
 		src/zjs_unit_tests.c \
 		src/zjs_util.c
+
+ifdef ZJS_SNAPSHOT_BUILD
+CORE_SRC +=	src/zjs_snapshot_gen.c
+else
+CORE_SRC +=	src/zjs_script_gen.c
+endif
 
 CORE_OBJ =	$(CORE_SRC:%.c=%.o)
 

--- a/Makefile.snapshot
+++ b/Makefile.snapshot
@@ -1,0 +1,90 @@
+ifndef ZJS_BASE
+$(error ZJS_BASE not defined)
+endif
+
+JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
+
+JERRY_FLAGS ?= --snapshot-save=on
+
+BUILD_DIR = $(ZJS_BASE)/outdir/snapshot/$(VARIANT)
+
+UNAME := $(shell uname)
+ifeq ($(UNAME),Darwin)
+COPY=rsync -R
+else
+COPY=cp --parents
+endif
+
+.PHONY: all
+all: snapshot
+
+.PHONY: setup
+setup:
+	@if [ ! -d $(ZJS_BASE)/outdir/snapshot/$(VARIANT) ]; then \
+		mkdir -p $(ZJS_BASE)/outdir/snapshot/$(VARIANT); \
+	fi
+
+CORE_SRC +=		src/snapshot.c \
+			src/zjs_script.c
+
+CORE_OBJ =		$(CORE_SRC:%.c=%.o)
+
+SNAPSHOT_INCLUDES += 	-Isrc/ \
+			-I$(JERRY_BASE)/jerry-core
+
+JERRY_LIBS += 		-l jerry-core -lm
+
+JERRY_LIB_PATH += 	-L $(JERRY_BASE)/build/lib/
+
+SNAPSHOT_LIBS += $(JERRY_LIBS) -pthread
+
+SNAPSHOT_DEFINES +=	-DZJS_LINUX_BUILD \
+			-DZJS_PRINT_FLOATS
+
+SNAPSHOT_FLAGS += 	-fno-asynchronous-unwind-tables \
+			-fno-omit-frame-pointer \
+			-Wno-format-zero-length \
+			-Wno-main \
+			-ffreestanding \
+			-Os \
+			-fno-stack-protector \
+			-ffunction-sections \
+			-fdata-sections \
+			-Wno-unused-but-set-variable \
+			-fno-reorder-functions \
+			-fno-defer-pop \
+			-Wno-pointer-sign \
+			-fno-strict-overflow \
+			-Werror=implicit-int \
+			-Wall \
+			-std=gnu99 \
+			-flto \
+			-Wpointer-sign
+
+ifeq ($(VARIANT), debug)
+SNAPSHOT_DEFINES +=	-DDEBUG_BUILD
+SNAPSHOT_FLAGS +=	-g
+DEBUG=1
+else
+DEBUG=0
+endif
+
+BUILD_OBJ = $(CORE_OBJ:%.o=$(BUILD_DIR)/%.o)
+
+.PHONY: snapshot_copy
+snapshot_copy:
+	$(COPY) $(CORE_SRC) $(BUILD_DIR)
+
+%.o:%.c
+	@echo "Building $@"
+	gcc -c -o $@ $< $(SNAPSHOT_INCLUDES) $(SNAPSHOT_DEFINES) $(SNAPSHOT_FLAGS)
+
+.PHONY: snapshot
+snapshot: setup snapshot_copy $(BUILD_OBJ)
+	@echo "Building for snapshot $(BUILD_OBJ)"
+	cd deps/jerryscript; python ./tools/build.py $(JERRY_FLAGS) $(VERBOSE);
+	gcc $(SNAPSHOT_INCLUDES) $(JERRY_LIB_PATH) -static -o $(BUILD_DIR)/snapshot $(BUILD_OBJ) $(SNAPSHOT_FLAGS) $(CFLAGS) $(SNAPSHOT_DEFINES) $(SNAPSHOT_LIBS)
+
+.PHONY: clean
+clean:
+	rm -f $(BUILD_OBJ)

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -36,7 +36,6 @@ obj-y += main.o \
          zjs_modules.o \
          zjs_promise.o \
          zjs_script.o \
-         zjs_script_gen.o \
          zjs_timers.o \
          zjs_util.o
 
@@ -51,6 +50,12 @@ obj-$(ZJS_UART) += zjs_uart.o
 obj-$(ZJS_OCF) += zjs_ocf_client.o \
                   zjs_ocf_server.o \
                   zjs_ocf_common.o
+
+ifeq ($(SNAPSHOT), on)
+obj-y += zjs_snapshot_gen.o
+else
+obj-y += zjs_script_gen.o
+endif
 
 # skip for now for frdm_k64f
 ifneq ($(BOARD), frdm_k64f)

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -1,0 +1,88 @@
+// Copyright (c) 2016, Intel Corporation.
+#include <string.h>
+#include "zjs_script.h"
+
+// JerryScript includes
+#include "jerry-api.h"
+
+#define SNAPSHOT_BUFFER_SIZE 51200
+#define SNAPSHOT_SOURCE_FILE "src/zjs_snapshot_gen.c"
+
+static uint8_t snapshot_buf[SNAPSHOT_BUFFER_SIZE];
+
+static int generate_snapshot(const char *file_name, uint8_t *buf, int buf_size)
+{
+    // create or overwite the existing the src file that
+    // initialize the array to stores the byte code
+    // to be executed by jerryscript
+    FILE* f = fopen(file_name, "w+");
+    if (!f) {
+        ERR_PRINT("error opening file\n");
+        return 1;
+    }
+
+    fwrite("/* This file was auto-generated */\n\n", 1, 36, f);
+    fwrite("#include \"zjs_common.h\"\n\n", 1, 25, f);
+    fwrite("const uint8_t snapshot_bytecode[] = {\n", 1, 38, f);
+
+    for (int i = 0; i < buf_size; i++)
+    {
+        if (i > 0) {
+            fwrite(",", 1, 1, f);
+        }
+        char byte[5];
+        snprintf(byte, 5, "0x%02x", snapshot_buf[i]);
+        fwrite(byte, 1, 4, f);
+        DBG_PRINT("%s,", byte);
+    }
+
+    fwrite("\n};\n\n", 1, 5, f);
+    fwrite("const int snapshot_len = sizeof(snapshot_bytecode) / ", 1, 53, f);
+    fwrite("sizeof(snapshot_bytecode[0]);\n", 1, 30, f);
+    fclose(f);
+
+    return 0;
+}
+
+int main(int argc, char *argv[])
+{
+    const char *script = NULL;
+    uint32_t len;
+
+    jerry_init(JERRY_INIT_EMPTY);
+
+    if (argc <= 1) {
+        ERR_PRINT("missing script file\n");
+        return 1;
+    }
+
+    if (zjs_read_script(argv[1], &script, &len)) {
+        ERR_PRINT("could not read script file %s\n", argv[1]);
+        return 1;
+    }
+
+    size_t size = jerry_parse_and_save_snapshot((jerry_char_t *)script,
+                                                strlen(script),
+                                                true,
+                                                false,
+                                                snapshot_buf,
+                                                sizeof(snapshot_buf));
+
+    zjs_free_script(script);
+
+    if (size == 0) {
+        ERR_PRINT("JerryScript: failed to parse JS and create snapshot\n");
+        return 1;
+    }
+
+    // store the snapshot as byte array in header
+    if (generate_snapshot(SNAPSHOT_SOURCE_FILE, snapshot_buf, size) != 0) {
+        ERR_PRINT("failed to generate %s\n", SNAPSHOT_SOURCE_FILE);
+        return 1;
+    }
+
+    ZJS_PRINT("Source code %lu bytes\n", len);
+    ZJS_PRINT("Byte code %d bytes\n", size);
+
+    return 0;
+}


### PR DESCRIPTION
The snapshot build is enabled by passing SNAPSHOT=on to make,
this will build a snapshot tool that will first parse the JS
script, and generate a zjs_snapshot_gen.c file that stores
the byte code of the running JS, and then the main program
will just run the snapshot byte code instead of parsing
the JS at run time.

For example:

$ make JS=samples/AIO.js SNAPSHOT=on all
$ make dfu-all

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>