### PR TITLE
[I2C] Fixed broken I2C and Grove LCD

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -188,6 +188,8 @@ if check_for_require i2c || check_config_file ZJS_I2C; then
     MODULES+=" -DBUILD_MODULE_I2C"
     if [ $BOARD = "arduino_101" ]; then
         echo "CONFIG_I2C=y" >> arc/prj.conf.tmp
+        echo "CONFIG_I2C_SS_0=y" >> arc/prj.conf.tmp
+        echo "CONFIG_I2C_SS_0_NAME=\"I2C_SS_0\"" >> arc/prj.conf.tmp
     else
         echo "CONFIG_I2C=y" >> prj.conf.tmp
     fi
@@ -203,6 +205,7 @@ if check_for_require grove_lcd || check_config_file ZJS_GROVE_LCD; then
         echo "CONFIG_GROVE=y" >> arc/prj.conf.tmp
         echo "CONFIG_GROVE_LCD_RGB=y" >> arc/prj.conf.tmp
         echo "CONFIG_GROVE_LCD_RGB_INIT_PRIORITY=90" >> arc/prj.conf.tmp
+        echo "CONFIG_GROVE_LCD_RGB_I2C_MASTER_DEV_NAME=\"I2C_SS_0\"" >> arc/prj.conf.tmp
     else
         echo "CONFIG_I2C=y" >> prj.conf.tmp
         echo "CONFIG_GROVE=y" >> prj.conf.tmp

--- a/src/zjs_i2c_handler.c
+++ b/src/zjs_i2c_handler.c
@@ -12,8 +12,8 @@ int zjs_i2c_handle_open(uint8_t msg_bus)
 {
     int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {
-        char bus[6];
-        snprintf(bus, 6, "I2C_%i", msg_bus);
+        char bus[9];
+        snprintf(bus, 9, "I2C_SS_%i", msg_bus);
         i2c_device[msg_bus] = device_get_binding(bus);
 
         if (!i2c_device[msg_bus]) {
@@ -33,7 +33,7 @@ int zjs_i2c_handle_open(uint8_t msg_bus)
             }
         }
     } else {
-        ERR_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
+        ERR_PRINT("I2C bus I2C_SS_%i is not a valid I2C bus.\n", msg_bus);
     }
     return error_code;
 }
@@ -58,7 +58,7 @@ int zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data,
             ERR_PRINT("no I2C device is ready yet\n");
         }
     } else {
-        ERR_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
+        ERR_PRINT("I2C bus I2C_SS_%i is not a valid I2C bus.\n", msg_bus);
     }
     return error_code;
 }
@@ -81,7 +81,7 @@ int zjs_i2c_handle_read(uint8_t msg_bus, uint8_t *data, uint32_t length,
         }
     }
     else {
-        ERR_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
+        ERR_PRINT("I2C bus I2C_SS_%i is not a valid I2C bus.\n", msg_bus);
     }
     return error_code;
 }
@@ -104,7 +104,7 @@ int zjs_i2c_handle_burst_read(uint8_t msg_bus, uint8_t *data, uint32_t length,
         }
     }
     else {
-        ERR_PRINT("I2C bus I2C_%i is not a valid I2C bus.\n", msg_bus);
+        ERR_PRINT("I2C bus I2C_SS_%i is not a valid I2C bus.\n", msg_bus);
     }
     return error_code;
 }


### PR DESCRIPTION
The I2C device driver name for sensor sub-system is "I2C_SS_0", not "I2C_0",
updating both I2C and Grove LCD to use the new driver name

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>