### PR TITLE
[general] Remove unnecessary function names from error messages

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -58,7 +58,7 @@ static bool zjs_aio_ipm_send_async(uint32_t type, uint32_t pin, void *data) {
 
     int success = zjs_ipm_send(MSG_ID_AIO, &msg);
     if (success != 0) {
-        ERR_PRINT("zjs_aio_ipm_send: failed to send message\n");
+        ERR_PRINT("failed to send message\n");
         return false;
     }
 
@@ -73,7 +73,7 @@ static bool zjs_aio_ipm_send_sync(zjs_ipm_message_t* send,
     send->error_code = ERROR_IPM_NONE;
 
     if (zjs_ipm_send(MSG_ID_AIO, send) != 0) {
-        ERR_PRINT("zjs_aio_ipm_send_sync: failed to send message\n");
+        ERR_PRINT("failed to send message\n");
         return false;
     }
 
@@ -81,7 +81,7 @@ static bool zjs_aio_ipm_send_sync(zjs_ipm_message_t* send,
     // time out, if the ARC response comes back after it
     // times out, it could pollute the result on the stack
     if (k_sem_take(&aio_sem, ZJS_AIO_TIMEOUT_TICKS)) {
-        ERR_PRINT("zjs_aio_ipm_send_sync: FATAL ERROR, ipm timed out\n");
+        ERR_PRINT("FATAL ERROR, ipm timed out\n");
         return false;
     }
 
@@ -150,14 +150,14 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
             zjs_signal_callback(handle->callback_id, &ret_val, sizeof(jerry_value_t));
             break;
         case TYPE_AIO_PIN_SUBSCRIBE:
-            DBG_PRINT("ipm_msg_receive_callback: subscribed to events on pin %lu\n", pin);
+            DBG_PRINT("subscribed to events on pin %lu\n", pin);
             break;
         case TYPE_AIO_PIN_UNSUBSCRIBE:
-            DBG_PRINT("ipm_msg_receive_callback: unsubscribed to events on pin %lu\n", pin);
+            DBG_PRINT("unsubscribed to events on pin %lu\n", pin);
             break;
 
         default:
-            ERR_PRINT("ipm_msg_receive_callback: IPM message not handled %lu\n", msg->type);
+            ERR_PRINT("IPM message not handled %lu\n", msg->type);
         }
     }
 }

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -102,7 +102,7 @@ static struct bt_uuid *gatt_ccc_uuid = BT_UUID_DECLARE_16(BT_UUID_GATT_CCC_VAL);
 struct bt_uuid* zjs_ble_new_uuid_16(uint16_t value) {
     struct bt_uuid_16 *uuid = zjs_malloc(sizeof(struct bt_uuid_16));
     if (!uuid) {
-        ERR_PRINT("zjs_ble_new_uuid_16: out of memory allocating struct bt_uuid_16\n");
+        ERR_PRINT("out of memory allocating struct bt_uuid_16\n");
         return NULL;
     }
 
@@ -192,7 +192,7 @@ static jerry_value_t zjs_ble_read_callback_function(const jerry_value_t function
             chrc->read_cb.buffer = buf->buffer;
             chrc->read_cb.buffer_size = buf->bufsize;
         } else {
-            ERR_PRINT("zjs_ble_read_attr_call_function_return: buffer not found\n");
+            ERR_PRINT("buffer not found\n");
         }
     }
 
@@ -217,7 +217,7 @@ static void zjs_ble_read_c_callback(void *handle, void* argv)
 
     rval = jerry_call_function(cb->js_callback, chrc->chrc_obj, args, 2);
     if (jerry_value_has_error_flag(rval)) {
-        DBG_PRINT("zjs_ble_read_c_callback: failed to call onReadRequest function\n");
+        DBG_PRINT("failed to call onReadRequest function\n");
     }
 
     jerry_release_value(args[0]);
