### PR TITLE
[perf] Add boot timestamps to key samples for QA measurement

### DIFF
--- a/samples/BootTime.js
+++ b/samples/BootTime.js
@@ -1,0 +1,5 @@
+// Copyright (c) 2017, Intel Corporation.
+
+var perf = require('performance');
+
+console.log('Boot timestamp:', perf.now());

--- a/samples/I2C.js
+++ b/samples/I2C.js
@@ -18,6 +18,9 @@
 
 // import i2c module
 var i2c = require("i2c");
+var perf = require("performance");
+
+console.log("Boot timestamp:", perf.now(), "\n");
 
 // Define various Grove LCD addresses
 var GROVE_LCD_DISPLAY_ADDR = 0x3E

--- a/samples/WebBluetoothGroveLcdDemo.js
+++ b/samples/WebBluetoothGroveLcdDemo.js
@@ -26,6 +26,9 @@ var aio = require("aio");
 var ble = require("ble");
 var grove_lcd = require("grove_lcd");
 var pins = require("arduino101_pins");
+var perf = require("performance");
+
+console.log("Boot timestamp:", perf.now(), "\n");
 
 var DEVICE_NAME = 'Arduino101';
 
@@ -40,7 +43,7 @@ var displayStateConfig = grove_lcd.GLCD_DS_DISPLAY_ON;
 glcd.setDisplayState(displayStateConfig);
 
 glcd.clear();
-glcd.print("Web BLE Demo");
+glcd.print("Web BLE Demo...");
 
 var TemperatureCharacteristic = new ble.Characteristic({
     uuid: 'fc0a',

--- a/tests/test-performance.js
+++ b/tests/test-performance.js
@@ -1,3 +1,5 @@
+// Copyright (c) 2016, Linaro Limited.
+
 var performance = require("performance");
 
 var total = 0;


### PR DESCRIPTION
Add new BootTime.js sample that does nothing but this check, since
it didn't seem appropriate to add to HelloWorld.js.

Addresses issue #611.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>