### PR TITLE
[bugfix] Buffer will fail if freeing the last item

### DIFF
--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -269,11 +269,7 @@ static void zjs_buffer_callback_free(uintptr_t handle)
             zjs_free((void *)handle);
             return;
         }
-        if ((*pItem) != NULL) {
-            pItem = &(*pItem)->next;
-        }
-        else
-            return;
+        pItem = &(*pItem)->next;
     }
 }
 

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -267,8 +267,13 @@ static void zjs_buffer_callback_free(uintptr_t handle)
             zjs_free((*pItem)->buffer);
             *pItem = (*pItem)->next;
             zjs_free((void *)handle);
+            return;
         }
-        pItem = &(*pItem)->next;
+        if ((*pItem) != NULL) {
+            pItem = &(*pItem)->next;
+        }
+        else
+            return;
     }
 }
 


### PR DESCRIPTION
Currently, Buffer will crash if it tries to free the last item,
because freeing it tries to look at the ->next of NULL. This adds
an extra check and also now returns once the handle has been freed,
since there's no reason to keep going.