### PR TITLE
[buffer] Remove unnecessary include of zephyr.h

### DIFF
--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -1,9 +1,5 @@
 // Copyright (c) 2016, Intel Corporation.
 #ifdef BUILD_MODULE_BUFFER
-#ifndef ZJS_LINUX_BUILD
-// Zephyr includes
-#include <zephyr.h>
-#endif
 
 #include <string.h>
 


### PR DESCRIPTION
Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>