### PR TITLE
[checkheaders] Update script to overlook false positives

### DIFF
--- a/scripts/checkheaders
+++ b/scripts/checkheaders
@@ -16,18 +16,46 @@ echo "}"            >> $TEMPLATE
 
 SOURCE=/tmp/zjs_source.c
 
-ERRCOUNT=0
+PASSCOUNT=0
+TOTAL=0
 
+CFLAGS="-o /tmp/zjs_source -m32 -DCONFIG_X86 -DCONFIG_NUM_COOP_PRIORITIES=2 -I. -I../deps/jerryscript/jerry-core -I../deps/zephyr/include -I../deps/iotivity-constrained/include -I../deps/iotivity-constrained"
+FAILURES=
+
+# collect list of files with failures on first pass
 for i in *.h; do
-    echo Checking $i...
     echo "#include \"$i\"" > $SOURCE
     cat $TEMPLATE >> $SOURCE
-    gcc -o /tmp/zjs_source -m32 -DCONFIG_X86 -I. -I../deps/jerryscript/jerry-core -I../deps/zephyr/include $SOURCE
-    ERRCOUNT=$(($ERRCOUNT + $?))
+    gcc $CFLAGS $SOURCE > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        PASSCOUNT=$(($PASSCOUNT + 1))
+    else
+        FAILURES="$FAILURES $i"
+    fi
+    TOTAL=$(($TOTAL + 1))
 done
 
-if [ $ERRCOUNT -eq "0" ]; then
-   echo Passed!
-else
-   echo Failed!
+echo Failures detected in $FAILURES
+echo Use checkheaders -v to see details
+
+if [ "$1" == "-v" ] && [ $PASSCOUNT -ne $TOTAL ]; then
+    # print failure output on second pass
+    for i in $FAILURES; do
+        STR="Failures in $i"
+        LEN=$((${#STR} + 2))
+        printf "%${LEN}s\n" | tr ' ' '='
+        echo " $STR"
+        printf "%${LEN}s\n" | tr ' ' '='
+        echo "#include \"$i\"" > $SOURCE
+        cat $TEMPLATE >> $SOURCE
+        gcc $CFLAGS $SOURCE
+    done
 fi
+
+echo RESULTS: $PASSCOUNT/$TOTAL passed
+
+if [ $PASSCOUNT -ne $TOTAL ]; then
+    exit 1
+fi
+
+exit 0

--- a/src/zjs_uart.h
+++ b/src/zjs_uart.h
@@ -3,6 +3,8 @@
 #ifndef SRC_ZJS_UART_H_
 #define SRC_ZJS_UART_H_
 
+#include "jerry-api.h"
+
 /** Initialize the uart module, or reinitialize after cleanup */
  jerry_value_t zjs_uart_init();
 


### PR DESCRIPTION
Also, hide details unless -v is specified to summarize more easily
spot where the problems lie, and whether you care to look into them.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>