### PR TITLE
[makefile] Explicitly remove libjerry-core.a on "make clean".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ endif
 clean: update
 	@if [ -d $(ZEPHYR_SDK_INSTALL_DIR) ]; then \
 		rm -rf $(JERRY_BASE)/build/$(BOARD)/; \
+		rm -f outdir/$(BOARD)/libjerry-core.a; \
 		make -f Makefile.zephyr clean BOARD=$(BOARD); \
 		cd arc/; make clean; \
 	fi


### PR DESCRIPTION
We put it there in "jerryscript" target, so there's nobody else but us
to remove it from there.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>