### PR TITLE
[general] Review and correct lifetime of jerry_value_t items

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -142,8 +142,10 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
         case TYPE_AIO_PIN_READ:
         case TYPE_AIO_PIN_EVENT_VALUE_CHANGE:
             handle->value = (double)pin_value;
-            jerry_value_t ret_val = jerry_create_number(handle->value);
-            zjs_signal_callback(handle->callback_id, &ret_val, sizeof(jerry_value_t));
+            jerry_value_t num = jerry_create_number(handle->value);
+            zjs_signal_callback(handle->callback_id, &num,
+                                sizeof(jerry_value_t));
+            jerry_release_value(num);
             break;
         case TYPE_AIO_PIN_SUBSCRIBE:
             DBG_PRINT("subscribed to events on pin %lu\n", pin);

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -119,6 +119,10 @@ static void zjs_ble_free_characteristics(ble_characteristic_t *chrc)
 
         jerry_release_value(tmp->chrc_obj);
 
+        if (tmp->cud_value) {
+            jerry_release_value(tmp->cud_value);
+        }
+
         if (tmp->uuid)
             zjs_free(tmp->uuid);
         if (tmp->read_cb.id != -1) {
@@ -205,12 +209,10 @@ static void zjs_ble_read_c_callback(void *handle, void* argv)
 
     jerry_value_t rval;
     jerry_value_t args[2];
-    jerry_value_t func_obj;
 
     args[0] = jerry_create_number(cb->offset);
-    func_obj = jerry_create_external_function(zjs_ble_read_callback_function);
-    jerry_set_object_native_handle(func_obj, (uintptr_t)handle, NULL);
-    args[1] = func_obj;
+    args[1] = jerry_create_external_function(zjs_ble_read_callback_function);
+    jerry_set_object_native_handle(args[1], (uintptr_t)handle, NULL);
 
     rval = jerry_call_function(cb->js_callback, chrc->chrc_obj, args, 2);
     if (jerry_value_has_error_flag(rval)) {
@@ -304,31 +306,24 @@ static void zjs_ble_write_c_callback(void *handle, void* argv)
 
     jerry_value_t rval;
     jerry_value_t args[4];
-    jerry_value_t func_obj;
 
     args[0] = jerry_create_null();
     if (cb->buffer && cb->buffer_size > 0) {
         jerry_value_t buf_obj = zjs_buffer_create(cb->buffer_size);
+        zjs_buffer_t *buf = zjs_buffer_find(buf_obj);
 
-        if (buf_obj) {
-           zjs_buffer_t *buf = zjs_buffer_find(buf_obj);
-
-           if (buf &&
-               buf->buffer &&
-               buf->bufsize == cb->buffer_size) {
-               memcpy(buf->buffer, cb->buffer, cb->buffer_size);
-           }
-
-           jerry_release_value(args[0]);
-           args[0] = buf_obj;
+        if (buf) {
+            memcpy(buf->buffer, cb->buffer, cb->buffer_size);
         }
+
+        jerry_release_value(args[0]);
+        args[0] = buf_obj;
     }
     args[1] = jerry_create_number(cb->offset);
     // TODO: support withoutResponse flag
     args[2] = jerry_create_boolean(false);
-    func_obj = jerry_create_external_function(zjs_ble_write_callback_function);
-    jerry_set_object_native_handle(func_obj, (uintptr_t)handle, NULL);
-    args[3] = func_obj;
+    args[3] = jerry_create_external_function(zjs_ble_write_callback_function);
+    jerry_set_object_native_handle(args[3], (uintptr_t)handle, NULL);
 
     rval = jerry_call_function(cb->js_callback, chrc->chrc_obj, args, 4);
     if (jerry_value_has_error_flag(rval)) {
@@ -498,6 +493,8 @@ static void zjs_ble_connected_c_callback(void *handle, void* argv)
 {
     // FIXME: get real bluetooth address
     jerry_value_t arg = jerry_create_string((jerry_char_t *)"AB:CD:DF:AB:CD:EF");
+    // FIXME: arg should be released after this call, or else it needs to be
+    //        saved somewhere to be released later, like in a handle/post
     zjs_trigger_event(ble_conn.ble_obj, "accept", &arg, 1, NULL, NULL);
     DBG_PRINT("BLE event: accept\n");
 }
@@ -517,6 +514,8 @@ static void zjs_ble_disconnected_c_callback(void *handle, void* argv)
 {
     // FIXME: get real bluetooth address
     jerry_value_t arg = jerry_create_string((jerry_char_t *)"AB:CD:DF:AB:CD:EF");
+    // FIXME: arg should be released after this call, or else it needs to be
+    //        saved somewhere to be released later, like in a handle/post
     zjs_trigger_event(ble_conn.ble_obj, "disconnect", &arg, 1, NULL, NULL);
     DBG_PRINT("BLE event: disconnect\n");
 }
@@ -552,6 +551,8 @@ static struct bt_conn_auth_cb zjs_ble_auth_cb_display = {
 static void zjs_ble_ready_c_callback(void *handle, void* argv)
 {
     jerry_value_t arg = jerry_create_string((jerry_char_t *)"poweredOn");
+    // FIXME: arg should be released after this call, or else it needs to be
+    //        saved somewhere to be released later, like in a handle/post
     zjs_trigger_event(ble_conn.ble_obj, "stateChange", &arg, 1, NULL, NULL);
     DBG_PRINT("BLE event: stateChange - poweredOn");
 }
@@ -748,6 +749,7 @@ static jerry_value_t zjs_ble_start_advertising(const jerry_value_t function_obj,
             ERR_PRINT("SIZE: %lu\n", size);
             return zjs_error("zjs_ble_adv_start: unexpected uuid length");
         }
+        jerry_release_value(uuid);
 
         uint8_t bytes[2];
         if (!zjs_hex_to_byte(ubuf + 2, &bytes[0]) ||
@@ -761,12 +763,17 @@ static jerry_value_t zjs_ble_start_advertising(const jerry_value_t function_obj,
         index++;
     }
 
+    // FIXME: If we're really running this synchronously, why are we sending
+    //   back the results asynchronously through hoops?
     int err = bt_le_adv_start(BT_LE_ADV_CONN, ad, ARRAY_SIZE(ad),
                               sd, ARRAY_SIZE(sd));
     jerry_value_t error = err ? zjs_error("advertising failed") :
                                 jerry_create_null();
 
-    zjs_trigger_event(ble_conn.ble_obj, "advertisingStart", &error, 1, NULL, NULL);
+    // FIXME: error should be released after this call, or else it needs to be
+    //        saved somewhere to be released later, like in a handle/post
+    zjs_trigger_event(ble_conn.ble_obj, "advertisingStart", &error,
+                      1, NULL, NULL);
     DBG_PRINT("BLE event: adveristingStart\n");
 
     zjs_free(url_frame);
@@ -798,6 +805,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
 
     jerry_value_t v_array = zjs_get_property(chrc_obj, "properties");
     if (!jerry_value_is_array(v_array)) {
+        jerry_release_value(v_array);
         ERR_PRINT("properties is empty or not array\n");
         return false;
     }
@@ -806,6 +814,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
         jerry_value_t v_property = jerry_get_property_by_index(v_array, i);
 
         if (!jerry_value_is_string(v_property)) {
+            jerry_release_value(v_property);
             ERR_PRINT("property is not string\n");
             return false;
         }
@@ -814,6 +823,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
         jerry_size_t size = MAX_NAME_LENGTH;
         char name[MAX_NAME_LENGTH];
         zjs_copy_jstring(v_property, name, &size);
+        jerry_release_value(v_property);
 
         if (!strcmp(name, "read")) {
             chrc->flags |= BT_GATT_CHRC_READ;
@@ -837,12 +847,14 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
         jerry_value_t v_desc = jerry_get_property_by_index(v_array, i);
 
         if (!jerry_value_is_object(v_desc)) {
+            jerry_release_value(v_desc);
             ERR_PRINT("not valid descriptor object\n");
             return false;
         }
 
         char desc_uuid[ZJS_BLE_UUID_LEN];
         if (!zjs_obj_get_string(v_desc, "uuid", desc_uuid, ZJS_BLE_UUID_LEN)) {
+            jerry_release_value(v_desc);
             ERR_PRINT("descriptor uuid doesn't exist\n");
             return false;
         }
@@ -851,9 +863,15 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
             // Support CUD only, ignore all other type of descriptors
             jerry_value_t v_value = zjs_get_property(v_desc, "value");
             if (jerry_value_is_string(v_value)) {
-                chrc->cud_value = jerry_acquire_value(v_value);
+                // transfer ownership, free cud_value later
+                chrc->cud_value = v_value;
+            }
+            else {
+                jerry_release_value(v_value);
             }
         }
+
+        jerry_release_value(v_desc);
     }
     jerry_release_value(v_array);
 
@@ -865,6 +883,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
     } else {
         chrc->read_cb.id = -1;
     }
+    jerry_release_value(v_func);
 
     v_func = zjs_get_property(chrc_obj, "onWriteRequest");
     if (jerry_value_is_function(v_func)) {
@@ -873,6 +892,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
     } else {
         chrc->write_cb.id = -1;
     }
+    jerry_release_value(v_func);
 
     v_func = zjs_get_property(chrc_obj, "onSubscribe");
     if (jerry_value_is_function(v_func)) {
@@ -881,6 +901,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
     } else {
         chrc->subscribe_cb.id = -1;
     }
+    jerry_release_value(v_func);
 
     v_func = zjs_get_property(chrc_obj, "onUnsubscribe");
     if (jerry_value_is_function(v_func)) {
@@ -889,6 +910,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
     } else {
         chrc->unsubscribe_cb.id = -1;
     }
+    jerry_release_value(v_func);
 
     v_func = zjs_get_property(chrc_obj, "onNotify");
     if (jerry_value_is_function(v_func)) {
@@ -897,6 +919,7 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
     } else {
         chrc->notify_cb.id = -1;
     }
+    jerry_release_value(v_func);
 
     return true;
 }
@@ -916,23 +939,28 @@ static bool zjs_ble_parse_service(ble_service_t *service)
 
     jerry_value_t v_array = zjs_get_property(service_obj, "characteristics");
     if (!jerry_value_is_array(v_array)) {
+        jerry_release_value(v_array);
         ERR_PRINT("characteristics is empty or not array\n");
         return false;
     }
 
+    char *errmsg = NULL;
     ble_characteristic_t *previous = NULL;
     for (int i=0; i<jerry_get_array_length(v_array); i++) {
+        // FIXME: it would make sense to move these next few lines into
+        //   parse_characteristic
         jerry_value_t v_chrc = jerry_get_property_by_index(v_array, i);
-
         if (!jerry_value_is_object(v_chrc)) {
-            ERR_PRINT("characteristic is not object\n");
-            return false;
+            jerry_release_value(v_chrc);
+            errmsg = "characteristic is not object";
+            break;
         }
 
         ble_characteristic_t *chrc = zjs_malloc(sizeof(ble_characteristic_t));
         if (!chrc) {
-            ERR_PRINT("out of memory allocating ble_characteristic_t\n");
-            return false;
+            jerry_release_value(v_chrc);
+            errmsg = "out of memory allocating ble_characteristic_t";
+            break;
         }
 
         memset(chrc, 0, sizeof(ble_characteristic_t));
@@ -942,12 +970,18 @@ static bool zjs_ble_parse_service(ble_service_t *service)
                          = chrc->notify_cb.id
                          = -1;
 
-        chrc->chrc_obj = jerry_acquire_value(v_chrc);
+        // transfer ownership of v_chrc to chrc struct
+        chrc->chrc_obj = v_chrc;
         jerry_set_object_native_handle(chrc->chrc_obj, (uintptr_t)chrc, NULL);
 
+        // FIXME: All the stuff above this in the loop should move into
+        //   parse_characteristic and it should take chrc_obj instead; it would
+        //   reduce a lot of this error handling.
         if (!zjs_ble_parse_characteristic(chrc)) {
-            DBG_PRINT("failed to parse temp characteristic\n");
-            return false;
+            jerry_release_value(chrc->chrc_obj);
+            zjs_free(chrc);
+            errmsg = "failed to parse temp characteristic";
+            break;
         }
 
         // append to the list
@@ -958,6 +992,14 @@ static bool zjs_ble_parse_service(ble_service_t *service)
         else {
            previous->next = chrc;
         }
+
+        jerry_release_value(v_chrc);
+    }
+
+    jerry_release_value(v_array);
+    if (errmsg) {
+        ERR_PRINT("%s\n", errmsg);
+        return false;
     }
 
     return true;
@@ -1136,25 +1178,35 @@ static jerry_value_t zjs_ble_set_services(const jerry_value_t function_obj,
         jerry_value_t v_service = jerry_get_property_by_index(v_services, i);
 
         if (!jerry_value_is_object(v_service)) {
+            jerry_release_value(v_service);
             return zjs_error("zjs_ble_set_services: service is not object");
         }
 
         ble_service_t *service = zjs_malloc(sizeof(ble_service_t));
         if (!service) {
+            jerry_release_value(v_service);
             return zjs_error("zjs_ble_set_services: out of memory allocating ble_service_t");
         }
 
         memset(service, 0, sizeof(ble_service_t));
 
-        service->service_obj = jerry_acquire_value(v_service);
+        // transfer ownership of v_service to service struct
+        service->service_obj = v_service;
         jerry_set_object_native_handle(service->service_obj,
                                        (uintptr_t)service, NULL);
 
+        // FIXME: The parse_service should take the service_obj instead and do
+        //   all this above stuff in the loop, reducing error handling cruft.
         if (!zjs_ble_parse_service(service)) {
+            jerry_release_value(service->service_obj);
+            zjs_free(service);
             return zjs_error("zjs_ble_set_services: failed to parse service");
         }
 
         if (!zjs_ble_register_service(service)) {
+            // FIXME: it's very weird that this one error case is handled by
+            //   calling an error callback, but the rest weren't? There seems
+            //   to be no point to doing this async, again.
             success = false;
             break;
         }
@@ -1177,6 +1229,9 @@ static jerry_value_t zjs_ble_set_services(const jerry_value_t function_obj,
         if (jerry_value_has_error_flag(rval)) {
             DBG_PRINT("failed to call callback function\n");
         }
+
+        jerry_release_value(rval);
+        jerry_release_value(arg);
     }
 
     return ZJS_UNDEFINED;
@@ -1187,8 +1242,10 @@ static jerry_value_t zjs_ble_update_rssi(const jerry_value_t function_obj,
                                          const jerry_value_t argv[],
                                          const jerry_length_t argc)
 {
-    // Todo: get actual RSSI value from Zephyr Bluetooth driver
+    // TODO: get actual RSSI value from Zephyr Bluetooth driver
     jerry_value_t arg = jerry_create_number(-50);
+    // FIXME: arg should be released after this call, or else it needs to be
+    //        saved somewhere to be released later, like in a handle/post
     zjs_trigger_event(ble_conn.ble_obj, "rssiUpdate", &arg, 1, NULL, NULL);
     return ZJS_UNDEFINED;
 }
@@ -1216,6 +1273,14 @@ static jerry_value_t zjs_ble_characteristic(const jerry_value_t function_obj,
         return zjs_error("zjs_ble_characterstic: invalid arguments");
     }
 
+    // FIXME: Taking over the incoming object isn't really right; one side
+    //   effect will be if they've stored a reference to the object they
+    //   passed in, they'll see these changes to it. So eventually we should
+    //   change it. We should make sure this even works because the "this"
+    //   object will be the newly constructed object and I believe that's
+    //   really what we should be modifying. In the new zjs_error.c code I
+    //   think I've successfully implemented a fully functional constructor
+    //   as an example.
     jerry_value_t obj = jerry_acquire_value(argv[0]);
     jerry_value_t val;
 
@@ -1282,9 +1347,17 @@ jerry_value_t zjs_ble_init()
     ble_conn.ready_cb_id = zjs_add_c_callback(&ble_conn, zjs_ble_ready_c_callback);
     ble_conn.connected_cb_id = zjs_add_c_callback(&ble_conn, zjs_ble_connected_c_callback);
     ble_conn.disconnected_cb_id = zjs_add_c_callback(&ble_conn, zjs_ble_disconnected_c_callback);
-    ble_conn.ble_obj = ble_obj;
+    // FIXME: must free this in a cleanup function
+    ble_conn.ble_obj = jerry_acquire_value(ble_obj);
 
     return ble_obj;
 }
+
+void zjs_ble_cleanup()
+{
+    zjs_ble_free_services(ble_conn.services);
+    ble_conn.services = NULL;
+}
+
 #endif  // QEMU_BUILD
 #endif  // BUILD_MODULE_BLE

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -493,9 +493,8 @@ static void zjs_ble_connected_c_callback(void *handle, void* argv)
 {
     // FIXME: get real bluetooth address
     jerry_value_t arg = jerry_create_string((jerry_char_t *)"AB:CD:DF:AB:CD:EF");
-    // FIXME: arg should be released after this call, or else it needs to be
-    //        saved somewhere to be released later, like in a handle/post
     zjs_trigger_event(ble_conn.ble_obj, "accept", &arg, 1, NULL, NULL);
+    jerry_release_value(arg);
     DBG_PRINT("BLE event: accept\n");
 }
 
@@ -514,9 +513,8 @@ static void zjs_ble_disconnected_c_callback(void *handle, void* argv)
 {
     // FIXME: get real bluetooth address
     jerry_value_t arg = jerry_create_string((jerry_char_t *)"AB:CD:DF:AB:CD:EF");
-    // FIXME: arg should be released after this call, or else it needs to be
-    //        saved somewhere to be released later, like in a handle/post
     zjs_trigger_event(ble_conn.ble_obj, "disconnect", &arg, 1, NULL, NULL);
+    jerry_release_value(arg);
     DBG_PRINT("BLE event: disconnect\n");
 }
 
@@ -1244,9 +1242,8 @@ static jerry_value_t zjs_ble_update_rssi(const jerry_value_t function_obj,
 {
     // TODO: get actual RSSI value from Zephyr Bluetooth driver
     jerry_value_t arg = jerry_create_number(-50);
-    // FIXME: arg should be released after this call, or else it needs to be
-    //        saved somewhere to be released later, like in a handle/post
     zjs_trigger_event(ble_conn.ble_obj, "rssiUpdate", &arg, 1, NULL, NULL);
+    jerry_release_value(arg);
     return ZJS_UNDEFINED;
 }
 

--- a/src/zjs_ble.h
+++ b/src/zjs_ble.h
@@ -5,7 +5,15 @@
 
 #include "jerry-api.h"
 
+/**
+ * Initialize the ble module, or reinitialize after cleanup
+ *
+ * @return BLE API object
+ */
 jerry_value_t zjs_ble_init();
+
+/** Release resources held by the ble module */
+void zjs_ble_cleanup();
 
 void zjs_ble_enable();
 

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -338,13 +338,13 @@ jerry_value_t zjs_buffer_create(uint32_t size)
     // requires: size is size of desired buffer, in bytes
     //  effects: allocates a JS Buffer object, an underlying C buffer, and a
     //             list item to track it; if any of these fail, free them all
-    //             and return NULL, otherwise return the JS object
+    //             and return undefined, otherwise return the JS object
     jerry_value_t buf_obj = jerry_create_object();
     void *buf = zjs_malloc(size);
     zjs_buffer_t *buf_item =
         (zjs_buffer_t *)zjs_malloc(sizeof(zjs_buffer_t));
 
-    if (!buf_obj || !buf || !buf_item) {
+    if (!buf || !buf_item) {
         ERR_PRINT("unable to allocate buffer\n");
         jerry_release_value(buf_obj);
         zjs_free(buf);

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -305,7 +305,8 @@ void zjs_remove_callback(zjs_callback_id id)
         if (GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_JS) {
             if (GET_JS_TYPE(cb_map[id]->flags) == JS_TYPE_SINGLE) {
                 jerry_release_value(cb_map[id]->js_func);
-            } else if (GET_JS_TYPE(cb_map[id]->flags) == JS_TYPE_LIST && cb_map[id]->func_list) {
+            } else if (GET_JS_TYPE(cb_map[id]->flags) == JS_TYPE_LIST &&
+                       cb_map[id]->func_list) {
                 int i;
                 for (i = 0; i < cb_map[id]->num_funcs; ++i) {
                     jerry_release_value(cb_map[id]->func_list[i]);
@@ -320,9 +321,10 @@ void zjs_remove_callback(zjs_callback_id id)
     }
 }
 
-void zjs_signal_callback(zjs_callback_id id, void* args, uint32_t size)
+void zjs_signal_callback(zjs_callback_id id, const void *args, uint32_t size)
 {
-    DBG_PRINT("pushing item to ring buffer. id=%d, args=%p, size=%lu\n", id, args, size);
+    DBG_PRINT("pushing item to ring buffer. id=%d, args=%p, size=%lu\n", id,
+              args, size);
     int ret = zjs_port_ring_buf_put(&ring_buffer,
                                     (uint16_t)id,
                                     0,

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -159,7 +159,7 @@ void zjs_remove_callback(zjs_callback_id id);
  * @param args          Arguments given to the JS/C callback
  * @param size          Size of arguments (in bytes)
  */
-void zjs_signal_callback(zjs_callback_id id, void* args, uint32_t size);
+void zjs_signal_callback(zjs_callback_id id, const void *args, uint32_t size);
 
 /*
  * Add/register a C callback

--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -56,6 +56,7 @@ static void print_value(const jerry_value_t value, FILE *out, bool deep,
                 }
                 jerry_value_t element = jerry_get_property_by_index(value, i);
                 print_value(element, out, false, true);
+                jerry_release_value(element);
             }
             fprintf(out, "]");
         }
@@ -245,10 +246,7 @@ static jerry_value_t console_assert(const jerry_value_t function_obj,
 
 void zjs_console_init(void)
 {
-    jerry_value_t global_obj = jerry_get_global_object();
-
     jerry_value_t console = jerry_create_object();
-
     zjs_obj_add_function(console, console_log, "log");
     zjs_obj_add_function(console, console_log, "info");
     zjs_obj_add_function(console, console_error, "error");
@@ -257,7 +255,10 @@ void zjs_console_init(void)
     zjs_obj_add_function(console, console_time_end, "timeEnd");
     zjs_obj_add_function(console, console_assert, "assert");
 
+    jerry_value_t global_obj = jerry_get_global_object();
     zjs_set_property(global_obj, "console", console);
+
+    jerry_release_value(console);
     jerry_release_value(global_obj);
 
     // initialize the time object
@@ -269,4 +270,4 @@ void zjs_console_cleanup()
     jerry_release_value(gbl_time_obj);
 }
 
-#endif
+#endif  // BUILD_MODULE_CONSOLE

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -414,7 +414,7 @@ static jerry_value_t get_listeners(const jerry_value_t function_obj,
 
     int32_t callback_id = -1;
     jerry_value_t id_prop = zjs_get_property(event_obj, "callback_id");
-    
+
     if (jerry_value_is_number(id_prop)) {
         // If there already is an event object, get the callback ID
         zjs_obj_get_int32(event_obj, "callback_id", &callback_id);

--- a/src/zjs_event.h
+++ b/src/zjs_event.h
@@ -37,18 +37,24 @@ void zjs_add_event_listener(jerry_value_t obj, const char* event, jerry_value_t 
 /**
  * Trigger an event
  *
+ * FIXME: We need to describe how the ownership of args values works; it appears
+ *        maybe the caller needs to keep them live (acquired) and then release
+ *        them in post; or could we simplify this by acquiring them ourselves
+ *        here and releasing our copies later? Then the caller would just
+ *        release theirs immediately after the zjs_trigger_event call.
+ *
  * @param obj           Object that contains the event to be triggered
  * @param event         Name of event
  * @param args          Arguments to give to the event listener as parameters
  * @param args_cnt      Number of arguments
  * @param post          Function to be called after the event is triggered
- * @param handle        A handle that is accessable in the 'post' call
+ * @param handle        A handle that is accessible in the 'post' call
  *
  * @return              True if there were listeners
  */
 bool zjs_trigger_event(jerry_value_t obj,
                        const char* event,
-                       jerry_value_t args[],
+                       const jerry_value_t *args,
                        uint32_t args_cnt,
                        zjs_post_event post,
                        void* handle);

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -267,7 +267,7 @@ static void zjs_gpio_free_cb(const uintptr_t native)
     gpio_handle_t *handle = (gpio_handle_t *)native;
     if (!handle->closed)
         zjs_gpio_close(handle);
-    
+
     zjs_free(handle);
 }
 

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -68,6 +68,7 @@ static jerry_value_t zjs_i2c_read_base(const jerry_value_t this,
         }
     }
     else {
+        jerry_release_value(buf_obj);
         return zjs_error("zjs_i2c_read_base: buffer creation failed");
     }
 

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -497,7 +497,7 @@ static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
     sensor_handle_t* handle = zjs_sensor_alloc_handle(channel);
     handle->id = zjs_add_c_callback(handle, zjs_sensor_onchange_c_callback);
     handle->channel = channel;
-    handle->sensor_obj = sensor_obj;
+    handle->sensor_obj = jerry_acquire_value(sensor_obj);
 
     // watch for the object getting garbage collected, and clean up
     jerry_set_object_native_handle(sensor_obj, (uintptr_t)handle,

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -166,6 +166,7 @@ static jerry_value_t uart_write(const jerry_value_t function_obj,
         jerry_value_t error = make_uart_error("TypeMismatchError",
                 "first parameter must be a Buffer");
         zjs_reject_promise(promise, &error, 1);
+        jerry_release_value(error);
         return promise;
     }
 
@@ -231,6 +232,7 @@ static jerry_value_t uart_init(const jerry_value_t function_obj,
         jerry_value_t error = make_uart_error("TypeMismatchError",
                 "first parameter must be UART options");
         zjs_reject_promise(promise, &error, 1);
+        jerry_release_value(error);
         return promise;
     }
 
@@ -241,21 +243,24 @@ static jerry_value_t uart_init(const jerry_value_t function_obj,
     char port[size];
 
     zjs_copy_jstring(port_val, port, &size);
+    jerry_release_value(port_val);
+
     if (!size) {
         DBG_PRINT("port length is too long\n");
         jerry_value_t error = make_uart_error("TypeMismatchError",
                 "port length is too long");
         zjs_reject_promise(promise, &error, 1);
+        jerry_release_value(error);
         return promise;
     }
-
-    jerry_release_value(port_val);
 
     jerry_value_t baud_val = zjs_get_property(argv[0], "baud");
 
     if (jerry_value_is_number(baud_val)) {
         baud = (int)jerry_get_number_value(baud_val);
     }
+    jerry_release_value(baud_val);
+
     for (i = 0; i < (sizeof(device_map) / sizeof(device_map[0])); ++i) {
         // FIXME: we allowed 16-char string above but are only looking at 4?
         if (strncmp(device_map[0].port, port, 4) == 0) {
@@ -268,6 +273,7 @@ static jerry_value_t uart_init(const jerry_value_t function_obj,
         jerry_value_t error = make_uart_error("NotFoundError",
                 "could not find port provided");
         zjs_reject_promise(promise, &error, 1);
+        jerry_release_value(error);
         return promise;
     }
 
@@ -310,6 +316,7 @@ static jerry_value_t uart_init(const jerry_value_t function_obj,
             jerry_value_t error = make_uart_error("InternalError",
                     "baud could not be set");
             zjs_reject_promise(promise, &error, 1);
+            jerry_release_value(error);
             return promise;
         }
     }

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -124,7 +124,7 @@ bool zjs_obj_get_boolean(jerry_value_t obj, const char *name, bool *flag)
         *flag = jerry_get_boolean_value(value);
         rval = true;
     }
-    
+
     jerry_release_value(value);
     return rval;
 }

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -118,15 +118,15 @@ bool zjs_obj_get_boolean(jerry_value_t obj, const char *name, bool *flag)
     //             boolean
     //  effects: retrieves field specified by name as a boolean
     jerry_value_t value = zjs_get_property(obj, name);
-    if (jerry_value_has_error_flag(value))
-        return false;
+    bool rval = false;
 
-    if (!jerry_value_is_boolean(value))
-        return false;
-
-    *flag = jerry_get_boolean_value(value);
+    if (!jerry_value_has_error_flag(value) && jerry_value_is_boolean(value)) {
+        *flag = jerry_get_boolean_value(value);
+        rval = true;
+    }
+    
     jerry_release_value(value);
-    return true;
+    return rval;
 }
 
 bool zjs_obj_get_string(jerry_value_t obj, const char *name, char *buffer,
@@ -139,11 +139,9 @@ bool zjs_obj_get_string(jerry_value_t obj, const char *name, char *buffer,
     //             a null terminator into buffer and returns true; otherwise,
     //             returns false
     jerry_value_t value = zjs_get_property(obj, name);
-    if (jerry_value_has_error_flag(value))
-        return false;
-
     bool rval = false;
-    if (jerry_value_is_string(value)) {
+
+    if (!jerry_value_has_error_flag(value) && jerry_value_is_string(value)) {
         jerry_size_t size = len;
         zjs_copy_jstring(value, buffer, &size);
         if (size)
@@ -159,12 +157,15 @@ bool zjs_obj_get_double(jerry_value_t obj, const char *name, double *num)
     // requires: obj is an existing JS object, value name should exist as number
     //  effects: retrieves field specified by name as a uint32
     jerry_value_t value = zjs_get_property(obj, name);
-    if (jerry_value_has_error_flag(value))
-        return false;
+    bool rval = false;
 
-    *num = jerry_get_number_value(value);
+    if (!jerry_value_has_error_flag(value)) {
+        *num = jerry_get_number_value(value);
+        rval = true;
+    }
+
     jerry_release_value(value);
-    return true;
+    return rval;
 }
 
 bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, uint32_t *num)
@@ -172,12 +173,15 @@ bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, uint32_t *num)
     // requires: obj is an existing JS object, value name should exist as number
     //  effects: retrieves field specified by name as a uint32
     jerry_value_t value = zjs_get_property(obj, name);
-    if (jerry_value_has_error_flag(value))
-        return false;
+    bool rval = false;
 
-    *num = (uint32_t)jerry_get_number_value(value);
+    if (!jerry_value_has_error_flag(value)) {
+        *num = (uint32_t)jerry_get_number_value(value);
+        rval = true;
+    }
+
     jerry_release_value(value);
-    return true;
+    return rval;
 }
 
 bool zjs_obj_get_int32(jerry_value_t obj, const char *name, int32_t *num)
@@ -185,12 +189,15 @@ bool zjs_obj_get_int32(jerry_value_t obj, const char *name, int32_t *num)
     // requires: obj is an existing JS object, value name should exist as number
     //  effects: retrieves field specified by name as a int32
     jerry_value_t value = zjs_get_property(obj, name);
-    if (jerry_value_has_error_flag(value))
-        return false;
+    bool rval = false;
 
-    *num = (int32_t)jerry_get_number_value(value);
+    if (!jerry_value_has_error_flag(value)) {
+        *num = (int32_t)jerry_get_number_value(value);
+        rval = true;
+    }
+
     jerry_release_value(value);
-    return true;
+    return rval;
 }
 
 void zjs_copy_jstring(jerry_value_t jstr, char *buffer, jerry_size_t *maxlen)


### PR DESCRIPTION
The document 06.REFERENCE-COUNTING.md in JerryScript makes it clear
now how and when jerry_value_t items must be released. In particular,
you're not responsible to release values passed in to you, but any
function that returns a value is giving you a "live" reference to
it that you must release. But when you return from a native function,
you transfer ownership of the returned value back to JavaScript.

In particular, even the error value that functions return is supposed
to be released, which we rarely if ever did before this review.

Reviewed all code in src/*.c except for the OCF files which were too
foreign to me to address correctly.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>