### PR TITLE
[build] Fix clean build to remove libjerry-core.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ clean:
 		cd arc/; make clean; \
 	fi
 	make -f Makefile.linux clean
+	@rm -rf $(JERRY_BASE)/build
 	@rm -f src/*.o
 	@rm -f src/zjs_script_gen.c
 	@rm -f src/zjs_snapshot_gen.c


### PR DESCRIPTION
Added line to remove $(JERRY_BASE)/build

Signed-off-by: James Prestwood <james.prestwood@intel.com>