### PR TITLE
[trlite] Preserve cached (staged) changes in trlite builds

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -69,8 +69,8 @@ done
 
 echo Preserving uncommitted changes:
 cd $ZJS_BASE
-git diff --stat
-git diff > $TRLPATCH
+git diff --cached --stat
+git diff --cached > $TRLPATCH
 cd $TRLDIR
 patch -p1 < patch > /dev/null
 


### PR DESCRIPTION
Changes that you have already staged with git-add were not being applied
to the trlite clone of the repo, so you would get unexpected results
running trlite in that state.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>