### PR TITLE
[general] Use prototype inheritance throughout the API

### DIFF
--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -34,11 +34,12 @@
 #include "file-utils.h"
 
 /* Zephyr.js init everything */
-#include "../zjs_timers.h"
 #include "../zjs_buffer.h"
 #include "../zjs_callbacks.h"
 #include "../zjs_modules.h"
 #include "../zjs_ipm.h"
+#include "../zjs_sensor.h"
+#include "../zjs_timers.h"
 
 void jerry_port_default_set_log_level(jerry_log_level_t level); /** Inside jerry-port-default.h */
 
@@ -142,7 +143,12 @@ void restore_zjs_api() {
 #ifdef BUILD_MODULE_CONSOLE
     zjs_console_init();
 #endif
+#ifdef BUILD_MODULE_BUFFER
     zjs_buffer_init();
+#endif
+#ifdef BUILD_MODULE_SENSOR
+    zjs_sensor_init();
+#endif
     zjs_init_callbacks();
     zjs_modules_init();
 }
@@ -159,7 +165,12 @@ void javascript_stop()
     /* Cleanup engine */
     zjs_timers_cleanup();
     zjs_ipm_free_callbacks();
+#ifdef BUILD_MODULE_BUFFER
     zjs_buffer_cleanup();
+#endif
+#ifdef BUILD_MODULE_SENSOR
+    zjs_sensor_cleanup();
+#endif
     zjs_modules_cleanup();
     jerry_cleanup();
 

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -1231,7 +1231,7 @@ jerry_value_t zjs_ble_init()
     zjs_obj_add_function(ble_obj, zjs_ble_descriptor, "Descriptor");
 
     // make it an event object
-    zjs_make_event(ble_obj);
+    zjs_make_event(ble_obj, ZJS_UNDEFINED);
 
     // bt events are called from the FIBER context, since we can't call
     // zjs_trigger_event() directly, we need to register a c callback which

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -524,7 +524,7 @@ static void destroy_event(const uintptr_t pointer)
     }
 }
 
