### PR TITLE
[bugfix] Extending the IPM timeout

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -11,7 +11,7 @@
 #include "zjs_ipm.h"
 #include "zjs_util.h"
 
-#define ZJS_AIO_TIMEOUT_TICKS                      500
+#define ZJS_AIO_TIMEOUT_TICKS                      5000
 
 static struct k_sem aio_sem;
 static jerry_value_t zjs_aio_prototype;

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -26,7 +26,7 @@
 #define ZJS_BLE_RESULT_INVALID_ATTRIBUTE_LENGTH     BT_ATT_ERR_INVALID_ATTRIBUTE_LEN
 #define ZJS_BLE_RESULT_UNLIKELY_ERROR               BT_ATT_ERR_UNLIKELY
 
-#define ZJS_BLE_TIMEOUT_TICKS                       500
+#define ZJS_BLE_TIMEOUT_TICKS                       5000
 
 static struct k_sem ble_sem;
 

--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -14,7 +14,6 @@
 #include "zjs_grove_lcd.h"
 #include "zjs_util.h"
 
-#define ZJS_GLCD_TIMEOUT_TICKS 500
 #define MAX_BUFFER_SIZE 256
 
 static struct device *glcd = NULL;

--- a/src/zjs_grove_lcd_ipm.c
+++ b/src/zjs_grove_lcd_ipm.c
@@ -15,7 +15,7 @@
 #include "zjs_ipm.h"
 #include "zjs_util.h"
 
-#define ZJS_GLCD_TIMEOUT_TICKS 500
+#define ZJS_GLCD_TIMEOUT_TICKS 5000
 
 static struct k_sem glcd_sem;
 

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -10,8 +10,6 @@
 #include "zjs_util.h"
 #include "zjs_buffer.h"
 
-#define ZJS_I2C_TIMEOUT_TICKS 500
-
 static struct k_sem i2c_sem;
 static jerry_value_t zjs_i2c_prototype;
 

--- a/src/zjs_i2c_ipm.c
+++ b/src/zjs_i2c_ipm.c
@@ -15,7 +15,7 @@
 #include "zjs_util.h"
 #include "zjs_buffer.h"
 
-#define ZJS_I2C_TIMEOUT_TICKS                      500
+#define ZJS_I2C_TIMEOUT_TICKS                      5000
 
 static struct k_sem i2c_sem;
 

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -27,7 +27,7 @@ struct device *trigger_ipm;
 struct gpio_callback cb;
 #endif
 
-#define ZJS_SENSOR_TIMEOUT_TICKS 500
+#define ZJS_SENSOR_TIMEOUT_TICKS 5000
 
 static struct k_sem sensor_sem;
 


### PR DESCRIPTION
Fix for issue #549.  This was caused by having too short of a IPM
timeout.  Extending the timeout solves the issue, allowing multiple
modules to be using IPM without issue.