### PR TITLE
[error] Implement standard error types

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -47,6 +47,7 @@ CORE_SRC +=	src/zjs_buffer.c \
 		src/zjs_callbacks.c \
 		src/zjs_common.c \
 		src/zjs_console.c \
+		src/zjs_error.c \
 		src/zjs_event.c \
 		src/zjs_linux_ring_buffer.c \
 		src/zjs_linux_time.c \

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -34,6 +34,7 @@ endif
 obj-y += main.o \
          zjs_callbacks.o \
          zjs_common.o \
+         zjs_error.o \
          zjs_modules.o \
          zjs_promise.o \
          zjs_script.o \

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,5 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
+
 #ifndef ZJS_LINUX_BUILD
 // Zephyr includes
 #include <zephyr.h>

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 
 // Platform agnostic modules/headers
 #include "zjs_callbacks.h"
+#include "zjs_error.h"
 #include "zjs_modules.h"
 #ifdef BUILD_MODULE_SENSOR
 #include "zjs_sensor.h"
@@ -140,6 +141,8 @@ int main(int argc, char *argv[])
 
     // initialize modules
     zjs_modules_init();
+
+    zjs_error_init();
 
 #ifdef BUILD_MODULE_OCF
     zjs_register_service_routine(NULL, main_poll_routine);

--- a/src/zjs_error.c
+++ b/src/zjs_error.c
@@ -1,0 +1,102 @@
+// Copyright (c) 2016, Intel Corporation.
+
+// ZJS includes
+#include "zjs_util.h"
+
+typedef struct {
+    char *name;
+    jerry_value_t ctor;
+} zjs_error_t;
+
+static zjs_error_t error_types[] = {
+    { "SecurityError" },
+    { "NotSupportedError" },
+    { "SyntaxError" },
+    { "TypeError" },
+    { "RangeError" },
+    { "TimeoutError" },
+    { "NetworkError" },
+    { "SystemError" }
+};
+
+static jerry_value_t error_handler(const jerry_value_t function_obj,
+                                   const jerry_value_t this,
+                                   const jerry_value_t argv[],
+                                   const jerry_length_t argc)
+{
+    int count = sizeof(error_types) / sizeof(zjs_error_t);
+    bool found = false;
+    for (int i=0; i<count; i++) {
+        if (function_obj == error_types[i].ctor) {
+            zjs_obj_add_string(this, error_types[i].name, "name");
+            found = true;
+            break;
+        }
+    }
+
+    // FIXME: may be able to remove because this should never happen
+    if (!found) {
+        return zjs_error("error_handler: unknown type");
+    }
+
+    if (argc >= 1 && jerry_value_is_string(argv[0])) {
+        zjs_set_property(this, "message", argv[0]);
+    }
+
+    return ZJS_UNDEFINED;
+}
+
+void zjs_error_init()
+{
+    jerry_value_t global = jerry_get_global_object();
+    jerry_value_t error_func = zjs_get_property(global, "Error");
+
+    int count = sizeof(error_types) / sizeof(zjs_error_t);
+    for (int i=0; i<count; i++) {
+        jerry_value_t error_obj = jerry_construct_object(error_func, NULL, 0);
+        if (jerry_value_is_undefined(error_obj)) {
+            ERR_PRINT("Error object undefined\n");
+        }
+
+        // create a copy of this function w/ unique error prototype for each
+        jerry_value_t ctor = jerry_create_external_function(error_handler);
+        error_types[i].ctor = ctor;
+        zjs_set_property(ctor, "prototype", error_obj);
+
+        zjs_obj_add_object(global, ctor, error_types[i].name);
+
+        jerry_release_value(error_obj);
+    }
+
+    jerry_release_value(error_func);
+    jerry_release_value(global);
+}
+
+void zjs_error_cleanup()
+{
+    int count = sizeof(error_types) / sizeof(zjs_error_t);
+    for (int i=0; i<count; i++) {
+        jerry_release_value(error_types[i].ctor);
+    }
+}
+
+jerry_value_t zjs_standard_error(zjs_error_type_t type, const char *message)
+{
+    int count = sizeof(error_types) / sizeof(zjs_error_t);
+    if (type >= count || type < 0) {
+#ifdef DEBUG_BUILD
+        ZJS_PRINT("[Error] %s\n", message);
+#endif
+        return jerry_create_error(JERRY_ERROR_TYPE, (jerry_char_t *)message);
+    }
+
+#ifdef DEBUG_BUILD
+    ZJS_PRINT("[%s] %s\n", error_types[type].name, message);
+#endif
+    jerry_value_t msg = jerry_create_string((jerry_char_t *)message);
+    jerry_value_t obj = jerry_construct_object(error_types[type].ctor, &msg, 1);
+    jerry_value_set_error_flag(&obj);
+
+    jerry_release_value(msg);
+    return obj;
+}

