### PR TITLE
[snapshot] Adding file path for new zjs_common.c

### DIFF
--- a/Makefile.snapshot
+++ b/Makefile.snapshot
@@ -25,6 +25,7 @@ setup:
 	fi
 
 CORE_SRC +=		src/snapshot.c \
+			src/zjs_common.c \
 			src/zjs_script.c
 
 CORE_OBJ =		$(CORE_SRC:%.c=%.o)


### PR DESCRIPTION
Fixes issue #588 where snapshot was failing to build since it
didn't have the path to the new zjs_common.c file.