### PR TITLE
[bugfix] Fixing #651 to remove compiler warnings

### DIFF
--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -73,17 +73,23 @@ static jerry_value_t zjs_i2c_read_base(const jerry_value_t this,
     }
 
     if (!burst) {
-        uint8_t error_msg = zjs_i2c_handle_read((uint8_t)bus,
-                                                buf->buffer,
-                                                buf->bufsize,
-                                                (uint16_t)address);
+        int error_msg = zjs_i2c_handle_read((uint8_t)bus,
+                                            buf->buffer,
+                                            buf->bufsize,
+                                            (uint16_t)address);
+        if (error_msg != 0) {
+            ERR_PRINT("i2c_read failed with error %i\n", error_msg);
+        }
     }
     else {
-        uint8_t error_msg = zjs_i2c_handle_burst_read((uint8_t)bus,
-                                                      buf->buffer,
-                                                      buf->bufsize,
-                                                      (uint16_t)address,
-                                                      (uint16_t)register_addr);
+        int error_msg = zjs_i2c_handle_burst_read((uint8_t)bus,
+                                                  buf->buffer,
+                                                  buf->bufsize,
+                                                  (uint16_t)address,
+                                                  (uint16_t)register_addr);
+        if (error_msg != 0) {
+            ERR_PRINT("i2c_read failed with error %i\n", error_msg);
+        }
     }
 
     return buf_obj;
@@ -169,13 +175,13 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
     } else {
         return zjs_error("zjs_i2c_write: missing data buffer");
     }
-    int reply;
+
     uint32_t address = (uint32_t)jerry_get_number_value(argv[0]);
 
-    uint8_t error_msg = zjs_i2c_handle_write((uint8_t)bus,
-                                             dataBuf->buffer,
-                                             dataBuf->bufsize,
-                                             (uint16_t)address);
+    int error_msg = zjs_i2c_handle_write((uint8_t)bus,
+                                         dataBuf->buffer,
+                                         dataBuf->bufsize,
+                                         (uint16_t)address);
 
     return jerry_create_number(error_msg);
 }
@@ -224,8 +230,9 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
         return zjs_error("zjs_i2c_open: missing required field (speed)");
     }
 
-    uint8_t error_msg = zjs_i2c_handle_open((uint8_t)bus);
-
+    if (zjs_i2c_handle_open((uint8_t)bus)) {
+        return zjs_error("zjs_i2c_open: failed to open connection to I2C bus");
+    }
     // create the I2C object
     jerry_value_t i2c_obj = jerry_create_object();
     jerry_set_prototype(i2c_obj, zjs_i2c_prototype);

--- a/src/zjs_i2c_handler.c
+++ b/src/zjs_i2c_handler.c
@@ -8,17 +8,16 @@
 
 static struct device *i2c_device[MAX_I2C_BUS];
 
-uint8_t zjs_i2c_handle_open(uint8_t msg_bus)
+int zjs_i2c_handle_open(uint8_t msg_bus)
 {
-    uint8_t error_code = 0;
+    int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {
         char bus[6];
         snprintf(bus, 6, "I2C_%i", msg_bus);
         i2c_device[msg_bus] = device_get_binding(bus);
 
         if (!i2c_device[msg_bus]) {
-                ZJS_PRINT("I2C bus %s not found.\n", bus);
-                error_code = 1;
+                ERR_PRINT("I2C bus %s not found.\n", bus);
         } else {
             /* TODO remove these hard coded numbers
              * once the config API is made */
@@ -27,23 +26,22 @@ uint8_t zjs_i2c_handle_open(uint8_t msg_bus)
             cfg.bits.use_10_bit_addr = 0;
             cfg.bits.speed = I2C_SPEED_STANDARD;
             cfg.bits.is_master_device = 1;
+            error_code = i2c_configure(i2c_device[msg_bus], cfg.raw);
 
-            if (i2c_configure(i2c_device[msg_bus], cfg.raw) != 0) {
-                ZJS_PRINT("I2C bus %s configure failed.\n", bus);
-                error_code = 1;
+            if (error_code != 0) {
+                ERR_PRINT("I2C bus %s configure failed with %i.\n", bus, error_code);
             }
         }
     } else {
-        ZJS_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
-        error_code = 1;
+        ERR_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
     }
     return error_code;
 }
 
-uint8_t zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data,
-                             uint32_t length, uint16_t address)
+int zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data,
+                         uint32_t length, uint16_t address)
 {
-    uint8_t error_code = 0;
+    int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {
         // Write has to come after an Open I2C message
         if (i2c_device[msg_bus]) {
@@ -52,64 +50,61 @@ uint8_t zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data,
                                    length,
                                    address);
 
-                if (error_code != 0)
-                    ZJS_PRINT("i2c_write failed!\n");
+                if (error_code != 0) {
+                    ERR_PRINT("i2c_write failed with %i\n", error_code);
+                }
         }
         else {
-            ZJS_PRINT("no I2C device is ready yet\n");
-            error_code = 1;
+            ERR_PRINT("no I2C device is ready yet\n");
         }
+    } else {
+        ERR_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
     }
     return error_code;
 }
 
