### PR TITLE
[Sensor] Updated BMI160 configs

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -230,16 +230,16 @@ if [ $? -eq 0 ] || check_config_file ZJS_SENSOR; then
         bmi160=$(grep -E Accelerometer\|Gyroscope $SCRIPT)
         if [ $? -eq 0 ]; then
             MODULES+=" -DBUILD_MODULE_SENSOR_TRIGGER"
-            echo "CONFIG_SENSOR=y" >> arc/prj.conf.tmp
             echo "CONFIG_GPIO=y" >> prj.conf.tmp
             echo "CONFIG_GPIO_QMSI=y" >> prj.conf.tmp
             echo "CONFIG_GPIO_QMSI_0_PRI=2" >> prj.conf.tmp
             echo "CONFIG_GPIO_QMSI_1=y" >> prj.conf.tmp
             echo "CONFIG_GPIO_QMSI_1_NAME=\"GPIO_1\"" >> prj.conf.tmp
             echo "CONFIG_GPIO_QMSI_1_PRI=2" >> prj.conf.tmp
+            echo "CONFIG_SENSOR=y" >> arc/prj.conf.tmp
+            echo "CONFIG_GPIO=y" >> arc/prj.conf.tmp
             echo "CONFIG_SPI=y" >> arc/prj.conf.tmp
             echo "CONFIG_BMI160=y" >> arc/prj.conf.tmp
-            echo "CONFIG_BMI160_INIT_PRIORITY=80" >> arc/prj.conf.tmp
             echo "CONFIG_BMI160_NAME=\"bmi160\"" >> arc/prj.conf.tmp
             echo "CONFIG_BMI160_SPI_PORT_NAME=\"SPI_1\"" >> arc/prj.conf.tmp
             echo "CONFIG_BMI160_SLAVE=1" >> arc/prj.conf.tmp


### PR DESCRIPTION
This will fix the error flooding Accelerometer events in
bug #504, although it doesn't fix the bug where Accelerometer
will report 0 on all axis, that's a separate bug.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>