### PR TITLE
[osx] fix make linux on osx

### DIFF
--- a/src/zjs_linux_port.h
+++ b/src/zjs_linux_port.h
@@ -5,6 +5,7 @@
 
 #include "zjs_util.h"
 #include <unistd.h>
+#include <time.h>
 
 typedef struct zjs_port_timer {
     uint32_t sec;


### PR DESCRIPTION
CLOCK_MONOTONIC was not defined.

Signed-off-by: Sakari Poussa <sakari.poussa@intel.com>