### PR TITLE
[i2c] I2C functionality for non-ARC boards

### DIFF
--- a/samples/I2C.js
+++ b/samples/I2C.js
@@ -108,7 +108,6 @@ function resetCursor() {
 
 function changeRGB(red, green, blue) {
     // Valid range for color is 0 - 255
-    console.log("RGB = " + red + " : " + green + " : " + blue);
     var redData = new Buffer([REGISTER_R, red]);
     var greenData = new Buffer([REGISTER_G, green]);
     var blueData = new Buffer([REGISTER_B, blue]);
@@ -120,7 +119,6 @@ function changeRGB(red, green, blue) {
 }
 
 function writeWord() {
-    clear();
     var wordBuffer = new Buffer(7);
         // The first byte in the buffer is for the register address,
         // which is where the word is going to be written to.
@@ -137,7 +135,11 @@ function writeWord() {
 
     hello = !hello;
     resetCursor();
-    i2cDevice.write(GROVE_LCD_DISPLAY_ADDR, wordBuffer);
+    var reply = i2cDevice.write(GROVE_LCD_DISPLAY_ADDR, wordBuffer);
+    while (reply !== 0) {
+        console.log("I2C write failed, trying again: " + reply);
+        reply = i2cDevice.write(GROVE_LCD_DISPLAY_ADDR, wordBuffer);
+    }
 }
 
 // Main function
@@ -145,4 +147,4 @@ function writeWord() {
 init();
 
 // Alternate writing HELLO! and WORLD! forever
-setInterval(writeWord, 2000);
+setInterval(writeWord, 1000);

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -178,7 +178,11 @@ fi
 if check_for_require i2c || check_config_file ZJS_I2C; then
     >&2 echo Using module: I2C
     MODULES+=" -DBUILD_MODULE_I2C"
-    echo "CONFIG_I2C=y" >> arc/prj.conf.tmp
+    if [ $BOARD = "arduino_101" ]; then
+        echo "CONFIG_I2C=y" >> arc/prj.conf.tmp
+    else
+        echo "CONFIG_I2C=y" >> prj.conf.tmp
+    fi
     echo "export ZJS_I2C=y" >> zjs.conf.tmp
     buffer=true;
 fi

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -61,8 +61,10 @@ endif
 ifneq ($(BOARD), frdm_k64f)
 	obj-$(ZJS_AIO) += zjs_aio.o
 	obj-$(ZJS_GROVE_LCD) += zjs_grove_lcd.o
-	obj-$(ZJS_I2C) += zjs_i2c.o
+	obj-$(ZJS_I2C) += zjs_i2c_ipm.o
 	obj-$(ZJS_SENSOR) += zjs_sensor.o
+else
+	obj-$(ZJS_I2C) += zjs_i2c.o
 endif
 
 obj-$(CONFIG_BOARD_ARDUINO_101) += \

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -58,7 +58,7 @@ obj-y += zjs_script_gen.o
 endif
 
 # skip for now for frdm_k64f
-ifneq ($(BOARD), frdm_k64f)
+ifeq ($(BOARD), arduino_101)
 	obj-$(ZJS_AIO) += zjs_aio.o
 	obj-$(ZJS_GROVE_LCD) += zjs_grove_lcd.o
 	obj-$(ZJS_I2C) += zjs_i2c_ipm.o

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -273,6 +273,7 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
         if (reply < 0) {
             ZJS_PRINT("I2C bus %s configure failed with error : %i\n", i2c_bus, reply);
         }
+
     } else {
         ZJS_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", (uint8_t)bus);
     }

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -13,6 +13,8 @@
 #define ZJS_I2C_TIMEOUT_TICKS 500
 
 static struct k_sem i2c_sem;
+static jerry_value_t zjs_i2c_prototype;
+
 static struct device *i2c_device[MAX_I2C_BUS];
 
 static jerry_value_t zjs_i2c_read_base(const jerry_value_t this,
@@ -190,12 +192,12 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
     } else {
         return zjs_error("zjs_i2c_write:  missing data buffer");
     }
-
+    int reply;
     uint32_t address = (uint32_t)jerry_get_number_value(argv[0]);
 
     if (bus < MAX_I2C_BUS && i2c_device[bus]) {
         // Write has to come after an Open I2C message
-        int reply = i2c_write(i2c_device[bus],
+        reply = i2c_write(i2c_device[bus],
                               dataBuf->buffer,
                               dataBuf->bufsize,
                               (uint16_t)address);
@@ -207,8 +209,8 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
     else {
         ZJS_PRINT("no I2C device is ready yet\n");
     }
-
-    return ZJS_UNDEFINED;
+    return (jerry_value_t)reply;
+    //return ZJS_UNDEFINED;
 }
 
 static jerry_value_t zjs_i2c_abort(const jerry_value_t function_obj,

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -209,8 +209,9 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
     else {
         ZJS_PRINT("no I2C device is ready yet\n");
     }
-    return (jerry_value_t)reply;
-    //return ZJS_UNDEFINED;
+
+    return jerry_create_number(reply);
+
 }
 
 static jerry_value_t zjs_i2c_abort(const jerry_value_t function_obj,
@@ -257,7 +258,7 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
         return zjs_error("zjs_i2c_open: missing required field (speed)");
     }
 
-    if (bus < MAX_I2C_BUS && i2c_device[bus]) {
+    if (bus < MAX_I2C_BUS) {
         char i2c_bus[6];
         snprintf(i2c_bus, 6, "I2C_%i", (uint8_t)bus);
         i2c_device[bus] = device_get_binding(i2c_bus);

--- a/src/zjs_i2c_ipm.c
+++ b/src/zjs_i2c_ipm.c
@@ -1,4 +1,9 @@
 // Copyright (c) 2016, Intel Corporation.
+
+// This is the implementation of I2C used by boards
+// with a ARC core, which requires IPM messages
+// to access certain pins from the X86 core.
+
 #ifndef QEMU_BUILD
 // Zephyr includes
 #include <i2c.h>

--- a/src/zjs_i2c_ipm.c
+++ b/src/zjs_i2c_ipm.c
@@ -236,7 +236,7 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
         return zjs_error("zjs_i2c_write: ipm message failed or timed out!");
     }
 
-    return ZJS_UNDEFINED;
+    return jerry_create_number(reply.error_code);
 }
 
 static jerry_value_t zjs_i2c_abort(const jerry_value_t function_obj,


### PR DESCRIPTION
This is the code to add I2C support for non-ARC boards such as the
FRDM-K64.
