### PR TITLE
[travis] Disallow new calls to jerry_string_to_char_buffer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ env:
     - TARGET="linux"
     - TARGET="ashell"
 
-matrix:
-  allow_failures:
-    - env: TARGET="ashell"
-
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install make gcc g++ python3-ply ncurses-dev uglifyjs sysvbanner -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,16 @@ script: >
     banner "git check" &&
     git diff --check $(git rev-list HEAD | tail -1) &&
 
+    # ensure only two uses of jerry_string_to_char_buffer in zjs_util.c
+    banner jstring1 &&
+    CALLCOUNT=$(grep jerry_string_to_char_buffer src/zjs_util.c | wc -l) &&
+    if [ "$CALLCOUNT" != "2" ]; then exit 1; fi &&
+
+    # ensure no other source file uses jerry-string_to_char_buffer
+    banner jstring2 &&
+    SRCFILES=$(find src -name "*.[ch]" | grep -v zjs_util.c) &&
+    if grep jerry_string_to_char_buffer $SRCFILES; then exit 1; fi &&
+
     # run linux build test
     banner "linux" &&
     make V=1 linux &&

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -64,6 +64,15 @@ echo Cloning git submodules...
 cd $TRLDIR/deps
 for i in */; do
     git clone -l ../../deps/$i/.git $i > /dev/null 2>&1
+
+    # clone submodules of submodules
+    if [ -d $i/deps/ ]; then
+        cd $i/deps
+        for j in */; do
+            git clone -l ../../../../deps/$i/deps/$j/.git $j > /dev/null 2>&1
+        done
+        cd ../..
+    fi
 done
 
 echo Preserving uncommitted changes:
@@ -87,7 +96,7 @@ source deps/zephyr/zephyr-env.sh
 
 # requires: first arg is a <=10-char label, second arg is command
 #  effects: runs banner with label, then runs the command; if it fails, prints
-#             label on the command line before exiting
+#             label before exiting
 function try_command()
 {
     TESTNUM=$((TESTNUM + 1))
@@ -100,10 +109,31 @@ function try_command()
     shift
     banner "$LABEL"
     if ! $*; then
-        echo Error: Failed in $1!
-        exit $?
+        CODE=$?
+        echo Error: Failed in $LABEL!
+        exit $CODE
     fi
     echo Success: $LABEL
+}
+
+# requires: first arg is a <=10-char label, second arg is function to run
+#  effects: runs banner with label, then runs the function; if it fails, prints
+#             label before exiting
+function try_func()
+{
+    TESTNUM=$((TESTNUM + 1))
+    if [ "$TESTNUM" -lt "$START" ]; then
+        echo "Skipping test #$TESTNUM"
+        return
+    fi
+
+    banner $1
+    if ! $2; then
+        CODE=$?
+        echo Error: Failed in $1!
+        exit $CODE
+    fi
+    echo Success: $1
 }
 
 #
@@ -140,11 +170,40 @@ fi
 # Tests from VM #2
 #
 
+function check_jstring_util() {
+    CALLCOUNT=$(grep jerry_string_to_char_buffer src/zjs_util.c | wc -l)
+
+    # make sure there are exactly two calls to the function
+    if [ "$CALLCOUNT" != "2" ]; then
+        echo "Error: Expected two calls to jerry_string_to_char_buffer in zjs_util.c!"
+        echo "Use zjs_copy_jstring and zjs_alloc_from_jstring instead."
+        return 1;
+    fi
+}
+
+function check_jstring_others() {
+    SRCFILES=$(find src -name "*.[ch]" | grep -v zjs_util.c)
+
+    # make sure there are no other calls to the function
+    if grep jerry_string_to_char_buffer $SRCFILES; then
+        echo
+        echo "Error: Found calls to jerry_string_to_char_buffer outside zjs_util.c!"
+        echo "Use zjs_copy_jstring and zjs_alloc_from_jstring instead."
+        return 1;
+    fi
+}
+
 if [ "$VM2" == "y" ]; then
     TESTNUM=0
 
     # git check
     try_command "git check" git diff --check $(git rev-list HEAD | tail -1)
+
+    # ensure only two uses of jerry_string_to_char_buffer in zjs_util.c
+    try_func "jstring1" check_jstring_util
+
+    # ensure no other source file uses jerry-string_to_char_buffer
+    try_func "jstring2" check_jstring_others
 
     # linux build tests
     try_command "linux" make $VERBOSE linux

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -44,9 +44,10 @@ VM1=y
 VM2=y
 VM3=y
 
-if [ "$1" == "1" -o "$1" == "zephyr" ]; then VM2=n; VM3=n; shift; fi
-if [ "$1" == "2" -o "$1" == "linux" ]; then VM1=n; VM3=n; shift; fi
-if [ "$1" == "3" -o "$1" == "ashell" ]; then VM1=n; VM2=n; shift; fi
+if [ "$1" == "1" -o "$1" == "zephyr" ]; then VM2=n; VM3=n; fi
+if [ "$1" == "2" -o "$1" == "linux" ]; then VM1=n; VM3=n; fi
+if [ "$1" == "3" -o "$1" == "ashell" ]; then VM1=n; VM2=n; fi
+shift
 
 START=1
 if [[ "$1" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
This is to force people to use the new zjs_copy_jstring and
zjs_alloc_from_jstring. These calls require a maximum size to avoid
overflowing the stack or missing a null terminator.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>