### PR TITLE
[util] Add helper functions to reduce bugs with JrS strings

### DIFF
--- a/samples/tests/Console.js
+++ b/samples/tests/Console.js
@@ -18,11 +18,15 @@ console.error("  Objects:", {}, {foo: 'bar'});
 console.error("  Strings:", '', "", 'abc', "def");  // expect: "  abc def"
 console.error("     Misc:", null, undefined);
 
-console.log("\nTesting long string...");
-var toolong =
+console.log("\nTesting a long string...");
+var longstr =
     "123456789012345678901234567890123456789012345678901234567890" +
     "123456789012345678901234567890123456789012345678901234567890" +
     "123456789012345678901234567890123456789012345678901234567890" +
     "123456789012345678901234567890123456789012345678901234567890" +
-    "12345678901234567";  // length 257
-console.log(toolong);
+    "123456789012345";  // length 255
+console.log(longstr);
+
+console.log("\nTesting a string too long...");
+longstr += '6';  // length 256
+console.log(longstr);

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -110,6 +110,8 @@ if check_for_require ocf || check_config_file ZJS_OCF; then
     echo "CONFIG_IP_BUF_TX_SIZE=5" >> prj.conf.tmp
     echo "CONFIG_NET_MAX_CONTEXTS=9" >> prj.conf.tmp
     echo "export ZJS_OCF=y" >> zjs.conf.tmp
+    MODULES+=" -DBUILD_MODULE_EVENTS"
+    echo "export ZJS_EVENTS=y" >> zjs.conf.tmp
 fi
 
 if check_for_require gpio || check_config_file ZJS_GPIO; then

--- a/scripts/checkcopyrights
+++ b/scripts/checkcopyrights
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright (c) 2016, Intel Corporation.
+
+# This script makes sure that all the source files in src/ have a copyright
+# header on the first line.
+
+cd $ZJS_BASE/src
+
+SRCFILES=$(find . -name "*.[ch]")
+RVAL=0
+
+for file in $SRCFILES; do
+    if ! head -1 $file | grep -q Copyright; then
+        echo Missing copyright: $file
+        RVAL=1
+    fi
+done
+
+if [ $RVAL -eq 0 ]; then
+    echo All copyright headers found!
+fi
+
+exit $RVAL

--- a/src/ashell/comms-shell.c
+++ b/src/ashell/comms-shell.c
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 /**
  * @file

--- a/src/ashell/comms-shell.h
+++ b/src/ashell/comms-shell.h
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 #ifndef __comms_shell_h__
 #define __comms_shell_h__

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 /**
  * @file

--- a/src/ashell/comms-uart.h
+++ b/src/ashell/comms-uart.h
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 #ifndef __comms_uart_h__
 #define __comms_uart_h__

--- a/src/ashell/file-utils.c
+++ b/src/ashell/file-utils.c
@@ -1,18 +1,4 @@
-/*
-* Copyright 2015 Intel Corporation
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+// Copyright (c) 2016, Intel Corporation.
 
 /**
 * @file

--- a/src/ashell/file-utils.h
+++ b/src/ashell/file-utils.h
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 #ifndef __file_wrapper_h__
 #define __file_wrapper_h__

--- a/src/ashell/ihex-handler.c
+++ b/src/ashell/ihex-handler.c
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 /**
  * @file

--- a/src/ashell/ihex-handler.h
+++ b/src/ashell/ihex-handler.h
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 #ifndef __ihex_handler_h__
 #define __ihex_handler_h__

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 /**
  * @file

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -22,10 +22,11 @@
 /* Zephyr.js init everything */
 #include "../zjs_buffer.h"
 #include "../zjs_callbacks.h"
-#include "../zjs_modules.h"
 #include "../zjs_ipm.h"
+#include "../zjs_modules.h"
 #include "../zjs_sensor.h"
 #include "../zjs_timers.h"
+#include "../zjs_util.h"
 
 void jerry_port_default_set_log_level(jerry_log_level_t level); /** Inside jerry-port-default.h */
 
