### PR TITLE
[zjs_callbacks] Automatically release JS callback args.

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -511,7 +511,12 @@ uint8_t zjs_service_callbacks(void)
                         break;
                     }
                     DBG_PRINT("calling callback with args. id=%u, args=%p, sz=%u, ret=%i\n", id, data, sz, ret);
+                    bool is_js = GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_JS;
                     zjs_call_callback(id, data, sz);
+                    if (is_js) {
+                        for (int i = 0; i < sz; i++)
+                            jerry_release_value(data[i]);
+                    }
                 } else if (ret == 0) {
                     // item in ring buffer with size == 0, no args
                     DBG_PRINT("calling callback with no args, original vals id=%u, size=%u, ret=%i\n", id, size, ret);


### PR DESCRIPTION
If not done like that, any JS callback which takes arguments must be
accompanied by "post" function which will release those arguments,
which is quite cumbersome.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>