### PR TITLE
[GPIO] Don't assume that GPIO_0, etc. exist.

### DIFF
--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -450,8 +450,7 @@ jerry_value_t zjs_gpio_init()
         snprintf(devname, 8, "GPIO_%d", i);
         zjs_gpio_dev[i] = device_get_binding(devname);
         if (!zjs_gpio_dev[i]) {
-            ERR_PRINT("DEVICE: %s\n", devname);
-            return zjs_error("zjs_gpio_init: cannot find GPIO device");
+            ERR_PRINT("zjs_gpio_init: cannot find GPIO device '%s'\n", devname);
         }
     }
 


### PR DESCRIPTION
Previously, it was a fatal error if GPIO_0 device didn't exist. Now,
print a (warning) message, but continue. This change allows to run
Zephyr.js on other boards than just arduino_101 and frdm_k64f.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>