@@ -57,13 +58,15 @@ static void javascript_print_value(const jerry_value_t value)
     /* String value */
     else if (jerry_value_is_string(value)) {
         /* Determining required buffer size */
-        jerry_size_t req_sz = jerry_get_string_size(value);
-        jerry_char_t str_buf_p[req_sz];
-
-        jerry_string_to_char_buffer(value, str_buf_p, req_sz);
-        str_buf_p[req_sz] = '\0';
-
-        jerry_port_console("%s", (const char *)str_buf_p);
+        jerry_size_t size = 0;
+        char *str = zjs_alloc_from_jstring(value, &size);
+        if (str) {
+            jerry_port_console("%s", str);
+            zjs_free(str);
+        }
+        else {
+            jerry_port_console("[String too long]");
+        }
     }
     /* Object reference */
     else if (jerry_value_is_object(value)) {
@@ -80,20 +83,17 @@ static void javascript_print_error(jerry_value_t error_value)
 
     jerry_value_clear_error_flag(&error_value);
     jerry_value_t err_str_val = jerry_value_to_string(error_value);
-    jerry_size_t err_str_size = jerry_get_string_size(err_str_val);
-    jerry_char_t err_str_buf[256];
 
-    if (err_str_size >= 256) {
-        const char msg[] = "[Error message too long]";
-        err_str_size = sizeof(msg) / sizeof(char) - 1;
-        memcpy(err_str_buf, msg, err_str_size);
-    } else {
-        jerry_string_to_char_buffer(err_str_val, err_str_buf, err_str_size);
+    jerry_size_t size = 0;
+    char *msg = zjs_alloc_from_jstring(err_str_val, &size);
+    const char *err_str = msg;
+    if (!msg) {
+        err_str = "[Error message too long]";
     }
-    err_str_buf[err_str_size] = 0;
 
-    jerry_port_log(JERRY_LOG_LEVEL_ERROR, err_str_buf);
+    jerry_port_log(JERRY_LOG_LEVEL_ERROR, err_str);
     jerry_port_log(JERRY_LOG_LEVEL_ERROR, "\n");
+    zjs_free(msg);
     jerry_release_value(err_str_val);
 }
 

--- a/src/ashell/jerry-code.h
+++ b/src/ashell/jerry-code.h
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 #ifndef __jerry_code_runner_h__
 #define __jerry_code_runner_h__

--- a/src/ashell/main-zephyr.c
+++ b/src/ashell/main-zephyr.c
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 #include <zephyr.h>
 #include <string.h>

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 /**
  * @file

--- a/src/ashell/shell-state.h
+++ b/src/ashell/shell-state.h
@@ -1,18 +1,4 @@
-/*
- * Copyright 2015 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2016, Intel Corporation.
 
 #ifndef __SHELL__STATE__H__
 #define __SHELL__STATE__H__

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,7 @@ static jerry_value_t native_eval_handler(const jerry_value_t function_obj,
                                          const jerry_value_t argv[],
                                          const jerry_length_t argc)
 {
-    return zjs_error("native_eval_handler: eval not supported");
+    return zjs_error("eval not supported");
 }
 
 // native print handler
@@ -53,16 +53,16 @@ static jerry_value_t native_print_handler(const jerry_value_t function_obj,
                                           const jerry_value_t argv[],
                                           const jerry_length_t argc)
 {
-    jerry_size_t jlen = jerry_get_string_size(argv[0]);
-    if (jlen > ZJS_MAX_PRINT_SIZE) {
-        ERR_PRINT("maximum print string length exceeded\n");
-        return ZJS_UNDEFINED;
-    }
-    char buffer[jlen + 1];
-    int wlen = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)buffer, jlen);
-    buffer[wlen] = '\0';
+    if (argc < 1 || !jerry_value_is_string(argv[0]))
+        return zjs_error("print: missing string argument");
 
-    ZJS_PRINT("%s\n", buffer);
+    jerry_size_t size = 0;
+    char *str = zjs_alloc_from_jstring(argv[0], &size);
+    if (!str)
+        return zjs_error("print: out of memory");
+
+    ZJS_PRINT("%s\n", str);
+    zjs_free(str);
     return ZJS_UNDEFINED;
 }
 

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -13,10 +13,10 @@
 
 #define ZJS_AIO_TIMEOUT_TICKS                      5000
 
+const int MAX_TYPE_LEN = 20;
+
 static struct k_sem aio_sem;
 static jerry_value_t zjs_aio_prototype;
-
-#define MAX_TYPE_LEN 20
 
 typedef struct aio_handle {
     jerry_value_t pin_obj;
@@ -220,14 +220,9 @@ static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj,
     uint32_t pin;
     zjs_obj_get_uint32(this, "pin", &pin);
 
-    char event[MAX_TYPE_LEN];
-    jerry_value_t arg = argv[0];
-    jerry_size_t sz = jerry_get_string_size(arg);
-    if (sz >= MAX_TYPE_LEN)
-        return zjs_error("zjs_aio_pin_on: event string too long");
-    int len = jerry_string_to_char_buffer(arg, (jerry_char_t *)event, sz);
-    event[len] = '\0';
-
+    jerry_size_t size = MAX_TYPE_LEN;
+    char event[size];
+    zjs_copy_jstring(argv[0], event, &size);
     if (strcmp(event, "change"))
         return zjs_error("zjs_aio_pin_on: unsupported event type");
 

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -225,15 +225,13 @@ static jerry_value_t zjs_buffer_to_string(const jerry_value_t function_obj,
         return jerry_create_string((jerry_char_t *)"[Buffer Object]");
     }
 
-    const int maxlen = 16;
-    char encoding[maxlen];
-    jerry_size_t sz = jerry_get_string_size(argv[0]);
-    if (sz >= maxlen) {
+    const int MAX_ENCODING_LEN = 16;
+    jerry_size_t size = MAX_ENCODING_LEN;
+    char encoding[size];
+    zjs_copy_jstring(argv[0], encoding, &size);
+    if (!size) {
         return zjs_error("zjs_buffer_to_string: encoding argument too long");
     }
-    int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)encoding,
-                                          sz);
-    encoding[len] = '\0';
 
     if (strcmp(encoding, "ascii") == 0) {
         buf->buffer[buf->bufsize] = '\0';
@@ -281,9 +279,10 @@ static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_va
     // requires: string - what will be written to buf
     //           offset - where to start writing (Default: 0)
     //           length - how many bytes to write (Default: buf.length -offset)
-    //           encoding - the character encoding of string. Currently only supports
-    //           the default of utf8
-    // effects: writes string to buf at offset according to the character encoding in encoding.
+    //           encoding - the character encoding of string. Currently only
+    //             supports the default of utf8
+    //  effects: writes string to buf at offset according to the character
+    //             encoding in encoding.
 
     if (argc < 1 || !jerry_value_is_string(argv[0]) ||
         (argc > 1 && !jerry_value_is_number(argv[1])) ||
@@ -310,36 +309,38 @@ static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_va
         }
     }
 
-    uint32_t offset = 0;
-    jerry_value_t arg = argv[0];
-    jerry_size_t sz = jerry_get_string_size(arg);
+    jerry_size_t size = 0;
+    char *str = zjs_alloc_from_jstring(argv[0], &size);
+    if (!str) {
+        return zjs_error("zjs_buffer_write_string: string too long");
+    }
+
     zjs_buffer_t *buf = zjs_buffer_find(this);
-
-    if (sz > 4096) {
-        return zjs_error("zjs_buffer_write_string: string is too long for the buffer");
-    }
-
-    char str[sz];
-
     if (!buf) {
-        return zjs_error("zjs_buffer_write_string: buffer pointer not found");
+        zjs_free(str);
+        return zjs_error("zjs_buffer_write_string: buffer not found");
     }
 
+    uint32_t offset = 0;
     if (argc > 1)
         offset = (uint32_t)jerry_get_number_value(argv[1]);
 
     uint32_t length = buf->bufsize - offset;
-
     if (argc > 2)
         length = (uint32_t)jerry_get_number_value(argv[2]);
 
-    if (offset + length > buf->bufsize) {
-        return zjs_error("zjs_buffer_write_string: string + offset is larger than the buffer");
+    if (length > size) {
+        zjs_free(str);
+        return zjs_error("zjs_buffer_write_string: requested length larger than string");
     }
 
-    jerry_string_to_char_buffer(arg, str, sz);
+    if (offset + length > buf->bufsize) {
+        zjs_free(str);
+        return zjs_error("zjs_buffer_write_string: string + offset larger than buffer");
+    }
 
-    memcpy(&buf->buffer[offset], &str[0], length);
+    memcpy(buf->buffer + offset, str, length);
+    zjs_free(str);
 
     return jerry_create_number(length);
 }
@@ -407,8 +408,8 @@ static jerry_value_t zjs_buffer(const jerry_value_t function_obj,
         // If passed an array, allocate the memory and fill it with the array value
         jerry_value_t array = argv[0];
         uint32_t arr_size = jerry_get_array_length(array);
-        jerry_value_t new_buf_obj = zjs_buffer_create(arr_size);
-        zjs_buffer_t *buf = zjs_buffer_find(new_buf_obj);
+        jerry_value_t new_buf = zjs_buffer_create(arr_size);
+        zjs_buffer_t *buf = zjs_buffer_find(new_buf);
         jerry_value_t array_item;
 
         if (buf) {
@@ -425,21 +426,22 @@ static jerry_value_t zjs_buffer(const jerry_value_t function_obj,
                 }
             }
         }
-        return new_buf_obj;
+        return new_buf;
     } else {
-        // If passed a string, convert it into a char array and copy it to the buffer.
-        jerry_value_t arg = argv[0];
-        jerry_size_t sz = jerry_get_string_size(arg);
-        jerry_value_t new_buf_obj = zjs_buffer_create(sz);
-        zjs_buffer_t *buf = zjs_buffer_find(new_buf_obj);
-
-        if (buf) {
-            jerry_string_to_char_buffer(arg, (char*)buf->buffer, sz);
-        } else {
-            return zjs_error("zjs_buffer: unable to find string buffer");
+        // if passed string, convert to char array and copy to buffer
+        jerry_size_t size = 0;
+        char *str = zjs_alloc_from_jstring(argv[0], &size);
+        if (!str) {
+            return zjs_error("zjs_buffer: could not allocate string");
         }
 
-        return new_buf_obj;
+        jerry_value_t new_buf = zjs_buffer_create(size);
+        zjs_buffer_t *buf = zjs_buffer_find(new_buf);
+
+        memcpy(buf->buffer, str, size);
+        zjs_free(str);
+
+        return new_buf;
     }
 }
 

--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -92,16 +92,13 @@ static void print_value(const jerry_value_t value, FILE *out, bool deep,
         fprintf(out, "[Object]");
     }
     else if (jerry_value_is_string(value)) {
-        jerry_size_t jlen = jerry_get_string_size(value);
-        if (jlen > MAX_STR_LENGTH) {
-            fprintf(out, "[String - length %lu]", jlen);
+        jerry_size_t size = jerry_get_string_size(value);
+        if (size >= MAX_STR_LENGTH) {
+            fprintf(out, "[String - length %lu]", size);
         }
         else {
-            char buffer[jlen + 1];
-            int wlen = jerry_string_to_char_buffer(value,
-                                                   (jerry_char_t *)buffer,
-                                                   jlen);
-            buffer[wlen] = '\0';
+            char buffer[++size];
+            zjs_copy_jstring(value, buffer, &size);
             if (quotes) {
                 fprintf(out, "\"%s\"", buffer);
             }

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -83,30 +83,23 @@ static jerry_value_t add_listener(const jerry_value_t function_obj,
                                   const jerry_value_t argv[],
                                   const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0])) {
-        ERR_PRINT("first parameter must be event string\n");
-        return jerry_acquire_value(this);
+    jerry_value_t rval = jerry_acquire_value(this);
+    if (!jerry_value_is_string(argv[0]) ||
+        !jerry_value_is_function(argv[1])) {
+        ERR_PRINT("invalid argument");
+        return rval;
     }
-    if (!jerry_value_is_function(argv[1])) {
-        ERR_PRINT("second parameter must be a listener function\n");
-        return jerry_acquire_value(this);
-    }
-    int sz = jerry_get_string_size(argv[0]);
-    if (sz > ZJS_MAX_EVENT_NAME_SIZE) {
+
+    jerry_size_t size = ZJS_MAX_EVENT_NAME_SIZE;
+    char name[size];
+    zjs_copy_jstring(argv[0], name, &size);
+    if (!size) {
         ERR_PRINT("event name is too long\n");
-        return jerry_acquire_value(this);
+        return rval;
     }
-    char name[sz];
-    int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)name, sz);
-    if (len != sz) {
-        ERR_PRINT("size mismatch\n");
-        return jerry_acquire_value(this);
-    }
-    name[len] = '\0';
 
     zjs_add_event_listener(this, name, argv[1]);
-
-    return jerry_acquire_value(this);
+    return rval;
 }
 
 static jerry_value_t emit_event(const jerry_value_t function_obj,
@@ -118,14 +111,14 @@ static jerry_value_t emit_event(const jerry_value_t function_obj,
         ERR_PRINT("parameter is not a string\n");
         return jerry_create_boolean(false);
     }
-    int sz = jerry_get_string_size(argv[0]);
-    char event[sz];
-    int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
-    if (len != sz) {
-        ERR_PRINT("size mismatch\n");
-        return jerry_create_boolean(false);
+
+    jerry_size_t size = ZJS_MAX_EVENT_NAME_SIZE;
+    char event[size];
+    zjs_copy_jstring(argv[0], event, &size);
+    if (!size) {
+        ERR_PRINT("event name is too long\n");
+        return jerry_acquire_value(this);
     }
-    event[len] = '\0';
 
     return jerry_create_boolean(zjs_trigger_event(this,
                                                   event,
@@ -155,14 +148,14 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
         ERR_PRINT("event listener must be second parameter\n");
         return jerry_acquire_value(this);
     }
-    int sz = jerry_get_string_size(argv[0]);
-    char event[sz];
-    int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
-    if (len != sz) {
-        ERR_PRINT("size mismatch\n");
+
+    jerry_size_t size = ZJS_MAX_EVENT_NAME_SIZE;
+    char event[size];
+    zjs_copy_jstring(argv[0], event, &size);
+    if (!size) {
+        ERR_PRINT("event name is too long\n");
         return jerry_acquire_value(this);
     }
-    event[len] = '\0';
 
     // Event object to hold callback ID and eventually listener arguments
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
@@ -202,14 +195,14 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
         ERR_PRINT("event name must be first parameter\n");
         return jerry_acquire_value(this);
     }
-    int sz = jerry_get_string_size(argv[0]);
-    char event[sz];
-    int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
-    if (len != sz) {
-        ERR_PRINT("size mismatch\n");
+
+    jerry_size_t size = ZJS_MAX_EVENT_NAME_SIZE;
+    char event[size];
+    zjs_copy_jstring(argv[0], event, &size);
+    if (!size) {
+        ERR_PRINT("event name is too long\n");
         return jerry_acquire_value(this);
     }
-    event[len] = '\0';
 
     // Event object to hold callback ID and eventually listener arguments
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
@@ -334,14 +327,14 @@ static jerry_value_t get_listener_count(const jerry_value_t function_obj,
         ERR_PRINT("event name must be first parameter\n");
         return jerry_create_number(0);
     }
-    int sz = jerry_get_string_size(argv[0]);
-    char event[sz];
-    int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
-    if (len != sz) {
-        ERR_PRINT("size mismatch\n");
-        return jerry_create_number(0);
+
+    jerry_size_t size = ZJS_MAX_EVENT_NAME_SIZE;
+    char event[size];
+    zjs_copy_jstring(argv[0], event, &size);
+    if (!size) {
+        ERR_PRINT("event name is too long\n");
+        return jerry_acquire_value(this);
     }
-    event[len] = '\0';
 
     // Event object to hold callback ID and eventually listener arguments
     jerry_value_t event_obj = zjs_get_property(ev->map, event);
@@ -379,14 +372,14 @@ static jerry_value_t get_listeners(const jerry_value_t function_obj,
         ERR_PRINT("event name must be first parameter\n");
         return ZJS_UNDEFINED;
     }
-    int sz = jerry_get_string_size(argv[0]);
-    char event[sz];
-    int len = jerry_string_to_char_buffer(argv[0], (jerry_char_t *)event, sz);
-    if (len != sz) {
-        ERR_PRINT("size mismatch\n");
-        return ZJS_UNDEFINED;
+
+    jerry_size_t size = ZJS_MAX_EVENT_NAME_SIZE;
+    char event[size];
+    zjs_copy_jstring(argv[0], event, &size);
+    if (!size) {
+        ERR_PRINT("event name is too long\n");
+        return jerry_acquire_value(this);
     }
-    event[len] = '\0';
 
     // Event object to hold callback ID and eventually listener arguments
     jerry_value_t event_obj = zjs_get_property(ev->map, event);

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Intel Corporation.
+
 #include "zjs_event.h"
 #include "zjs_callbacks.h"
 

--- a/src/zjs_event.h
+++ b/src/zjs_event.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Intel Corporation.
+
 #ifndef __zjs_event_h__
 #define __zjs_event_h__
 

--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -17,7 +17,6 @@
 #define MAX_BUFFER_SIZE 256
 
 static struct device *glcd = NULL;
-static char str[MAX_BUFFER_SIZE];
 
 static jerry_value_t zjs_glcd_prototype;
 
@@ -34,21 +33,14 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
         return zjs_error("Grove LCD device not found");
     }
 
-    jerry_size_t sz = jerry_get_string_size(argv[0]);
-
-    char *buffer = zjs_malloc(sz+1);
+    jerry_size_t size = MAX_BUFFER_SIZE;
+    char *buffer = zjs_alloc_from_jstring(argv[0], &size);
     if (!buffer) {
         return zjs_error("zjs_glcd_print: cannot allocate buffer");
     }
 
-    int len = jerry_string_to_char_buffer(argv[0],
-                                          (jerry_char_t *)buffer,
-                                          sz);
-    buffer[len] = '\0';
-
-    snprintf(str, MAX_BUFFER_SIZE, "%s", buffer);
-    glcd_print(glcd, str, strnlen(str, MAX_BUFFER_SIZE));
-    DBG_PRINT("Grove LCD print: %s\n", str);
+    glcd_print(glcd, buffer, size);
+    DBG_PRINT("Grove LCD print: %s\n", buffer);
     zjs_free(buffer);
 
     return ZJS_UNDEFINED;

--- a/src/zjs_grove_lcd_ipm.c
+++ b/src/zjs_grove_lcd_ipm.c
@@ -16,6 +16,7 @@
 #include "zjs_util.h"
 
 #define ZJS_GLCD_TIMEOUT_TICKS 5000
+#define MAX_BUFFER_SIZE 256
 
 static struct k_sem glcd_sem;
 
@@ -97,17 +98,11 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
         return zjs_error("zjs_glcd_print: invalid argument");
     }
 
-    jerry_size_t sz = jerry_get_string_size(argv[0]);
-
-    char *buffer = zjs_malloc(sz+1);
+    jerry_size_t size = MAX_BUFFER_SIZE;
+    char *buffer = zjs_alloc_from_jstring(argv[0], &size);
     if (!buffer) {
         return zjs_error("zjs_glcd_print: cannot allocate buffer");
     }
-
-    int len = jerry_string_to_char_buffer(argv[0],
-                                          (jerry_char_t *)buffer,
-                                          sz);
-    buffer[len] = '\0';
 
     // send IPM message to the ARC side
     zjs_ipm_message_t send;

--- a/src/zjs_linux_ring_buffer.c
+++ b/src/zjs_linux_ring_buffer.c
@@ -1,18 +1,4 @@
-/*
- * Copyright (c) 2015-2016 Intel Corporation
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright (c) 2015-2016, Intel Corporation.
 
 /*
  * This ring buffer implementation was taken from the Zephyr source and

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -114,19 +114,17 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
                                             const jerry_value_t argv[],
                                             const jerry_length_t argc)
 {
-    jerry_value_t arg = argv[0];
-    if (!jerry_value_is_string(arg)) {
+    if (!jerry_value_is_string(argv[0])) {
         return zjs_error("native_require_handler: invalid argument");
     }
 
-    const int maxlen = 32;
-    char module[maxlen];
-    jerry_size_t sz = jerry_get_string_size(arg);
-    if (sz >= maxlen) {
+    const int MAX_MODULE_LEN = 32;
+    jerry_size_t size = MAX_MODULE_LEN;
+    char module[size];
+    zjs_copy_jstring(argv[0], module, &size);
+    if (!size) {
         return zjs_error("native_require_handler: argument too long");
     }
-    int len = jerry_string_to_char_buffer(arg, (jerry_char_t *)module, sz);
-    module[len] = '\0';
 
     int modcount = sizeof(zjs_modules_array) / sizeof(module_t);
     for (int i = 0; i < modcount; i++) {
@@ -157,7 +155,7 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
 
     for (int i = 0; i < 4; i++) {
         // Strip the ".js"
-        module[len-i] = '\0';
+        module[size-i] = '\0';
     }
 
     jerry_value_t found_obj = zjs_get_property(exports_obj, module);

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Intel Corporation.
+
 #ifdef BUILD_MODULE_OCF
 
 #include "jerry-api.h"

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -488,9 +488,6 @@ static jerry_value_t ocf_find_resources(const jerry_value_t function_val,
 
     add_resource(device_id, resource_type, resource_path, this, listener);
 
-    //if (resource_type) {
-    //    zjs_free(resource_type);
-    //}
     if (device_id) {
         zjs_free(device_id);
     }
@@ -504,6 +501,10 @@ static jerry_value_t ocf_find_resources(const jerry_value_t function_val,
     zjs_make_promise(promise, post_ocf_promise, h);
 
     oc_do_ip_discovery(resource_type, &discovery, h);
+
+    if (resource_type) {
+        zjs_free(resource_type);
+    }
 
     return promise;
 }

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -291,7 +291,7 @@ static void add_resource(char* id, char* type, char* path, jerry_value_t client,
         memcpy(new->resource_type, type, strlen(type));
         new->resource_type[strlen(type)] = '\0';
     }
-    if (id) {
+    if (path) {
         new->resource_path = zjs_malloc(strlen(path) + 1);
         memcpy(new->resource_path, path, strlen(path));
         new->resource_path[strlen(path)] = '\0';
@@ -449,28 +449,22 @@ static jerry_value_t ocf_find_resources(const jerry_value_t function_val,
         jerry_value_t res_path_val = zjs_get_property(argv[0], "resourcePath");
 
         if (jerry_value_is_string(device_id_val)) {
-            int sz = jerry_get_string_size(device_id_val);
-            device_id = zjs_malloc(sz + 1);
-            int len = jerry_string_to_char_buffer(device_id_val, (jerry_char_t *)device_id, sz);
-            device_id[len] = '\0';
-
-            DBG_PRINT("deviceId: %s\n", device_id);
+            jerry_size_t size = OCF_MAX_DEVICE_ID_LEN;
+            device_id = zjs_alloc_from_jstring(device_id_val, &size);
+            if (device_id)
+                DBG_PRINT("deviceId: %s\n", device_id);
         }
         if (jerry_value_is_string(res_type_val)) {
-            int sz = jerry_get_string_size(res_type_val);
-            resource_type = zjs_malloc(sz + 1);
-            int len = jerry_string_to_char_buffer(res_type_val, (jerry_char_t *)resource_type, sz);
-            resource_type[len] = '\0';
-
-            DBG_PRINT("resourceType: %s\n", resource_type);
+            jerry_size_t size = OCF_MAX_RES_TYPE_LEN;
+            resource_type = zjs_alloc_from_jstring(res_type_val, &size);
+            if (resource_type)
+                DBG_PRINT("resourceType: %s\n", resource_type);
         }
         if (jerry_value_is_string(res_path_val)) {
-            int sz = jerry_get_string_size(res_path_val);
-            resource_path = zjs_malloc(sz + 1);
-            int len = jerry_string_to_char_buffer(res_path_val, (jerry_char_t *)resource_path, sz);
-            resource_path[len] = '\0';
-
-            DBG_PRINT("resourcePath: %s\n", resource_path);
+            jerry_size_t size = OCF_MAX_RES_PATH_LEN;
+            resource_path = zjs_alloc_from_jstring(res_path_val, &size);
+            if (resource_path)
+                DBG_PRINT("resourcePath: %s\n", resource_path);
         }
     }
 
@@ -557,7 +551,7 @@ static jerry_value_t ocf_retrieve(const jerry_value_t function_val,
         return promise;
     }
 
-    ZJS_GET_STRING(argv[0], device_id);
+    ZJS_GET_STRING(argv[0], device_id, OCF_MAX_DEVICE_ID_LEN + 1);
 
     struct client_resource* resource = find_resource_by_id(device_id);
     if (!resource) {
@@ -680,7 +674,7 @@ static jerry_value_t ocf_update(const jerry_value_t function_val,
     // Get device ID property from resource
     jerry_value_t device_id_val = zjs_get_property(argv[0], "deviceId");
 
-    ZJS_GET_STRING(device_id_val, device_id);
+    ZJS_GET_STRING(device_id_val, device_id, OCF_MAX_DEVICE_ID_LEN + 1);
 
     jerry_release_value(device_id_val);
 
@@ -761,7 +755,7 @@ static jerry_value_t ocf_delete(const jerry_value_t function_val,
         return promise;
     }
 
-    ZJS_GET_STRING(argv[0], uri);
+    ZJS_GET_STRING(argv[0], uri, OCF_MAX_URI_LEN);
 
     DBG_PRINT("DELETE call, uri=%s\n", uri);
 
@@ -866,7 +860,7 @@ static jerry_value_t ocf_get_platform_info(const jerry_value_t function_val,
         return promise;
     }
 
-    ZJS_GET_STRING(argv[0], device_id);
+    ZJS_GET_STRING(argv[0], device_id, OCF_MAX_DEVICE_ID_LEN + 1);
 
     struct client_resource* resource = find_resource_by_id(device_id);
     if (!resource) {
@@ -972,7 +966,7 @@ static jerry_value_t ocf_get_device_info(const jerry_value_t function_val,
         return promise;
     }
 
-    ZJS_GET_STRING(argv[0], device_id);
+    ZJS_GET_STRING(argv[0], device_id, OCF_MAX_DEVICE_ID_LEN + 1);
 
     struct client_resource* resource = find_resource_by_id(device_id);
     if (!resource) {

--- a/src/zjs_ocf_client.h
+++ b/src/zjs_ocf_client.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Intel Corporation.
+
 #ifndef __zjs_ocf_client__
 #define __zjs_ocf_client__
 

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -35,12 +35,12 @@ int zjs_ocf_is_int(jerry_value_t val) {
 }
 
 static bool ocf_foreach_prop(const jerry_value_t prop_name,
-                          const jerry_value_t prop_value,
-                          void *data)
+                             const jerry_value_t prop_value,
+                             void *data)
 {
     struct props_handle* handle = (struct props_handle*)data;
 
-    ZJS_GET_STRING(prop_name, name);
+    ZJS_GET_STRING(prop_name, name, OCF_MAX_PROP_NAME_LEN);
 
     // Skip id/resourcePath/resourceType because that is not a resource property that is sent out
     if ((strcmp(name, "deviceId") != 0) &&
@@ -131,7 +131,7 @@ void* zjs_ocf_props_setup(jerry_value_t props_object,
             zjs_rep_set_boolean(enc, h->names_array[i], boolean);
             DBG_PRINT("Encoding boolean: %d\n", boolean);
         } else if (jerry_value_is_string(prop)) {
-            ZJS_GET_STRING(prop, str);
+            ZJS_GET_STRING(prop, str, OCF_MAX_PROP_NAME_LEN);
             zjs_rep_set_text_string(enc, h->names_array[i], str);
             DBG_PRINT("Encoding string: %s\n", str);
         } else if (jerry_value_is_object(prop) && !jerry_value_is_array(prop)) {

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Intel Corporation.
+
 #ifdef BUILD_MODULE_OCF
 
 #include "jerry-api.h"

--- a/src/zjs_ocf_common.h
+++ b/src/zjs_ocf_common.h
@@ -2,10 +2,9 @@
 
 #include "jerry-api.h"
 
-#include "zjs_util.h"
 #include "zjs_common.h"
-
 #include "zjs_ocf_client.h"
+#include "zjs_util.h"
 
 #include "oc_api.h"
 #include <stdio.h>
@@ -24,12 +23,17 @@ struct props_handle {
 #define TYPE_IS_INT    1
 #define TYPE_IS_UINT   2
 
+#define OCF_MAX_DEVICE_ID_LEN 36
+#define OCF_MAX_RES_TYPE_LEN  16
+#define OCF_MAX_RES_PATH_LEN  64
+#define OCF_MAX_URI_LEN       64
+#define OCF_MAX_PROP_NAME_LEN 16
+
 // Helper to get the string from a jerry_value_t
-#define ZJS_GET_STRING(jval, name) \
-    int name##_sz = jerry_get_string_size(jval); \
-    char name[name##_sz]; \
-    int name##_len = jerry_string_to_char_buffer(jval, (jerry_char_t *)name, name##_sz); \
-    name[name##_len] = '\0';
+#define ZJS_GET_STRING(jval, name, maxlen)       \
+    jerry_size_t name##_size = maxlen; \
+    char name[name##_size]; \
+    zjs_copy_jstring(jval, name, &name##_size);
 
 #define REJECT(promise, err_name, err_msg, handler) \
     handler = new_ocf_handler(NULL); \

--- a/src/zjs_ocf_common.h
+++ b/src/zjs_ocf_common.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Intel Corporation.
+
 #include "jerry-api.h"
 
 #include "zjs_util.h"

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Intel Corporation.
+
 #ifdef BUILD_MODULE_OCF
 
 #include "oc_api.h"

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -411,7 +411,7 @@ static jerry_value_t ocf_register(const jerry_value_t function_val,
         REJECT(promise, "TypeMismatchError", "resourcePath not found", h);
         return promise;
     }
-    ZJS_GET_STRING(resource_path_val, resource_path);
+    ZJS_GET_STRING(resource_path_val, resource_path, OCF_MAX_RES_PATH_LEN);
 
     jerry_value_t res_type_array = zjs_get_property(argv[0], "resourceTypes");
     if (!jerry_value_is_array(res_type_array)) {
@@ -454,7 +454,7 @@ static jerry_value_t ocf_register(const jerry_value_t function_val,
 
     for (i = 0; i < num_types; ++i) {
         jerry_value_t type_val = jerry_get_property_by_index(res_type_array, i);
-        ZJS_GET_STRING(type_val, type_name);
+        ZJS_GET_STRING(type_val, type_name, OCF_MAX_RES_TYPE_LEN);
         oc_resource_bind_resource_type(resource->res, type_name);
     }
     oc_resource_bind_resource_interface(resource->res, OC_IF_RW);

--- a/src/zjs_ocf_server.h
+++ b/src/zjs_ocf_server.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Intel Corporation.
+
 #include "zjs_util.h"
 #include "zjs_common.h"
 

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -81,7 +81,7 @@ static zjs_timer_t* add_timer(uint32_t interval,
     zjs_timers = tm;
 
     DBG_PRINT("adding timer. id=%d, interval=%lu, repeat=%u, argv=%p, argc=%lu\n",
-            tm->callback_id, interval, repeat, argv, argc);
+              tm->callback_id, interval, repeat, argv, argc);
     zjs_port_timer_start(&tm->timer, interval);
     return tm;
 }

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -126,19 +126,16 @@ bool zjs_obj_get_string(jerry_value_t obj, const char *name, char *buffer,
     if (jerry_value_has_error_flag(value))
         return false;
 
-    if (!jerry_value_is_string(value))
-        return false;
-
-    jerry_size_t jlen = jerry_get_string_size(value);
-    if (jlen >= len)
-        return false;
-
-    int wlen = jerry_string_to_char_buffer(value, (jerry_char_t *)buffer, jlen);
-    buffer[wlen] = '\0';
+    bool rval = false;
+    if (jerry_value_is_string(value)) {
+        jerry_size_t size = len;
+        zjs_copy_jstring(value, buffer, &size);
+        if (size)
+            rval = true;
+    }
 
     jerry_release_value(value);
-
-    return true;
+    return rval;
 }
 
 bool zjs_obj_get_double(jerry_value_t obj, const char *name, double *num)
@@ -178,6 +175,41 @@ bool zjs_obj_get_int32(jerry_value_t obj, const char *name, int32_t *num)
     *num = (int32_t)jerry_get_number_value(value);
     jerry_release_value(value);
     return true;
+}
+
+void zjs_copy_jstring(jerry_value_t jstr, char *buffer, jerry_size_t *maxlen)
+{
+    jerry_size_t size = jerry_get_string_size(jstr);
+    jerry_size_t len = 0;
+    if (*maxlen > size)
+        len = jerry_string_to_char_buffer(jstr, (jerry_char_t *)buffer, size);
+    buffer[len] = '\0';
+}
+
+char *zjs_alloc_from_jstring(jerry_value_t jstr, jerry_size_t *maxlen)
+{
+    jerry_size_t size = jerry_get_string_size(jstr);
+    char *buffer = zjs_malloc(size + 1);
+    if (!buffer) {
+        ERR_PRINT("allocation failed (%lu bytes)\n", size + 1);
+        return NULL;
+    }
+
+    jerry_size_t len;
+    len = jerry_string_to_char_buffer(jstr, (jerry_char_t *)buffer, size);
+    buffer[len] = '\0';
+
+    if (maxlen) {
+        if (*maxlen && *maxlen < len) {
+            DBG_PRINT("string limited to %lu bytes\n", *maxlen);
+            buffer[*maxlen] = '\0';
+        }
+        else {
+            *maxlen = len;
+        }
+    }
+
+    return buffer;
 }
 
 bool zjs_hex_to_byte(char *buf, uint8_t *byte)

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -56,6 +56,37 @@ bool zjs_obj_get_double(jerry_value_t obj, const char *name, double *num);
 bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, uint32_t *num);
 bool zjs_obj_get_int32(jerry_value_t obj, const char *name, int32_t *num);
 
+/**
+ * Copy a JerryScript string into a supplied char * buffer.
+ *
+ * @param jstr    A JerryScript string value.
+ * @param buffer  A char * buffer with at least *maxlen bytes.
+ * @param maxlen  Pointer to a maximum size to be written to the buffer. If the
+ *                  string size with a null terminator would exceed *maxlen,
+ *                  only a null terminator will be written to the buffer and
+ *                  *maxlen will be set to 0. If the string is successfully
+ *                  copied, *maxlen will be set to the bytes copied (not
+ *                  counting the null terminator). If *maxlen is 0, behavior is
+ *                  undefined.
+ */
+void zjs_copy_jstring(jerry_value_t jstr, char *buffer, jerry_size_t *maxlen);
+
+/**
+ * Allocate a char * buffer on the heap and copy the JerryScript string to it.
+ *
+ * @param jstr    A JerryScript string value.
+ * @param maxlen  Pointer to a maximum size for the returned string. If NULL or
+ *                  pointing to 0, there is no limit to the string size
+ *                  returned. If not NULL, the actual length of the string will
+ *                  be written to *maxlen. If the call succeeds, the buffer
+ *                  returned will be truncated to the given maxlen with a null
+ *                  terminator. You can use zjs_copy_jstring if you'd rather
+ *                  fail than truncate on error.
+ * @return A new null-terminated string (which must be freed with zjs_free) or
+ *          NULL on failure.
+ */
+char *zjs_alloc_from_jstring(jerry_value_t jstr, jerry_size_t *maxlen);
+
 bool zjs_hex_to_byte(char *buf, uint8_t *byte);
 
 void zjs_default_convert_pin(uint32_t orig, int *dev, int *pin);


### PR DESCRIPTION
We have to be pretty careful with JerryScript strings to avoid using
too much stack space for a big string, make sure strings are null
terminated, etc. It makes sense to handle these issues in a single
place. This patch adds two new functions for copying JrS strings to
a buffer on the stack or allocating one on the heap (which must be
freed).