### PR TITLE
[buffer] Make length attribute read-only

### DIFF
--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -371,7 +371,7 @@ jerry_value_t zjs_buffer_create(uint32_t size)
     zjs_buffers = buf_item;
 
     jerry_set_prototype(buf_obj, zjs_buffer_prototype);
-    zjs_obj_add_number(buf_obj, size, "length");
+    zjs_obj_add_readonly_number(buf_obj, size, "length");
 
     // TODO: sign up to get callback when the object is freed, then free the
     //   buffer and remove it from the list
@@ -389,8 +389,8 @@ static jerry_value_t zjs_buffer(const jerry_value_t function_obj,
                                 const jerry_value_t argv[],
                                 const jerry_length_t argc)
 {
-    // requires: single argument can be a numeric size in bytes, an array of uint8,
-    //           or a string.
+    // requires: single argument can be a numeric size in bytes, an array of
+    //             uint8, or a string
     //  effects: constructs a new JS Buffer object, and an associated buffer
     //             tied to it through a zjs_buffer_t struct stored in a global
     //             list

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -287,8 +287,8 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
     jerry_value_t i2c_obj = jerry_create_object();
     jerry_set_prototype(i2c_obj, zjs_i2c_prototype);
 
-    zjs_obj_add_number(i2c_obj, bus, "bus");
-    zjs_obj_add_number(i2c_obj, speed, "speed");
+    zjs_obj_add_readonly_number(i2c_obj, bus, "bus");
+    zjs_obj_add_readonly_number(i2c_obj, speed, "speed");
 
     return i2c_obj;
 }

--- a/src/zjs_i2c_ipm.c
+++ b/src/zjs_i2c_ipm.c
@@ -300,17 +300,16 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
         return zjs_error("zjs_i2c_open: ipm message failed or timed out!");
     }
 
-    if (reply.error_code == 0) {
-        // create the I2C object
-        jerry_value_t i2c_obj = jerry_create_object();
-        jerry_set_prototype(i2c_obj, zjs_i2c_prototype);
-        zjs_obj_add_number(i2c_obj, bus, "bus");
-        zjs_obj_add_number(i2c_obj, speed, "speed");
-        return i2c_obj;
-    }
-    else {
+    if (reply.error_code) {
         return zjs_error("zjs_i2c_open: Failed to open I2C bus");
     }
+
+    // create the I2C object
+    jerry_value_t i2c_obj = jerry_create_object();
+    jerry_set_prototype(i2c_obj, zjs_i2c_prototype);
+    zjs_obj_add_readonly_number(i2c_obj, bus, "bus");
+    zjs_obj_add_readonly_number(i2c_obj, speed, "speed");
+    return i2c_obj;
 }
 
 jerry_value_t zjs_i2c_init()

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -96,6 +96,22 @@ void zjs_obj_add_number(jerry_value_t obj, double num, const char *name)
     jerry_release_value(jnum);
 }
 
+void zjs_obj_add_readonly_number(jerry_value_t obj, double num,
+                                 const char *name)
+{
+    // requires: obj is an existing JS object
+    //  effects: creates a new readonly field in parent named name, set to nval
+    jerry_value_t jname = jerry_create_string((const jerry_char_t *)name);
+    jerry_property_descriptor_t pd;
+    jerry_init_property_descriptor_fields(&pd);
+    pd.is_writable = false;
+    pd.is_value_defined = true;
+    pd.value = jerry_create_number(num);
+    jerry_define_own_property(obj, jname, &pd);
+    jerry_free_property_descriptor_fields(&pd);
+    jerry_release_value(jname);
+}
+
 bool zjs_obj_get_boolean(jerry_value_t obj, const char *name, bool *flag)
 {
     // requires: obj is an existing JS object, value name should exist as

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -48,6 +48,8 @@ void zjs_obj_add_object(jerry_value_t parent, jerry_value_t child,
                         const char *name);
 void zjs_obj_add_string(jerry_value_t obj, const char *str, const char *name);
 void zjs_obj_add_number(jerry_value_t obj, double num, const char *name);
+void zjs_obj_add_readonly_number(jerry_value_t obj, double num,
+                                 const char *name);
 
 bool zjs_obj_get_boolean(jerry_value_t obj, const char *name, bool *flag);
 bool zjs_obj_get_string(jerry_value_t obj, const char *name, char *buffer,


### PR DESCRIPTION
Fixes issue #172.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>