### PR TITLE
Enabled buffer support on Linux

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -31,7 +31,8 @@ include Makefile.ocf_linux
 
 LINUX_DEFINES +=	-DOC_CLIENT \
 			-DOC_SERVER \
-			-DBUILD_MODULE_OCF
+			-DBUILD_MODULE_OCF \
+			-DBUILD_MODULE_BUFFER
 endif
 
 .PHONY: all

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -288,7 +288,7 @@ static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_va
         }
 
         char arg4_str[arg4_sz];
-        char utf8_str[4];
+        char utf8_str[5];
         strcpy(utf8_str, "utf8");
         uint8_t utf8 = strcmp(arg4_str, utf8_str);
 


### PR DESCRIPTION
 - Fixed minor overflow bug that Linux compiler warned about.

Signed-off-by: James Prestwood <james.prestwood@intel.com>