### PR TITLE
[callbacks] Correct lifetime of jerry_value_t items in callbacks

### DIFF
--- a/src/zjs_ble.h
+++ b/src/zjs_ble.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_ble_h__
 #define __zjs_ble_h__

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -1,4 +1,5 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
+
 #ifndef SRC_ZJS_CALLBACKS_H_
 #define SRC_ZJS_CALLBACKS_H_
 
@@ -154,6 +155,14 @@ void zjs_remove_callback(zjs_callback_id id);
  * called only once, and will NOT remove the callback from the list. You can
  * signal callbacks multiple times, but if the callback has not been serviced
  * between signaling, it will only get called once.
+ *
+ * For a JS callback, the arguments are of type jerry_value_t and they will be
+ * acquired by the callback module and released when the callback fires. So the
+ * caller should release its copies as usual.
+ *
+ * For a C callback, if there is a pointer among the arguments, it is opaque
+ * to the callback module and must be managed by the caller and perhaps freed
+ * in the post-callback function if appropriate.
  *
  * @param id            ID returned from zjs_add_callback
  * @param args          Arguments given to the JS/C callback

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #include "zjs_event.h"
 #include "zjs_callbacks.h"

--- a/src/zjs_event.h
+++ b/src/zjs_event.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_event_h__
 #define __zjs_event_h__

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -1,4 +1,5 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
+
 #ifdef BUILD_MODULE_GPIO
 // Zephyr includes
 #include <zephyr.h>
@@ -147,7 +148,8 @@ static void gpio_zephyr_callback(struct device *port,
     if ((handle->edge_both && handle->value != handle->last) ||
         !handle->edge_both) {
         // Signal the C callback, where we call the JS callback
-        zjs_signal_callback(handle->callbackId, &handle->value, 4);
+        zjs_signal_callback(handle->callbackId, &handle->value,
+                            sizeof(uint32_t));
         handle->last = handle->value;
     }
 }

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #include <string.h>
 #include "zjs_util.h"
@@ -150,7 +150,8 @@ void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
                                                 handle,
                                                 post_promise);
 
-        zjs_signal_callback(handle->then_id, argv, argc * sizeof(jerry_value_t));
+        zjs_signal_callback(handle->then_id, argv,
+                            argc * sizeof(jerry_value_t));
 
         DBG_PRINT("fulfilling promise, obj=%lu, then_id=%d, argv=%p, nargs=%lu\n",
                   obj, handle->then_id, argv, argc);
@@ -186,7 +187,8 @@ void zjs_reject_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
                                                  handle,
                                                  post_promise);
 
-        zjs_signal_callback(handle->catch_id, argv, argc * sizeof(jerry_value_t));
+        zjs_signal_callback(handle->catch_id, argv,
+                            argc * sizeof(jerry_value_t));
 
         DBG_PRINT("rejecting promise, obj=%lu, catch_id=%d, argv=%p, nargs=%lu\n",
                   obj, handle->catch_id, argv, argc);

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef ZJS_LINUX_BUILD
 // Zephyr includes
@@ -218,7 +218,8 @@ uint8_t zjs_timers_process_events()
             // timer has expired, signal the callback
             DBG_PRINT("signaling timer. id=%d, argv=%p, argc=%lu\n",
                     tm->callback_id, tm->argv, tm->argc);
-            zjs_signal_callback(tm->callback_id, tm->argv, tm->argc * sizeof(jerry_value_t));
+            zjs_signal_callback(tm->callback_id, tm->argv,
+                                tm->argc * sizeof(jerry_value_t));
 
             // reschedule or remove timer
             if (tm->repeat) {


### PR DESCRIPTION
Enforce rule that ring buffer owns JrS values stored in it. They are
acquired in zjs_signal_callback and released in zjs_service_callbacks.

Various other minor cleanups.

This was inadvertently left out of my patch in commit 8d6571a.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>