### PR TITLE
[general] Added exit features to linux target

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -420,8 +420,9 @@ void zjs_call_callback(zjs_callback_id id, void* data, uint32_t sz)
     }
 }
 
-void zjs_service_callbacks(void)
+uint8_t zjs_service_callbacks(void)
 {
+    uint8_t serviced = 0;
     if (ring_buf_initialized) {
 #ifdef ZJS_PRINT_CALLBACK_STATS
         uint8_t header_printed = 0;
@@ -440,6 +441,7 @@ void zjs_service_callbacks(void)
                                         NULL,
                                         &size);
             if (ret == -EMSGSIZE || ret == 0) {
+                serviced = 1;
                 // item in ring buffer with size > 0, has args
                 // pull from ring buffer
                 uint8_t sz = size;
@@ -487,4 +489,5 @@ void zjs_service_callbacks(void)
         }
 #endif
     }
+    return serviced;
 }

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -187,7 +187,10 @@ void zjs_call_callback(zjs_callback_id id, void* data, uint32_t sz);
 /*
  * Service the callback module. Any callback's that have been signaled will
  * be serviced and the signal flag will be unset.
+ *
+ * @return              1 if any callbacks were processed
+ *                      0 if no callbacks were processed
  */
-void zjs_service_callbacks(void);
+uint8_t zjs_service_callbacks(void);
 
 #endif /* SRC_ZJS_CALLBACKS_H_ */

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -214,10 +214,14 @@ void zjs_register_service_routine(void* handle, zjs_service_routine func)
     return;
 }
 
-void zjs_service_routines(void)
+uint8_t zjs_service_routines(void)
 {
+    uint8_t serviced = 0;
     int i;
     for (i = 0; i < num_routines; ++i) {
-        svc_routine_map[i].func(svc_routine_map[i].handle);
+        if (svc_routine_map[i].func(svc_routine_map[i].handle)) {
+            serviced = 1;
+        }
     }
+    return serviced;
 }

--- a/src/zjs_modules.h
+++ b/src/zjs_modules.h
@@ -11,11 +11,23 @@
 
 #define NUM_SERVICE_ROUTINES 3
 
-typedef void (*zjs_service_routine)(void* handle);
+/*
+ * Service routine function type
+ *
+ * @param handle        Handle that was registered
+ *
+ * @return              1 if the routine did any processing
+ *                      0 if the routine did not process anything
+ *
+ * Note: The return value is only used for the auto-exit Linux feature. If
+ *       0 is returned (and there are no timers or callbacks) AND auto-exit
+ *       is enabled, it will cause the program to exit.
+ */
+typedef uint8_t (*zjs_service_routine)(void* handle);
 
 void zjs_modules_init();
 void zjs_modules_cleanup();
 void zjs_register_service_routine(void* handle, zjs_service_routine func);
-void zjs_service_routines(void);
+uint8_t zjs_service_routines(void);
 
 #endif  // __zjs_modules_h__

--- a/src/zjs_modules.h
+++ b/src/zjs_modules.h
@@ -11,7 +11,7 @@
 
 #define NUM_SERVICE_ROUTINES 3
 
-/*
+/**
  * Service routine function type
  *
  * @param handle        Handle that was registered

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -203,9 +203,12 @@ static void app_init(void)
     oc_add_device("/oic/d", "oic.d.zephyrjs", "Zephyr.js Device", "1.0", "1.0", NULL, NULL);
 }
 
-void main_poll_routine(void* handle)
+uint8_t main_poll_routine(void* handle)
 {
-    oc_main_poll();
+    if (oc_main_poll()) {
+        return 1;
+    }
+    return 0;
 }
 
 static const oc_handler_t handler = { .init = app_init,

--- a/src/zjs_ocf_common.h
+++ b/src/zjs_ocf_common.h
@@ -66,7 +66,7 @@ void* zjs_ocf_props_setup(jerry_value_t props_object,
  */
 void zjs_ocf_free_props(void* h);
 
-/*
+/**
  * Routine to call into iotivity-constrained
  *
  * @return              iotivity-constrained's polling functions return value

--- a/src/zjs_ocf_common.h
+++ b/src/zjs_ocf_common.h
@@ -68,8 +68,10 @@ void zjs_ocf_free_props(void* h);
 
 /*
  * Routine to call into iotivity-constrained
+ *
+ * @return              iotivity-constrained's polling functions return value
  */
-void main_poll_routine(void* handle);
+uint8_t main_poll_routine(void* handle);
 
 /*
  * Object returned from require('ocf')

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -200,8 +200,9 @@ static jerry_value_t native_clear_interval_handler(const jerry_value_t function_
     return jerry_create_undefined();
 }
 
-void zjs_timers_process_events()
+uint8_t zjs_timers_process_events()
 {
+    uint8_t serviced = 0;
 #ifdef DEBUG_BUILD
 #ifndef ZJS_LINUX_BUILD
     extern void update_print_timer(void);
@@ -209,6 +210,7 @@ void zjs_timers_process_events()
 #endif
 #endif
     for (zjs_timer_t *tm = zjs_timers; tm; tm = tm->next) {
+        serviced = 1;
         if (tm->completed) {
             delete_timer(tm->callback_id);
         }
@@ -227,6 +229,7 @@ void zjs_timers_process_events()
             }
         }
     }
+    return serviced;
 }
 
 void zjs_timers_init()

--- a/src/zjs_timers.h
+++ b/src/zjs_timers.h
@@ -3,7 +3,13 @@
 #ifndef __zjs_timers_h__
 #define __zjs_timers_h__
 
-void zjs_timers_process_events();
+/*
+ * Service the timer module.
+ *
+ * @return          1 if any timers were serviced
+ *                  0 if no timers were serviced
+ */
+uint8_t zjs_timers_process_events();
 void zjs_timers_init();
 // Stops and frees all timers
 void zjs_timers_cleanup();

--- a/src/zjs_timers.h
+++ b/src/zjs_timers.h
@@ -3,7 +3,7 @@
 #ifndef __zjs_timers_h__
 #define __zjs_timers_h__
 
-/*
+/**
  * Service the timer module.
  *
  * @return          1 if any timers were serviced


### PR DESCRIPTION
 - Passing in "--autoexit" will cause jslinux to terminate if no
   callbacks or timers were processed on the current or previous
   main loop.

 - Passing in "-t <time>" will cause jslinux to terminate after
   <time> milliseconds>.

 - Both new flags can be used at the same time if desired.

Signed-off-by: James Prestwood <james.prestwood@intel.com>