### PR TITLE
[util] Serialize data function

### DIFF
--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -161,20 +161,22 @@ static jerry_value_t uart_write(const jerry_value_t function_obj,
 
     zjs_make_promise(promise, NULL, NULL);
 
-    if (!jerry_value_is_object(argv[0])) {
-        DBG_PRINT("first parameter must be a Buffer");
+    uint32_t len;
+    void* data = zjs_serialize_data(argv[0], NULL, &len);
+    if (!data) {
+        ERR_PRINT("invalid parameters\n");
         jerry_value_t error = make_uart_error("TypeMismatchError",
-                "first parameter must be a Buffer");
+                                              "first parameter must be a Buffer");
         zjs_reject_promise(promise, &error, 1);
         jerry_release_value(error);
         return promise;
     }
 
-    zjs_buffer_t* buffer = zjs_buffer_find(argv[0]);
-
-    write_data(uart_dev, (const char*)buffer->buffer, buffer->bufsize);
+    write_data(uart_dev, (const char*)data, len);
 
     zjs_fulfill_promise(promise, NULL, 0);
+
+    zjs_free(data);
 
     return promise;
 }

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -97,4 +97,18 @@ void zjs_default_convert_pin(uint32_t orig, int *dev, int *pin);
 uint16_t zjs_compress_32_to_16(uint32_t num);
 uint32_t zjs_uncompress_16_to_32(uint16_t num);
 
+/**
+ * Serialize a jerry_value_t into a buffer. The returned buffer must be freed
+ * after use.
+ *
+ * @param value     Value to serialize. This can be a Buffer, Array (of bytes)
+ *                  or String.
+ * @param maxLen    Maximum length of data to serialize. If the length does not
+ *                  matter you can specify 0 or NULL.
+ * @param actualLen Actual length of buffer
+ *
+ * @return          Pointer to serialized data (must be freed).
+ */
+void* zjs_serialize_data(jerry_value_t value, uint32_t* maxLen, uint32_t* actualLen);
+
 #endif  // __zjs_util_h__


### PR DESCRIPTION
 - Can be used to convert any serializable jerry_value_t into a C buffer
   (Buffers, Strings, and Arrays (of bytes) supported)

Signed-off-by: James Prestwood <james.prestwood@intel.com>