### PR TITLE
[make] Made make HW support more consistent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,14 @@ ifneq ($(shell pwd)/deps/zephyr, $(ZEPHYR_BASE))
 $(info Note: ZEPHYR_BASE is set outside the current ZJS tree ($(ZEPHYR_BASE)))
 endif
 endif
+
+.PHONY: all
+ifeq ($(BOARD), linux)
+all: linux
+else
+all: zephyr arc
+endif
+
 # Build for zephyr, default target
 .PHONY: zephyr
 zephyr: analyze generate jerryscript
@@ -96,9 +104,6 @@ endif
 	fi
 	@sed -i '/This is a generated file/r./zjs.conf.tmp' src/Makefile
 
-.PHONY: all
-all: zephyr arc
-
 # Update dependency repos
 .PHONY: update
 update:
@@ -132,13 +137,14 @@ endif
 # Explicit clean
 .PHONY: clean
 clean:
-	@if [ -d $(ZEPHYR_SDK_INSTALL_DIR) ]; then \
-		rm -rf $(JERRY_BASE)/build/$(BOARD)/; \
-		rm -f outdir/$(BOARD)/libjerry-core.a; \
-		make -f Makefile.zephyr clean BOARD=$(BOARD); \
-		cd arc/; make clean; \
-	fi
+ifeq ($(BOARD), linux)
 	make -f Makefile.linux clean
+else
+	rm -rf $(JERRY_BASE)/build/$(BOARD)/; \
+	rm -f outdir/$(BOARD)/libjerry-core.a; \
+	make -f Makefile.zephyr clean BOARD=$(BOARD); \
+	cd arc/; make clean;
+endif
 	@rm -f src/*.o
 	@rm -f src/zjs_script_gen.c
 	@rm -f src/zjs_snapshot_gen.c

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -11,7 +11,7 @@ UNAME := $(shell uname)
 ifeq ($(UNAME),Darwin)
 COPY=rsync -R
 else
-COPY=cp --parents
+COPY=cp --parents --no-clobber
 # Only build OCF on linux, until iotivity-constrained is fixed on Mac
 CORE_SRC +=	src/zjs_ocf_common.c \
 		src/zjs_ocf_client.c \
@@ -136,4 +136,5 @@ linux: setup linux_copy $(BUILD_OBJ)
 
 .PHONY: clean
 clean:
-	rm -f $(BUILD_OBJ)
+	rm -rf $(ZJS_BASE)/outdir/linux/
+	rm -rf $(JERRY_BASE)/build/lib/


### PR DESCRIPTION
 - To clean, you must specify the BOARD you want to clean for. Not specifying
   BOARD will result in the default (Arduino 101) getting cleaned.
 - To build for Linux, you now specify BOARD=linux. This matches all the other
   targets. To clean for linux you must also specify BOARD=linux.
 - Fixed the jerryscript clean issue where the library was not getting removed
   during a clean, hence JrS would use the old stale library.

Signed-off-by: James Prestwood <james.prestwood@intel.com>