### PR TITLE
[buffer] Fix bug with uninitialized buffer in write_string

### DIFF
--- a/samples/I2C.js
+++ b/samples/I2C.js
@@ -115,7 +115,7 @@ function changeRGB(red, green, blue) {
     var greenData = new Buffer([REGISTER_G, green]);
     var blueData = new Buffer([REGISTER_B, blue]);
 
-    // Send messages as close together as possible so that the color change is smoother
+    // Send messages as close together as possible so color change is smoother
     i2cDevice.write(GROVE_RGB_BACKLIGHT_ADDR, blueData);
     i2cDevice.write(GROVE_RGB_BACKLIGHT_ADDR, redData);
     i2cDevice.write(GROVE_RGB_BACKLIGHT_ADDR, greenData);
@@ -123,9 +123,10 @@ function changeRGB(red, green, blue) {
 
 function writeWord() {
     var wordBuffer = new Buffer(7);
-        // The first byte in the buffer is for the register address,
-        // which is where the word is going to be written to.
-        wordBuffer.writeUInt8(GLCD_CMD_SET_CGRAM_ADDR, 0);
+
+    // The first byte in the buffer is for the register address,
+    // which is where the word is going to be written to.
+    wordBuffer.writeUInt8(GLCD_CMD_SET_CGRAM_ADDR, 0);
     if (hello) {
         // Append the text we want to print after that
         wordBuffer.write("HELLO!", 1);
@@ -146,7 +147,6 @@ function writeWord() {
 }
 
 // Main function
-
 init();
 
 // Alternate writing HELLO! and WORLD! forever

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -280,15 +280,14 @@ static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_va
 
     // Check if the encoding string is anything other than utf8
     if (argc > 3) {
-        const char *utf8_encoding = "utf8";
-        int utf8_len = strlen(utf8_encoding);
-        jerry_size_t size = utf8_len + 1;
-        char *encoding = zjs_alloc_from_jstring(argv[3], &size);
+        char *encoding = zjs_alloc_from_jstring(argv[3], NULL);
         if (!encoding) {
             return zjs_error("zjs_buffer_write_string: allocation failure");
         }
 
         // ask for one more char than needed to make sure not just prefix match
+        const char *utf8_encoding = "utf8";
+        int utf8_len = strlen(utf8_encoding);
         int rval = strncmp(encoding, utf8_encoding, utf8_len + 1);
         zjs_free(encoding);
         if (rval != 0) {

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -280,20 +280,17 @@ static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_va
 
     // Check if the encoding string is anything other than utf8
     if (argc > 3) {
-        jerry_value_t arg4 = argv[3];
-        jerry_size_t arg4_sz = jerry_get_string_size(arg4);
-
-        if (arg4_sz > 4096) {
-            return zjs_error("zjs_buffer_write_string: encoding arg string is too long");
+        // ask for one more char than needed to make sure not just prefix match
+        jerry_size_t size = 5;
+        char *encoding = zjs_alloc_from_jstring(argv[3], &size);
+        if (!encoding) {
+            return zjs_error("zjs_buffer_write_string: allocation failure");
         }
 
-        char arg4_str[arg4_sz];
-        char utf8_str[5];
-        strcpy(utf8_str, "utf8");
-        uint8_t utf8 = strcmp(arg4_str, utf8_str);
-
-        if (utf8 != 0) {
-            return zjs_error("zjs_buffer_write_string: only utf8 encoding is supported");
+        int rval = strncmp(encoding, "utf8", 5);
+        zjs_free(encoding);
+        if (rval != 0) {
+            return NOTSUPPORTED_ERROR("zjs_buffer_write_string: only utf8 encoding supported");
         }
     }
 

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -280,14 +280,16 @@ static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_va
 
     // Check if the encoding string is anything other than utf8
     if (argc > 3) {
-        // ask for one more char than needed to make sure not just prefix match
-        jerry_size_t size = 5;
+        const char *utf8_encoding = "utf8";
+        int utf8_len = strlen(utf8_encoding);
+        jerry_size_t size = utf8_len + 1;
         char *encoding = zjs_alloc_from_jstring(argv[3], &size);
         if (!encoding) {
             return zjs_error("zjs_buffer_write_string: allocation failure");
         }
 
-        int rval = strncmp(encoding, "utf8", 5);
+        // ask for one more char than needed to make sure not just prefix match
+        int rval = strncmp(encoding, utf8_encoding, utf8_len + 1);
         zjs_free(encoding);
         if (rval != 0) {
             return NOTSUPPORTED_ERROR("zjs_buffer_write_string: only utf8 encoding supported");


### PR DESCRIPTION
This bug was hit if you tried to pass the fourth encoding parameter
to the function; it would get an error even if you passed 'utf8'.

Also, cleaned up indentation issue in I2C.js.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>