### PR TITLE
[BLE] Fixed auto notification subscription upon connect

### DIFF
--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -493,7 +493,7 @@ static void zjs_ble_blvl_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16
             zjs_signal_callback(base_chrc->unsubscribe_cb.id, NULL, 0);
         }
     } else {
-        ERR_PRINT("zjs_ble_blvl_ccc_cfg_changed: base characterstic not found\n");
+        ERR_PRINT("base characterstic not found\n");
     }
 }
 


### PR DESCRIPTION
Currently update notification is sent immediately after a client
connects, this patch will now monitor subscribe/unsubscribe
events from client, fixes bug#349

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>