--- a/src/zjs_error.c
+++ b/src/zjs_error.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2017, Intel Corporation.
 
 // ZJS includes
 #include "zjs_util.h"

--- a/src/zjs_error.h
+++ b/src/zjs_error.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2016, Intel Corporation.
+
+#ifndef __zjs_error_h__
+#define __zjs_error_h__
+
+#include "jerry-api.h"
+
+typedef enum zjs_error_type {
+    SecurityError,
+    NotSupportedError,
+    SyntaxError,
+    TypeError,
+    RangeError,
+    TimeoutError,
+    NetworkError,
+    SystemError,
+    Error
+} zjs_error_type_t;
+
+/** Initialize the error module, or reinitialize after cleanup. */
+void zjs_error_init();
+
+/** Release resources held by the error module. */
+void zjs_error_cleanup();
+
+/**
+ * Create an error object to return from an API.
+ *
+ * @param type An error type from zjs_error_type enum.
+ * @param message String for additional detail about the error.
+ *
+ * @return A new Error or subclass object.
+ */
+jerry_value_t zjs_standard_error(zjs_error_type_t type, const char *message);
+
+#define zjs_error(msg)          (zjs_standard_error(Error, (msg)))
+
+#define SECURITY_ERROR(msg)     (zjs_standard_error(SecurityError, (msg)))
+#define NOTSUPPORTED_ERROR(msg) (zjs_standard_error(NotSupportedError, (msg)))
+#define SYNTAX_ERROR(msg)       (zjs_standard_error(SyntaxError, (msg)))
+#define TYPE_ERROR(msg)         (zjs_standard_error(TypeError, (msg)))
+#define RANGE_ERROR(msg)        (zjs_standard_error(RangeError, (msg)))
+#define TIMEOUT_ERROR(msg)      (zjs_standard_error(TimeoutError, (msg)))
+#define NETWORK_ERROR(msg)      (zjs_standard_error(NetworkError, (msg)))
+#define SYSTEM_ERROR(msg)       (zjs_standard_error(SystemError, (msg)))
+
+#endif  // __zjs_error_h__

--- a/src/zjs_error.h
+++ b/src/zjs_error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2017, Intel Corporation.
 
 #ifndef __zjs_error_h__
 #define __zjs_error_h__

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef ZJS_LINUX_BUILD
 // Zephyr includes

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -115,7 +115,7 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
                                             const jerry_length_t argc)
 {
     if (!jerry_value_is_string(argv[0])) {
-        return zjs_error("native_require_handler: invalid argument");
+        return TYPE_ERROR("native_require_handler: string expected");
     }
 
     const int MAX_MODULE_LEN = 32;
@@ -123,7 +123,7 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
     char module[size];
     zjs_copy_jstring(argv[0], module, &size);
     if (!size) {
-        return zjs_error("native_require_handler: argument too long");
+        return RANGE_ERROR("native_require_handler: argument too long");
     }
 
     int modcount = sizeof(zjs_modules_array) / sizeof(module_t);
@@ -144,14 +144,14 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
     if (!jerry_value_is_object(modules_obj)) {
         jerry_release_value(global_obj);
         jerry_release_value(modules_obj);
-        return zjs_error("native_require_handler: modules object not found");
+        return SYSTEM_ERROR("native_require_handler: modules object not found");
     }
     jerry_value_t exports_obj = zjs_get_property(modules_obj, "exports");
     if (!jerry_value_is_object(exports_obj)) {
         jerry_release_value(global_obj);
         jerry_release_value(modules_obj);
         jerry_release_value(exports_obj);
-        return zjs_error("native_require_handler: exports object not found");
+        return SYSTEM_ERROR("native_require_handler: exports object not found");
     }
 
     for (int i = 0; i < 4; i++) {
@@ -172,7 +172,7 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
     jerry_release_value(global_obj);
     jerry_release_value(modules_obj);
     jerry_release_value(exports_obj);
-    return zjs_error("native_require_handler: module not found");
+    return NOTSUPPORTED_ERROR("native_require_handler: module not found");
 }
 
 void zjs_modules_init()
@@ -197,6 +197,7 @@ void zjs_modules_init()
     }
 
     // initialize fixed modules
+    zjs_error_init();
     zjs_timers_init();
 #ifdef BUILD_MODULE_CONSOLE
     zjs_console_init();
