### PR TITLE
[bugfix] I2C will now throw an error if bus fails to open

### DIFF
--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -30,7 +30,7 @@
 #define ADC_DEVICE_NAME "ADC_0"
 #define ADC_BUFFER_SIZE 2
 
-#define MAX_I2C_BUS 1
+#define MAX_I2C_BUS 2
 
 #define MAX_BUFFER_SIZE 256
 
@@ -261,7 +261,7 @@ static void handle_i2c(struct zjs_ipm_message* msg)
                 }
             }
         } else {
-            ZJS_PRINT("I2C bus I2C_%s is not a valid I2C bus.\n", msg_bus);
+            ZJS_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
             error_code = ERROR_IPM_OPERATION_FAILED;
         }
         break;

--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -261,7 +261,7 @@ static void handle_i2c(struct zjs_ipm_message* msg)
                 }
             }
         } else {
-            ZJS_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
+            ERR_PRINT("I2C bus %i is not a valid I2C bus\n", msg_bus);
             error_code = ERROR_IPM_OPERATION_FAILED;
         }
         break;

--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -263,7 +263,6 @@ static void handle_i2c(struct zjs_ipm_message* msg)
                 }
             }
         } else {
-
             ERR_PRINT("I2C bus %i is not a valid I2C bus\n", msg_bus);
             error_code = ERROR_IPM_OPERATION_FAILED;
         }

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -278,11 +278,12 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
         int reply = i2c_configure(i2c_device[bus], cfg.raw);
 
         if (reply < 0) {
-            ZJS_PRINT("I2C bus %s configure failed with error : %i\n", i2c_bus, reply);
+            ERR_PRINT("I2C bus %s configure failed with error: %i\n", i2c_bus,
+                      reply);
         }
 
     } else {
-        ZJS_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", (uint8_t)bus);
+        ERR_PRINT("I2C bus %i is not a valid I2C bus\n", (uint8_t)bus);
         return zjs_error("I2C bus not found");
     }
 

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -263,6 +263,10 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
         snprintf(i2c_bus, 6, "I2C_%i", (uint8_t)bus);
         i2c_device[bus] = device_get_binding(i2c_bus);
 
+        if (!i2c_device[bus]) {
+            return zjs_error("I2C bus not found");
+        }
+
         /* TODO remove these hard coded numbers
          * once the config API is made */
         union dev_config cfg;
@@ -279,6 +283,7 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
 
     } else {
         ZJS_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", (uint8_t)bus);
+        return zjs_error("I2C bus not found");
     }
 
     // create the I2C object

--- a/src/zjs_i2c.h
+++ b/src/zjs_i2c.h
@@ -7,7 +7,7 @@
 
 #define I2C_0 0
 #define I2C_1 1
-#define MAX_I2C_BUS 1
+#define MAX_I2C_BUS 2
 
 /**
  * Initialize the i2c module, or reinitialize after cleanup

--- a/src/zjs_i2c_ipm.c
+++ b/src/zjs_i2c_ipm.c
@@ -198,10 +198,12 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
 
     uint32_t register_addr = 0;
 
-    if (argc >= 3 && !jerry_value_is_number(argv[2])) {
-        return zjs_error("zjs_i2c_read: register is not a number");
-    } else {
-        register_addr = (uint32_t)jerry_get_number_value(argv[2]);
+    if (argc >= 3) {
+        if (!jerry_value_is_number(argv[2])) {
+            return zjs_error("zjs_i2c_read: register is not a number");
+        } else {
+            register_addr = (uint32_t)jerry_get_number_value(argv[2]);
+        }
     }
 
     uint32_t bus;

--- a/src/zjs_i2c_ipm.c
+++ b/src/zjs_i2c_ipm.c
@@ -294,20 +294,24 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
     bool success = zjs_i2c_ipm_send_sync(&send, &reply);
 
     if (!success) {
-        return zjs_error("zjs_i2c_write: ipm message failed or timed out!");
+        return zjs_error("zjs_i2c_open: ipm message failed or timed out!");
     }
 
-    // create the I2C object
-    jerry_value_t i2c_obj = jerry_create_object();
-    zjs_obj_add_function(i2c_obj, zjs_i2c_read, "read");
-    zjs_obj_add_function(i2c_obj, zjs_i2c_burst_read, "burstRead");
-    zjs_obj_add_function(i2c_obj, zjs_i2c_write, "write");
-    zjs_obj_add_function(i2c_obj, zjs_i2c_abort, "abort");
-    zjs_obj_add_function(i2c_obj, zjs_i2c_close, "close");
-    zjs_obj_add_number(i2c_obj, bus, "bus");
-    zjs_obj_add_number(i2c_obj, speed, "speed");
-
-    return i2c_obj;
+    if (reply.error_code == 0) {
+        // create the I2C object
+        jerry_value_t i2c_obj = jerry_create_object();
+        zjs_obj_add_function(i2c_obj, zjs_i2c_read, "read");
+        zjs_obj_add_function(i2c_obj, zjs_i2c_burst_read, "burstRead");
+        zjs_obj_add_function(i2c_obj, zjs_i2c_write, "write");
+        zjs_obj_add_function(i2c_obj, zjs_i2c_abort, "abort");
+        zjs_obj_add_function(i2c_obj, zjs_i2c_close, "close");
+        zjs_obj_add_number(i2c_obj, bus, "bus");
+        zjs_obj_add_number(i2c_obj, speed, "speed");
+        return i2c_obj;
+    }
+    else {
+        return zjs_error("zjs_i2c_open: Failed to open I2C bus");
+    }
 }
 
 jerry_value_t zjs_i2c_init()


### PR DESCRIPTION
This is a fix for issue #551, now an error will be thrown if the
I2C bus fails to open.