-uint8_t zjs_i2c_handle_read(uint8_t msg_bus, uint8_t *data,
-                            uint32_t length, uint16_t address)
+int zjs_i2c_handle_read(uint8_t msg_bus, uint8_t *data, uint32_t length,
+                        uint16_t address)
 {
-    uint8_t error_code = 0;
+    int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {
         // Read has to come after an Open I2C message
         if (i2c_device[msg_bus]) {
 
-            int reply = i2c_read(i2c_device[msg_bus],
-                                 data,
-                                 length,
-                                 address);
-
-            if (reply < 0) {
-                error_code = 1;
-            }
+            error_code = i2c_read(i2c_device[msg_bus],
+                                  data,
+                                  length,
+                                  address);
         }
         else {
-            ZJS_PRINT("No I2C device is ready yet\n");
-            error_code = 1;
+            ERR_PRINT("No I2C device is ready yet\n");
         }
+    }
+    else {
+        ERR_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
     }
     return error_code;
 }
 
-uint8_t zjs_i2c_handle_burst_read(uint8_t msg_bus, uint8_t *data,
-                                  uint32_t length, uint16_t address,
-                                  uint16_t register_addr)
+int zjs_i2c_handle_burst_read(uint8_t msg_bus, uint8_t *data, uint32_t length,
+                              uint16_t address, uint16_t register_addr)
 {
-    uint8_t error_code = 0;
+    int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {
         // Burst read has to come after an Open I2C message
         if (i2c_device[msg_bus]) {
-           int reply = i2c_burst_read(i2c_device[msg_bus],
-                                      address,
-                                      register_addr,
-                                      data,
-                                      length);
-
-            if (reply < 0) {
-                error_code = 1;
-            }
+            error_code = i2c_burst_read(i2c_device[msg_bus],
+                                        address,
+                                        register_addr,
+                                        data,
+                                        length);
         }
         else {
-            ZJS_PRINT("No I2C device is ready yet\n");
-            error_code = 1;
+            ERR_PRINT("No I2C device is ready yet\n");
         }
+    }
+    else {
+        ERR_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
     }
     return error_code;
 }

--- a/src/zjs_i2c_handler.h
+++ b/src/zjs_i2c_handler.h
@@ -4,9 +4,9 @@
 
 #include <i2c.h>
 
-uint8_t zjs_i2c_handle_open(uint8_t msg_bus);
-uint8_t zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address);
-uint8_t zjs_i2c_handle_read(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address);
-uint8_t zjs_i2c_handle_burst_read(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address, uint16_t register_addr);
+int zjs_i2c_handle_open(uint8_t msg_bus);
+int zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address);
+int zjs_i2c_handle_read(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address);
+int zjs_i2c_handle_burst_read(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address, uint16_t register_addr);
 
 #endif  // __zjs_i2c_handler_h__

--- a/src/zjs_i2c_ipm_handler.c
+++ b/src/zjs_i2c_ipm_handler.c
@@ -2,6 +2,7 @@
 #include "zjs_i2c_handler.h"
 #include "zjs_ipm.h"
 #include "zjs_common.h"
+#include <string.h>
 
 static struct k_sem i2c_sem;
 #define ZJS_I2C_TIMEOUT_TICKS                      5000
@@ -55,7 +56,7 @@ void zjs_i2c_ipm_init() {
     k_sem_init(&i2c_sem, 0, 1);
 }
 
-uint8_t zjs_i2c_handle_write (uint8_t msg_bus, uint8_t *data, uint32_t length,
+int zjs_i2c_handle_write (uint8_t msg_bus, uint8_t *data, uint32_t length,
                               uint16_t address)
 {
     zjs_ipm_message_t send;
@@ -78,7 +79,7 @@ uint8_t zjs_i2c_handle_write (uint8_t msg_bus, uint8_t *data, uint32_t length,
     return send.error_code;
 }
 
-uint8_t zjs_i2c_handle_open (uint8_t msg_bus)
+int zjs_i2c_handle_open (uint8_t msg_bus)
 {
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -101,7 +102,7 @@ uint8_t zjs_i2c_handle_open (uint8_t msg_bus)
     return send.error_code;
 }
 
-uint8_t zjs_i2c_handle_read (uint8_t msg_bus, uint8_t *data, uint32_t length,
+int zjs_i2c_handle_read (uint8_t msg_bus, uint8_t *data, uint32_t length,
                              uint16_t address)
 {
     zjs_ipm_message_t send;
@@ -121,7 +122,7 @@ uint8_t zjs_i2c_handle_read (uint8_t msg_bus, uint8_t *data, uint32_t length,
     return send.error_code;
 }
 
-uint8_t zjs_i2c_handle_burst_read (uint8_t msg_bus, uint8_t *data,
+int zjs_i2c_handle_burst_read (uint8_t msg_bus, uint8_t *data,
                                    uint32_t length, uint16_t address,
                                    uint16_t register_addr)
 {


### PR DESCRIPTION
Also fixing the return type to be int, since that's what
zephyr returns.