### PR TITLE
[analyze] Detect Buffer constructor with any arguments.

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -75,7 +75,7 @@ function check_config_file()
 }
 
 # Check if buffer module required in the JS or config file
-grep Buffer\([0-9]*\) $SCRIPT > /dev/null
+grep Buffer\(.*\) $SCRIPT > /dev/null
 if [ $? -eq 0 ] || check_config_file ZJS_BUFFER; then
     buffer=true;
 else


### PR DESCRIPTION
Previously, detection expected a numeric argument, e.g. `new Buffer(8)`,
but it can also be called with a string, like `new Buffer("foo")`. So,
support any argument (including still supporting none at all).

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>