-void zjs_make_event(jerry_value_t obj)
+void zjs_make_event(jerry_value_t obj, jerry_value_t prototype)
 {
     jerry_value_t event_obj = jerry_create_object();
     struct event* ev = zjs_malloc(sizeof(struct event));
@@ -537,7 +537,12 @@ void zjs_make_event(jerry_value_t obj)
     ev->num_events = 0;
     ev->map = jerry_create_object();
 
-    jerry_set_prototype(obj, zjs_event_emitter_prototype);
+    jerry_value_t proto = zjs_event_emitter_prototype;
+    if (jerry_value_is_object(prototype)) {
+        jerry_set_prototype(prototype, proto);
+        proto = prototype;
+    }
+    jerry_set_prototype(obj, proto);
 
     jerry_set_object_native_handle(event_obj, (uintptr_t)ev, destroy_event);
 
@@ -551,7 +556,7 @@ static jerry_value_t event_constructor(const jerry_value_t function_obj,
                                        const jerry_length_t argc)
 {
     jerry_value_t new_emitter = jerry_create_object();
-    zjs_make_event(new_emitter);
+    zjs_make_event(new_emitter, ZJS_UNDEFINED);
     return new_emitter;
 }
 

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -9,6 +9,8 @@
 #define HIDDEN_PROP(n) "\377" n
 #endif
 
+static jerry_value_t zjs_event_emitter_prototype;
+
 struct event {
     int num_events;
     jerry_value_t map;
@@ -535,16 +537,7 @@ void zjs_make_event(jerry_value_t obj)
     ev->num_events = 0;
     ev->map = jerry_create_object();
 
-    zjs_obj_add_function(obj, add_listener, "on");
-    zjs_obj_add_function(obj, add_listener, "addListener");
-    zjs_obj_add_function(obj, emit_event, "emit");
-    zjs_obj_add_function(obj, remove_listener, "removeListener");
-    zjs_obj_add_function(obj, remove_all_listeners, "removeAllListeners");
-    zjs_obj_add_function(obj, get_event_names, "eventNames");
-    zjs_obj_add_function(obj, get_max_listeners, "getMaxListeners");
-    zjs_obj_add_function(obj, get_listener_count, "listenerCount");
-    zjs_obj_add_function(obj, get_listeners, "listeners");
-    zjs_obj_add_function(obj, set_max_listeners, "setMaxListeners");
+    jerry_set_prototype(obj, zjs_event_emitter_prototype);
 
     jerry_set_object_native_handle(event_obj, (uintptr_t)ev, destroy_event);
 
@@ -564,5 +557,26 @@ static jerry_value_t event_constructor(const jerry_value_t function_obj,
 
 jerry_value_t zjs_event_init()
 {
+    zjs_native_func_t array[] = {
+        { add_listener, "on" },
+        { add_listener, "addListener" },
+        { emit_event, "emit" },
+        { remove_listener, "removeListener" },
+        { remove_all_listeners, "removeAllListeners" },
+        { get_event_names, "eventNames" },
+        { get_max_listeners, "getMaxListeners" },
+        { get_listener_count, "listenerCount" },
+        { get_listeners, "listeners" },
+        { set_max_listeners, "setMaxListeners" },
+        { NULL, NULL }
+    };
+    zjs_event_emitter_prototype = jerry_create_object();
+    zjs_obj_add_functions(zjs_event_emitter_prototype, array);
+
     return jerry_create_external_function(event_constructor);
+}
+
+void zjs_event_cleanup()
+{
+    jerry_release_value(zjs_event_emitter_prototype);
 }

--- a/src/zjs_event.h
+++ b/src/zjs_event.h
@@ -3,14 +3,14 @@
 
 #include "zjs_util.h"
 
-/*
+/**
  * Callback prototype for after an event is triggered
  *
  * @param handle        Handle given to zjs_trigger_event()
  */
 typedef void (*zjs_post_event)(void* handle);
 
-/*
+/**
  * Turn an object into an event object. After this call the object will have
  * all the event functions like addListener(), on(), etc. This object can also
  * be used to trigger events in C.
@@ -19,7 +19,7 @@ typedef void (*zjs_post_event)(void* handle);
  */
 void zjs_make_event(jerry_value_t obj);
 
-/*
+/**
  * Add a new event listener to an event object.
  *
  * @param obj           Object to add listener to
@@ -28,7 +28,7 @@ void zjs_make_event(jerry_value_t obj);
  */
 void zjs_add_event_listener(jerry_value_t obj, const char* event, jerry_value_t listener);
 
-/*
+/**
  * Trigger an event
  *
  * @param obj           Object that contains the event to be triggered
@@ -47,7 +47,7 @@ bool zjs_trigger_event(jerry_value_t obj,
                        zjs_post_event post,
                        void* handle);
 
-/*
+/**
  * Call any registered event listeners immediately
  *
  * @param obj           Object that contains the event to be triggered
@@ -66,12 +66,14 @@ bool zjs_trigger_event_now(jerry_value_t obj,
                            zjs_post_event post,
                            void* h);
 
-/*
+/**
  * Initialize the event module
  *
  * @return              Event constructor
  */
 jerry_value_t zjs_event_init();
 
+/** Release resources held by the event module */
+void zjs_event_cleanup();
 
 #endif

--- a/src/zjs_event.h
+++ b/src/zjs_event.h
@@ -13,11 +13,15 @@ typedef void (*zjs_post_event)(void* handle);
 /**
  * Turn an object into an event object. After this call the object will have
  * all the event functions like addListener(), on(), etc. This object can also
- * be used to trigger events in C.
+ * be used to trigger events in C. If the object needs no other prototype, pass
+ * undefined and the event emitter prototype will be used. If a prototype is
+ * given, it will be used as the object's prototype but its prototype in turn
+ * will be set to the event emitter prototype.
  *
  * @param obj           Object to turn into an event object
+ * @param prototype     Object to decorate and use as prototype, or undefined
  */
-void zjs_make_event(jerry_value_t obj);
+void zjs_make_event(jerry_value_t obj, jerry_value_t prototype);
 
 /**
  * Add a new event listener to an event object.

--- a/src/zjs_gpio.h
+++ b/src/zjs_gpio.h
@@ -7,6 +7,14 @@
 
 extern void (*zjs_gpio_convert_pin)(uint32_t orig, int *dev, int *pin);
 
+/**
+ * Initialize the gpio module, or reinitialize after cleanup
+ *
+ * @return GPIO API object
+ */
 jerry_value_t zjs_gpio_init();
+
+/** Release resources held by the gpio module */
+void zjs_gpio_cleanup();
 
 #endif  // __zjs_gpio_h__

--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -19,6 +19,8 @@
 
 static struct k_sem glcd_sem;
 
+static jerry_value_t zjs_glcd_prototype;
+
 static bool zjs_glcd_ipm_send_sync(zjs_ipm_message_t* send,
                                    zjs_ipm_message_t* result) {
     send->id = MSG_ID_GLCD;
@@ -311,20 +313,9 @@ static jerry_value_t zjs_glcd_init(const jerry_value_t function_obj,
     }
 
     // create the Grove LCD device object
-    jerry_value_t devObj = jerry_create_object();
-    zjs_obj_add_function(devObj, zjs_glcd_print, "print");
-    zjs_obj_add_function(devObj, zjs_glcd_clear, "clear");
-    zjs_obj_add_function(devObj, zjs_glcd_set_cursor_pos, "setCursorPos");
-    zjs_obj_add_function(devObj, zjs_glcd_select_color, "selectColor");
-    zjs_obj_add_function(devObj, zjs_glcd_set_color, "setColor");
-    zjs_obj_add_function(devObj, zjs_glcd_set_function, "setFunction");
-    zjs_obj_add_function(devObj, zjs_glcd_get_function, "getFunction");
-    zjs_obj_add_function(devObj, zjs_glcd_set_display_state, "setDisplayState");
-    zjs_obj_add_function(devObj, zjs_glcd_get_display_state, "getDisplayState");
-    zjs_obj_add_function(devObj, zjs_glcd_set_input_state, "setInputState");
-    zjs_obj_add_function(devObj, zjs_glcd_get_input_state, "getInputState");
-
-    return devObj;
+    jerry_value_t dev_obj = jerry_create_object();
+    jerry_set_prototype(dev_obj, zjs_glcd_prototype);
+    return dev_obj;
 }
 
 jerry_value_t zjs_grove_lcd_init()
@@ -333,6 +324,23 @@ jerry_value_t zjs_grove_lcd_init()
     zjs_ipm_register_callback(MSG_ID_GLCD, ipm_msg_receive_callback);
 
     k_sem_init(&glcd_sem, 0, 1);
+
+    zjs_native_func_t array[] = {
+        { zjs_glcd_print, "print" },
+        { zjs_glcd_clear, "clear" },
+        { zjs_glcd_set_cursor_pos, "setCursorPos" },
+        { zjs_glcd_select_color, "selectColor" },
+        { zjs_glcd_set_color, "setColor" },
+        { zjs_glcd_set_function, "setFunction" },
+        { zjs_glcd_get_function, "getFunction" },
+        { zjs_glcd_set_display_state, "setDisplayState" },
+        { zjs_glcd_get_display_state, "getDisplayState" },
+        { zjs_glcd_set_input_state, "setInputState" },
+        { zjs_glcd_get_input_state, "getInputState" },
+        { NULL, NULL }
+    };
+    zjs_glcd_prototype = jerry_create_object();
+    zjs_obj_add_functions(zjs_glcd_prototype, array);
 
     // create global grove_lcd object
     jerry_value_t glcd_obj = jerry_create_object();
@@ -422,6 +430,11 @@ jerry_value_t zjs_grove_lcd_init()
     jerry_release_value(val);
 
     return glcd_obj;
+}
+
+void zjs_grove_lcd_cleanup()
+{
+    jerry_release_value(zjs_glcd_prototype);
 }
 
 #endif // QEMU_BUILD

--- a/src/zjs_grove_lcd.h
+++ b/src/zjs_grove_lcd.h
@@ -7,4 +7,14 @@
 
 jerry_value_t zjs_grove_lcd_init();
 
+/**
+ * Initialize the grove_lcd module, or reinitialize after cleanup
+ *
+ * @return Grove LCD API object
+ */
+jerry_value_t zjs_grove_lcd_init();
+
+/** Release resources held by the grove_lcd module */
+void zjs_grove_lcd_cleanup();
+
 #endif  // __zjs_grove_lcd_h__

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -1,6 +1,7 @@
 // Copyright (c) 2016, Intel Corporation.
 #ifdef BUILD_MODULE_I2C
 #ifndef QEMU_BUILD
+
 // Zephyr includes
 #include <i2c.h>
 #include <string.h>
@@ -11,9 +12,11 @@
 #include "zjs_util.h"
 #include "zjs_buffer.h"
 
-#define ZJS_I2C_TIMEOUT_TICKS                      500
+#define ZJS_I2C_TIMEOUT_TICKS 500
 
 static struct k_sem i2c_sem;
+
+static jerry_value_t zjs_i2c_prototype;
 
 static bool zjs_i2c_ipm_send_sync(zjs_ipm_message_t* send,
                                   zjs_ipm_message_t* result) {
@@ -295,11 +298,8 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
 
     // create the I2C object
     jerry_value_t i2c_obj = jerry_create_object();
-    zjs_obj_add_function(i2c_obj, zjs_i2c_read, "read");
-    zjs_obj_add_function(i2c_obj, zjs_i2c_burst_read, "burstRead");
-    zjs_obj_add_function(i2c_obj, zjs_i2c_write, "write");
-    zjs_obj_add_function(i2c_obj, zjs_i2c_abort, "abort");
-    zjs_obj_add_function(i2c_obj, zjs_i2c_close, "close");
+    jerry_set_prototype(i2c_obj, zjs_i2c_prototype);
+
     zjs_obj_add_number(i2c_obj, bus, "bus");
     zjs_obj_add_number(i2c_obj, speed, "speed");
 
@@ -313,10 +313,26 @@ jerry_value_t zjs_i2c_init()
 
     k_sem_init(&i2c_sem, 0, 1);
 
+    zjs_native_func_t array[] = {
+        { zjs_i2c_read, "read" },
+        { zjs_i2c_burst_read, "burstRead" },
+        { zjs_i2c_write, "write" },
+        { zjs_i2c_abort, "abort" },
+        { zjs_i2c_close, "close" },
+        { NULL, NULL }
+    };
+    zjs_i2c_prototype = jerry_create_object();
+    zjs_obj_add_functions(zjs_i2c_prototype, array);
+
     // create global I2C object
     jerry_value_t i2c_obj = jerry_create_object();
     zjs_obj_add_function(i2c_obj, zjs_i2c_open, "open");
     return i2c_obj;
+}
+
+void zjs_i2c_cleanup()
+{
+    jerry_release_value(zjs_i2c_prototype);
 }
 
 #endif // QEMU_BUILD

--- a/src/zjs_i2c.h
+++ b/src/zjs_i2c.h
@@ -9,6 +9,14 @@
 #define I2C_1 1
 #define MAX_I2C_BUS 1
 
+/**
+ * Initialize the i2c module, or reinitialize after cleanup
+ *
+ * @return I2C API object
+ */
 jerry_value_t zjs_i2c_init();
+
+/** Release resources held by the i2c module */
+void zjs_i2c_cleanup();
 
 #endif  // __zjs_i2c_h__

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -55,10 +55,10 @@ module_t zjs_modules_array[] = {
     { "ble", zjs_ble_init },
 #endif
 #ifdef BUILD_MODULE_GPIO
-    { "gpio", zjs_gpio_init },
+    { "gpio", zjs_gpio_init, zjs_gpio_cleanup },
 #endif
 #ifdef BUILD_MODULE_GROVE_LCD
-    { "grove_lcd", zjs_grove_lcd_init },
+    { "grove_lcd", zjs_grove_lcd_init, zjs_grove_lcd_cleanup },
 #endif
 #ifdef BUILD_MODULE_PWM
     { "pwm", zjs_pwm_init },
@@ -76,11 +76,11 @@ module_t zjs_modules_array[] = {
 #endif
 #endif // QEMU_BUILD
 #ifdef BUILD_MODULE_UART
-    { "uart", zjs_init_uart },
+    { "uart", zjs_uart_init },
 #endif
 #endif // ZJS_LINUX_BUILD
 #ifdef BUILD_MODULE_EVENTS
-    { "events", zjs_event_init },
+    { "events", zjs_event_init, zjs_event_cleanup },
 #endif
 #ifdef BUILD_MODULE_PERFORMANCE
     { "performance", zjs_performance_init },

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -76,7 +76,7 @@ module_t zjs_modules_array[] = {
 #endif
 #endif // QEMU_BUILD
 #ifdef BUILD_MODULE_UART
-    { "uart", zjs_uart_init },
+    { "uart", zjs_uart_init, zjs_uart_cleanup },
 #endif
 #endif // ZJS_LINUX_BUILD
 #ifdef BUILD_MODULE_EVENTS

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -1027,7 +1027,7 @@ jerry_value_t zjs_ocf_client_init()
 {
     jerry_value_t ocf_client = jerry_create_object();
 
-    zjs_make_event(ocf_client);
+    zjs_make_event(ocf_client, ZJS_UNDEFINED);
 
     zjs_obj_add_function(ocf_client, ocf_find_resources, "findResources");
     zjs_obj_add_function(ocf_client, ocf_retrieve, "retrieve");

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -504,7 +504,7 @@ jerry_value_t zjs_ocf_server_init()
     zjs_obj_add_function(server, ocf_respond, "respond");
     zjs_obj_add_function(server, ocf_notify, "notify");
 
-    zjs_make_event(server);
+    zjs_make_event(server, ZJS_UNDEFINED);
 
     return server;
 }

--- a/src/zjs_sensor.h
+++ b/src/zjs_sensor.h
@@ -5,6 +5,10 @@
 
 #include "jerry-api.h"
 
+/** Initialize the sensor module, or reinitialize after cleanup */
 void zjs_sensor_init();
+
+/** Release resources held by the sensor module */
+void zjs_sensor_cleanup();
 
 #endif  // __zjs_sensor_h__

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -342,7 +342,7 @@ static jerry_value_t uart_init(const jerry_value_t function_obj,
     return promise;
 }
 
-jerry_value_t zjs_init_uart(void)
+jerry_value_t zjs_uart_init(void)
 {
     jerry_value_t uart_obj = jerry_create_object();
 

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -20,6 +20,8 @@
 #include "zjs_event.h"
 #include "zjs_buffer.h"
 
+static jerry_value_t zjs_uart_prototype;
+
 typedef struct {
     const char* name;
     const char* port;
@@ -330,10 +332,7 @@ static jerry_value_t uart_init(const jerry_value_t function_obj,
 
     handle->uart_obj = jerry_create_object();
 
-    zjs_make_event(handle->uart_obj);
-
-    zjs_obj_add_function(handle->uart_obj, uart_write, "write");
-    zjs_obj_add_function(handle->uart_obj, uart_set_read_range, "setReadRange");
+    zjs_make_event(handle->uart_obj, zjs_uart_prototype);
 
     zjs_fulfill_promise(promise, &handle->uart_obj, 1);
 
@@ -342,13 +341,24 @@ static jerry_value_t uart_init(const jerry_value_t function_obj,
     return promise;
 }
 
-jerry_value_t zjs_uart_init(void)
+jerry_value_t zjs_uart_init()
 {
+    zjs_native_func_t array[] = {
+        { uart_write, "write" },
+        { uart_set_read_range, "setReadRange" },
+        { NULL, NULL }
+    };
+    zjs_uart_prototype = jerry_create_object();
+    zjs_obj_add_functions(zjs_uart_prototype, array);
+
     jerry_value_t uart_obj = jerry_create_object();
-
     zjs_obj_add_function(uart_obj, uart_init, "init");
-
     return uart_obj;
+}
+
+void zjs_uart_cleanup()
+{
+    jerry_release_value(zjs_uart_prototype);
 }
 
 #endif // BUILD_MODULE_UART

--- a/src/zjs_uart.h
+++ b/src/zjs_uart.h
@@ -3,6 +3,6 @@
 #ifndef SRC_ZJS_UART_H_
 #define SRC_ZJS_UART_H_
 
-jerry_value_t zjs_init_uart(void);
+jerry_value_t zjs_uart_init(void);
 
 #endif /* SRC_ZJS_UART_H_ */

--- a/src/zjs_uart.h
+++ b/src/zjs_uart.h
@@ -3,6 +3,10 @@
 #ifndef SRC_ZJS_UART_H_
 #define SRC_ZJS_UART_H_
 
-jerry_value_t zjs_uart_init(void);
+/** Initialize the uart module, or reinitialize after cleanup */
+ jerry_value_t zjs_uart_init();
+
+/** Release resources held by the uart module */
+void zjs_uart_cleanup();
 
 #endif /* SRC_ZJS_UART_H_ */


### PR DESCRIPTION
... except for UART because it has an extra complexity. The prototype
needs to also be an event emitter so we'll have to restructure things
a little.

Updated event, gpio, grove_lcd, i2c, and sensor modules though.

Also added sensor init/cleanup into ashell, and wrapped buffer calls
there with an ifdef in case it's not included.

Also some jsdoc comment format in zjs_event.h.

Also renamed zjs_init_uart to zjs_uart_init to follow pattern, but
abandoned fixing the prototype stuff in there for the moment.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>