@@ -237,7 +237,7 @@ static ssize_t zjs_ble_read_attr_callback(struct bt_conn *conn,
     ble_characteristic_t *chrc = attr->user_data;
 
     if (!chrc) {
-        ERR_PRINT("zjs_ble_read_attr_callback: characteristic not found\n");
+        ERR_PRINT("characteristic not found\n");
         return BT_GATT_ERR(BT_ATT_ERR_INVALID_HANDLE);
     }
 
@@ -252,7 +252,7 @@ static ssize_t zjs_ble_read_attr_callback(struct bt_conn *conn,
 
         // block until result is ready
         if (k_sem_take(&ble_sem, ZJS_BLE_TIMEOUT_TICKS)) {
-            ERR_PRINT("zjs_ble_read_attr_callback: JS callback timed out\n");
+            ERR_PRINT("JS callback timed out\n");
             return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
         }
 
@@ -264,16 +264,16 @@ static ssize_t zjs_ble_read_attr_callback(struct bt_conn *conn,
                 return chrc->read_cb.buffer_size;
             }
 
-            ERR_PRINT("zjs_ble_read_attr_callback: buffer is empty\n");
+            ERR_PRINT("buffer is empty\n");
             return BT_GATT_ERR(BT_ATT_ERR_NOT_SUPPORTED);
         } else {
-            ERR_PRINT("zjs_ble_read_attr_callback: on read attr error %lu\n",
+            ERR_PRINT("on read attr error %lu\n",
                   chrc->read_cb.error_code);
             return BT_GATT_ERR(chrc->read_cb.error_code);
         }
     }
 
-    DBG_PRINT("zjs_ble_read_attr_callback: js callback not available\n");
+    DBG_PRINT("js callback not available\n");
     return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 }
 
@@ -335,7 +335,7 @@ static void zjs_ble_write_c_callback(void *handle, void* argv)
 
     rval = jerry_call_function(cb->js_callback, chrc->chrc_obj, args, 4);
     if (jerry_value_has_error_flag(rval)) {
-        DBG_PRINT("zjs_ble_write_c_callback: failed to call onWriteRequest function\n");
+        DBG_PRINT("failed to call onWriteRequest function\n");
     }
 
     jerry_release_value(args[0]);
@@ -353,7 +353,7 @@ static ssize_t zjs_ble_write_attr_callback(struct bt_conn *conn,
     ble_characteristic_t *chrc = attr->user_data;
 
     if (!chrc) {
-        ERR_PRINT("zjs_ble_write_attr_callback: characteristic not found\n");
+        ERR_PRINT("characteristic not found\n");
         return BT_GATT_ERR(BT_ATT_ERR_INVALID_HANDLE);
     }
 
@@ -368,7 +368,7 @@ static ssize_t zjs_ble_write_attr_callback(struct bt_conn *conn,
 
         // block until result is ready
         if (k_sem_take(&ble_sem, ZJS_BLE_TIMEOUT_TICKS)) {
-            ERR_PRINT("zjs_ble_write_attr_callback: JS callback timed out\n");
+            ERR_PRINT("JS callback timed out\n");
             return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
         }
 
@@ -379,7 +379,7 @@ static ssize_t zjs_ble_write_attr_callback(struct bt_conn *conn,
         }
     }
 
-    DBG_PRINT("zjs_ble_write_attr_callback: js callback not available\n");
+    DBG_PRINT("js callback not available\n");
     return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 }
 
@@ -426,7 +426,7 @@ static void zjs_ble_subscribe_c_callback(void *handle, void* argv)
     args[1] = jerry_create_external_function(zjs_ble_update_value_callback_function);
     rval = jerry_call_function(cb->js_callback, chrc->chrc_obj, args, 2);
     if (jerry_value_has_error_flag(rval)) {
-        DBG_PRINT("zjs_ble_subscribe_c_callback: failed to call onSubscribe function\n");
+        DBG_PRINT("failed to call onSubscribe function\n");
     }
 
     jerry_release_value(args[0]);
@@ -443,7 +443,7 @@ static void zjs_ble_unsubscribe_c_callback(void *handle, void* argv)
 
     rval = jerry_call_function(cb->js_callback, chrc->chrc_obj, NULL, 0);
     if (jerry_value_has_error_flag(rval)) {
-        DBG_PRINT("zjs_ble_unsubscribe_c_callback: failed to call onUnsubscribe function\n");
+        DBG_PRINT("failed to call onUnsubscribe function\n");
     }
 
     jerry_release_value(rval);
@@ -458,7 +458,7 @@ static void zjs_ble_notify_c_callback(void *handle, void* argv)
 
     rval = jerry_call_function(cb->js_callback, chrc->chrc_obj, NULL, 0);
     if (jerry_value_has_error_flag(rval)) {
-        DBG_PRINT("zjs_ble_notify_c_callback: failed to call onNotify function\n");
+        DBG_PRINT("failed to call onNotify function\n");
     }
 
     jerry_release_value(rval);