@@ -224,6 +225,7 @@ void zjs_modules_cleanup()
     }
 
     // clean up fixed modules
+    zjs_error_cleanup();
     zjs_timers_cleanup();
 #ifdef BUILD_MODULE_BUFFER
     zjs_buffer_cleanup();

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -299,9 +299,3 @@ uint32_t zjs_uncompress_16_to_32(uint16_t num)
     // shift back up to the right point
     return uncompressed << (21 - zeroes);
 }
-
-jerry_value_t zjs_error(const char *error)
-{
-    ZJS_PRINT("[ERROR] %s\n", error);
-    return jerry_create_error(JERRY_ERROR_TYPE, (jerry_char_t *)error);
-}

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #include <string.h>
 

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -7,6 +7,7 @@
 
 #include "jerry-api.h"
 #include "zjs_common.h"
+#include "zjs_error.h"
 
 #define ZJS_UNDEFINED jerry_create_undefined()
 
@@ -95,7 +96,5 @@ void zjs_default_convert_pin(uint32_t orig, int *dev, int *pin);
 
 uint16_t zjs_compress_32_to_16(uint32_t num);
 uint32_t zjs_uncompress_16_to_32(uint16_t num);
-
-jerry_value_t zjs_error(const char *error);
 
 #endif  // __zjs_util_h__

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_util_h__
 #define __zjs_util_h__

--- a/tests/test-error.js
+++ b/tests/test-error.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2017, Intel Corporation.
 
 // Types defined here: https://github.com/zolkis/iot-js-api/tree/master/api
 

--- a/tests/test-error.js
+++ b/tests/test-error.js
@@ -1,0 +1,100 @@
+// Copyright (c) 2016, Intel Corporation.
+
+// Types defined here: https://github.com/zolkis/iot-js-api/tree/master/api
+
+console.log('Testing error types...\n');
+
+var total = 0;
+var passed = 0;
+
+function assert(actual, description) {
+    total += 1;
+
+    var label = "\033[1m\033[31mFAIL\033[0m";
+    if (actual === true) {
+        passed += 1;
+        label = "\033[1m\033[32mPASS\033[0m";
+    }
+
+    console.log(label + " - " + description);
+}
+
+function expectStandardError(description, type, func) {
+    var threw = false;
+    try {
+        func();
+        console.log(description + ": expected exception");
+    }
+    catch (err) {
+        try {
+            if (err instanceof Error && err instanceof type) {
+                threw = true;
+            }
+            else {
+                console.log(description + ": expected error object");
+            }
+        }
+        catch (e) {
+            console.log(description + ": instanceof threw exception");
+        }
+    }
+    assert(threw, description);
+}
+
+function testError(errorType, errorName, isSecurityError) {
+    var error = new errorType("message text");
+    var pass = true;
+
+    if (error.name != errorName) {
+        pass = false;
+        console.log("found", error.name, "name, expected", errorName);
+    }
+    else if (!(error instanceof Error)) {
+        pass = false;
+        console.log("error is not an Error");
+    }
+    else {
+        try {
+            pass = error instanceof errorType;
+        }
+        catch (e) {
+            pass = false;
+            console.log(e.name + ': ' + e.message);
+        }
+
+        if (pass && !isSecurityError) {
+            try {
+                result = error instanceof SecurityError;
+                pass = !result;
+            }
+            catch (e) {
+                pass = false;
+                console.log(e.name + ': ' + e.message);
+            }
+        }
+    }
+
+    assert(pass, errorName + " works as expected");
+}
+
+testError(SecurityError,     "SecurityError", true);
+testError(NotSupportedError, "NotSupportedError");
+testError(SyntaxError,       "SyntaxError");
+testError(TypeError,         "TypeError");
+testError(RangeError,        "RangeError");
+testError(TimeoutError,      "TimeoutError");
+testError(NetworkError,      "NetworkError");
+testError(SystemError,       "SystemError");
+
+expectStandardError("calling require with an integer", TypeError, function() {
+    require(42);
+});
+expectStandardError("calling require with a long name", RangeError, function() {
+    require('supercalifragilisticexpialidocious');
+});
+expectStandardError("calling require with an invalid module name",
+                    NotSupportedError, function() {
+    require('easterbunny');
+});
+
+console.log("TOTAL: " + passed + " of " + total + " passed");


### PR DESCRIPTION
These are defined by Zoltan's iot-js-api. It works to check them with
the .name property or instanceof, the latter due to lots of painful
experimentation so you better use it!

Also, update native_require_handler to use the new standard error
macros and test these along with error constructors in a new
test-error.js file.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>