### PR TITLE
Changed UART docs to reflect proper usage

### DIFF
--- a/docs/uart.md
+++ b/docs/uart.md
@@ -53,7 +53,7 @@ API Documentation
 `void init(UARTOptions options);`
 
 The `options` object lets you choose the UART device/port you would like to
-initialize. This can either be "tty0" or "tty1".
+initialize. The Arduino 101, for example, should be "tty0".
 
 ### UART.write
 


### PR DESCRIPTION
 - Documentation said that UART could use tty1, which was not true
   and would cause an error to be thrown. The error will still be
   thrown, but the docs now only mention tty0.

Signed-off-by: James Prestwood <james.prestwood@intel.com>