### PR TITLE
[docs] Alphabetize API document list

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -9,9 +9,9 @@ I/O
 
 [GPIO](./gpio.md)
 
-[PWM](./pwm.md)
-
 [I2C](./i2c.md)
+
+[PWM](./pwm.md)
 
 [UART](./uart.md)
 
@@ -33,10 +33,10 @@ General
 -------
 [Buffer](./buffer.md)
 
-[Performance](./performance.md)
-
-[Timers](./timers.md)
+[Console](./console.md)
 
 [Events](./events.md)
 
-[Console](./console.md)
+[Performance](./performance.md)
+
+[Timers](./timers.md)


### PR DESCRIPTION
Always a good idea to alphabetize: helps the users find what they're looking
for, helps us avoid duplication when the list gets longer, etc.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>