### PR TITLE
[console] Simplify time/timeEnd implementation with JS object

### DIFF
--- a/samples/Console.js
+++ b/samples/Console.js
@@ -1,18 +1,19 @@
-console.log("TESTING LOG");
+// Copyright (c) 2016-2017, Intel Corporation.
+
+console.log("TESTING LOG...");
 console.log(1);
 console.log(-1);
 console.log(123.456);
 console.log(-123.456);
 console.log({int_val: 1});
 
-console.error("TESTING ERROR");
+console.error("\nTESTING ERROR...");
 console.error(1);
 console.error(123.456);
 console.error(-123.456);
 console.error({int_val: 1});
 
-console.log("TESTING TIME");
-
+console.log("\nTESTING TIME...");
 console.time('timer-1');
 setTimeout(function() {
     console.timeEnd('timer-1');

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -227,6 +227,9 @@ void zjs_modules_cleanup()
     // clean up fixed modules
     zjs_error_cleanup();
     zjs_timers_cleanup();
+#ifdef BUILD_MODULE_CONSOLE
+    zjs_console_cleanup();
+#endif
 #ifdef BUILD_MODULE_BUFFER
     zjs_buffer_cleanup();
 #endif


### PR DESCRIPTION
Works without malloc or adding a JS object for each timer.
Also, add cleanup function to release the global time object.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>