@@ -508,7 +508,7 @@ static void zjs_ble_connected_c_callback(void *handle, void* argv)
 static void zjs_ble_connected(struct bt_conn *conn, uint8_t err)
 {
     if (err) {
-        DBG_PRINT("zjs_ble_connected: Connection failed (err %u)\n", err);
+        DBG_PRINT("Connection failed (err %u)\n", err);
     } else {
         DBG_PRINT("========== connected ==========\n");
         ble_conn->default_conn = bt_conn_ref(conn);
@@ -697,7 +697,7 @@ static jerry_value_t zjs_ble_start_advertising(const jerry_value_t function_obj,
     int frame_size;
     if (argc >= 3) {
         if (zjs_encode_url_frame(argv[2], &url_frame, &frame_size)) {
-            DBG_PRINT("zjs_ble_start_advertising: error encoding url frame, won't be advertised\n");
+            DBG_PRINT("error encoding url frame, won't be advertised\n");
 
             // TODO: Make use of error values and turn them into exceptions
         }
@@ -771,7 +771,7 @@ static jerry_value_t zjs_ble_stop_advertising(const jerry_value_t function_obj,
                                               const jerry_value_t argv[],
                                               const jerry_length_t argc)
 {
-    DBG_PRINT("zjs_ble_stop_advertising: stopAdvertising has been called\n");
+    DBG_PRINT("stopAdvertising has been called\n");
     return ZJS_UNDEFINED;
 }
 
@@ -783,7 +783,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
 
     jerry_value_t chrc_obj = chrc->chrc_obj;
     if (!zjs_obj_get_string(chrc_obj, "uuid", uuid, ZJS_BLE_UUID_LEN)) {
-        ERR_PRINT("zjs_ble_parse_characteristic: characteristic uuid doesn't exist\n");
+        ERR_PRINT("characteristic uuid doesn't exist\n");
         return false;
     }
 
@@ -791,7 +791,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
 
     jerry_value_t v_array = zjs_get_property(chrc_obj, "properties");
     if (!jerry_value_is_array(v_array)) {
-        ERR_PRINT("zjs_ble_parse_characteristic: properties is empty or not array\n");
+        ERR_PRINT("properties is empty or not array\n");
         return false;
     }
 
@@ -799,7 +799,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
         jerry_value_t v_property = jerry_get_property_by_index(v_array, i);
 
         if (!jerry_value_is_string(v_property)) {
-            ERR_PRINT("zjs_ble_parse_characteristic: property is not string\n");
+            ERR_PRINT("property is not string\n");
             return false;
         }
 
@@ -825,7 +825,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
     if (!jerry_value_is_undefined(v_array) &&
         !jerry_value_is_null(v_array) &&
         !jerry_value_is_array(v_array)) {
-        ERR_PRINT("zjs_ble_parse_characteristic: descriptors is not array\n");
+        ERR_PRINT("descriptors is not array\n");
         return false;
     }
 
@@ -833,13 +833,13 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
         jerry_value_t v_desc = jerry_get_property_by_index(v_array, i);
 
         if (!jerry_value_is_object(v_desc)) {
-            ERR_PRINT("zjs_ble_parse_characteristic: not valid descriptor object\n");
+            ERR_PRINT("not valid descriptor object\n");
             return false;
         }
 
         char desc_uuid[ZJS_BLE_UUID_LEN];
         if (!zjs_obj_get_string(v_desc, "uuid", desc_uuid, ZJS_BLE_UUID_LEN)) {
-            ERR_PRINT("zjs_ble_parse_service: descriptor uuid doesn't exist\n");
+            ERR_PRINT("descriptor uuid doesn't exist\n");
             return false;
         }
 
@@ -905,14 +905,14 @@ static bool zjs_ble_parse_service(ble_service_t *service)
 
     jerry_value_t service_obj = service->service_obj;
     if (!zjs_obj_get_string(service_obj, "uuid", uuid, ZJS_BLE_UUID_LEN)) {
-        ERR_PRINT("zjs_ble_parse_service: service uuid doesn't exist\n");
+        ERR_PRINT("service uuid doesn't exist\n");
         return false;
     }
     service->uuid = zjs_ble_new_uuid_16(strtoul(uuid, NULL, 16));
 
     jerry_value_t v_array = zjs_get_property(service_obj, "characteristics");
     if (!jerry_value_is_array(v_array)) {
-        ERR_PRINT("zjs_ble_parse_service: characteristics is empty or not array\n");
+        ERR_PRINT("characteristics is empty or not array\n");
         return false;
     }
 
@@ -921,13 +921,13 @@ static bool zjs_ble_parse_service(ble_service_t *service)
         jerry_value_t v_chrc = jerry_get_property_by_index(v_array, i);
 
         if (!jerry_value_is_object(v_chrc)) {
-            ERR_PRINT("zjs_ble_parse_characteristic: characteristic is not object\n");
+            ERR_PRINT("characteristic is not object\n");
             return false;
         }
 
         ble_characteristic_t *chrc = zjs_malloc(sizeof(ble_characteristic_t));
         if (!chrc) {
-            ERR_PRINT("zjs_ble_parse_service: out of memory allocating ble_characteristic_t\n");
+            ERR_PRINT("out of memory allocating ble_characteristic_t\n");
             return false;
         }
 
@@ -962,7 +962,7 @@ static bool zjs_ble_parse_service(ble_service_t *service)
 static bool zjs_ble_register_service(ble_service_t *service)
 {
     if (!service) {
-        ERR_PRINT("zjs_ble_register_service: invalid ble_service\n");
+        ERR_PRINT("invalid ble_service\n");
         return false;
     }
 
@@ -987,7 +987,7 @@ static bool zjs_ble_register_service(ble_service_t *service)
 
    struct bt_gatt_attr *bt_attrs = zjs_malloc(sizeof(struct bt_gatt_attr) * num_of_entries);
     if (!bt_attrs) {
-        ERR_PRINT("zjs_ble_register_service: out of memory allocating struct bt_gatt_attr\n");
+        ERR_PRINT("out of memory allocating struct bt_gatt_attr\n");
         return false;
     }
 
@@ -1006,7 +1006,7 @@ static bool zjs_ble_register_service(ble_service_t *service)
         // GATT Characteristic
         struct bt_gatt_chrc *chrc_user_data = zjs_malloc(sizeof(struct bt_gatt_chrc));
         if (!chrc_user_data) {
-            ERR_PRINT("zjs_ble_register_service: out of memory allocating struct bt_gatt_chrc\n");
+            ERR_PRINT("out of memory allocating struct bt_gatt_chrc\n");
             return false;
         }
 
@@ -1042,7 +1042,7 @@ static bool zjs_ble_register_service(ble_service_t *service)
             jerry_size_t sz = jerry_get_string_size(ch->cud_value);
             char *cud_buffer = zjs_malloc(sz+1);
             if (!cud_buffer) {
-                ERR_PRINT("zjs_ble_register_service: out of memory allocating cud buffer\n");
+                ERR_PRINT("out of memory allocating cud buffer\n");
                 return false;
             }
 
@@ -1061,7 +1061,7 @@ static bool zjs_ble_register_service(ble_service_t *service)
             // add CCC only if notify flag is set
             struct _bt_gatt_ccc *ccc_user_data = zjs_malloc(sizeof(struct _bt_gatt_ccc));
             if (!ccc_user_data) {
-                ERR_PRINT("zjs_ble_register_service: out of memory allocating struct bt_gatt_ccc\n");
+                ERR_PRINT("out of memory allocating struct bt_gatt_ccc\n");
                 return false;
             }
 
@@ -1085,7 +1085,7 @@ static bool zjs_ble_register_service(ble_service_t *service)
     }
 
     if (entry_index != num_of_entries) {
-        ERR_PRINT("zjs_ble_register_service: number of entries didn't match\n");
+        ERR_PRINT("number of entries didn't match\n");
         return false;
     }
 
@@ -1169,7 +1169,7 @@ static jerry_value_t zjs_ble_set_services(const jerry_value_t function_obj,
               jerry_create_string((jerry_char_t *)"failed to register services");
         jerry_value_t rval = jerry_call_function(argv[1], ZJS_UNDEFINED, &arg, 1);
         if (jerry_value_has_error_flag(rval)) {
-            DBG_PRINT("zjs_ble_set_services: failed to call callback function\n");
+            DBG_PRINT("failed to call callback function\n");
         }
     }
 

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -356,7 +356,7 @@ jerry_value_t zjs_buffer_create(uint32_t size)
         (zjs_buffer_t *)zjs_malloc(sizeof(zjs_buffer_t));
 
     if (!buf_obj || !buf || !buf_item) {
-        ERR_PRINT("zjs_buffer_create: unable to allocate buffer\n");
+        ERR_PRINT("unable to allocate buffer\n");
         jerry_release_value(buf_obj);
         zjs_free(buf);
         zjs_free(buf_item);

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -445,7 +445,7 @@ bool zjs_trigger_event(jerry_value_t obj,
 
     if (!zjs_obj_get_int32(event_obj, "callback_id", &callback_id)) {
         zjs_free(trigger);
-        ERR_PRINT("[event] zjs_trigger_event(): Error, callback_id not found\n");
+        ERR_PRINT("callback_id not found\n");
         return false;
     }
 

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -450,7 +450,7 @@ jerry_value_t zjs_gpio_init()
         snprintf(devname, 8, "GPIO_%d", i);
         zjs_gpio_dev[i] = device_get_binding(devname);
         if (!zjs_gpio_dev[i]) {
-            ERR_PRINT("zjs_gpio_init: cannot find GPIO device '%s'\n", devname);
+            ERR_PRINT("cannot find GPIO device '%s'\n", devname);
         }
     }
 

--- a/src/zjs_grove_lcd_ipm.c
+++ b/src/zjs_grove_lcd_ipm.c
@@ -29,7 +29,7 @@ static bool zjs_glcd_ipm_send_sync(zjs_ipm_message_t* send,
     send->error_code = ERROR_IPM_NONE;
 
     if (zjs_ipm_send(MSG_ID_GLCD, send) != 0) {
-        ERR_PRINT("zjs_glcd_ipm_send_sync: failed to send message\n");
+        ERR_PRINT("failed to send message\n");
         return false;
     }
 
@@ -37,7 +37,7 @@ static bool zjs_glcd_ipm_send_sync(zjs_ipm_message_t* send,
     // time out, if the ARC response comes back after it
     // times out, it could pollute the result on the stack
     if (k_sem_take(&glcd_sem, ZJS_GLCD_TIMEOUT_TICKS)) {
-        ERR_PRINT("zjs_glcd_ipm_send_sync: FATAL ERROR, ipm timed out\n");
+        ERR_PRINT("FATAL ERROR, ipm timed out\n");
         return false;
     }
 
@@ -84,7 +84,7 @@ static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *
         k_sem_give(&glcd_sem);
     } else {
         // asynchronous ipm, should not get here
-        ERR_PRINT("ipm_msg_receive_callback: async message received\n");
+        ERR_PRINT("async message received\n");
     }
 }
 

--- a/src/zjs_i2c_ipm.c
+++ b/src/zjs_i2c_ipm.c
@@ -27,13 +27,13 @@ static bool zjs_i2c_ipm_send_sync(zjs_ipm_message_t* send,
     send->error_code = ERROR_IPM_NONE;
 
     if (zjs_ipm_send(MSG_ID_I2C, send) != 0) {
-        ERR_PRINT("zjs_i2c_ipm_send_sync: failed to send message\n");
+        ERR_PRINT("failed to send message\n");
         return false;
     }
 
     // block until reply or timeout
     if (k_sem_take(&i2c_sem, ZJS_I2C_TIMEOUT_TICKS)) {
-        ERR_PRINT("zjs_i2c_ipm_send_sync: ipm timed out\n");
+        ERR_PRINT("ipm timed out\n");
         return false;
     }
 
@@ -57,7 +57,7 @@ static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *
         k_sem_give(&i2c_sem);
     } else {
         // asynchronous ipm, should not get here
-        ERR_PRINT("ipm_msg_receive_callback: async message received\n");
+        ERR_PRINT("async message received\n");
     }
 }
 

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -33,7 +33,7 @@ static void zjs_pwm_set(jerry_value_t obj, double period, double pulseWidth)
     zjs_pwm_convert_pin(orig_chan, &devnum, &channel);
 
     if (pulseWidth > period) {
-        ERR_PRINT("zjs_pwm_set: pulseWidth was greater than period\n");
+        ERR_PRINT("pulseWidth was greater than period\n");
         pulseWidth = period;
     }
 
@@ -62,7 +62,7 @@ static void zjs_pwm_set_cycles(jerry_value_t obj, uint32_t periodHW, uint32_t pu
     zjs_pwm_convert_pin(orig_chan, &devnum, &channel);
 
     if (pulseWidthHW > periodHW) {
-        ERR_PRINT("zjs_pwm_set: pulseWidth was greater than period\n");
+        ERR_PRINT("pulseWidth was greater than period\n");
         pulseWidthHW = periodHW;
     }
 


### PR DESCRIPTION
ERR_PRINT and DBG_PRINT automatically display the function, file, and
line number so the function name should not be in the message string.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>