### PR TITLE
[build] Add passthrough support for Zephyr ram/rom_report targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,26 @@ endif
 A101BIN = outdir/arduino_101/zephyr.bin
 A101SSBIN = arc/outdir/arduino_101_sss/zephyr.bin
 
+.PHONY: ram_report
+ram_report:
+	@make -f Makefile.zephyr	BOARD=$(BOARD) \
+					VARIANT=$(VARIANT) \
+					MEM_STATS=$(MEM_STATS) \
+					CB_STATS=$(CB_STATS) \
+					PRINT_FLOAT=$(PRINT_FLOAT) \
+					SNAPSHOT=$(SNAPSHOT) \
+					ram_report
+
+.PHONY: rom_report
+rom_report:
+	@make -f Makefile.zephyr	BOARD=$(BOARD) \
+					VARIANT=$(VARIANT) \
+					MEM_STATS=$(MEM_STATS) \
+					CB_STATS=$(CB_STATS) \
+					PRINT_FLOAT=$(PRINT_FLOAT) \
+					SNAPSHOT=$(SNAPSHOT) \
+					ram_report
+
 # Build for zephyr, default target
 .PHONY: zephyr
 zephyr: analyze generate jerryscript $(ARC)

--- a/Makefile
+++ b/Makefile
@@ -83,31 +83,28 @@ A101BIN = outdir/arduino_101/zephyr.bin
 A101SSBIN = arc/outdir/arduino_101_sss/zephyr.bin
 
 .PHONY: ram_report
-ram_report:
+ram_report: zephyr
 	@make -f Makefile.zephyr	BOARD=$(BOARD) \
 					VARIANT=$(VARIANT) \
-					MEM_STATS=$(MEM_STATS) \
 					CB_STATS=$(CB_STATS) \
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT) \
 					ram_report
 
 .PHONY: rom_report
-rom_report:
+rom_report: zephyr
 	@make -f Makefile.zephyr	BOARD=$(BOARD) \
 					VARIANT=$(VARIANT) \
-					MEM_STATS=$(MEM_STATS) \
 					CB_STATS=$(CB_STATS) \
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT) \
-					ram_report
+					rom_report
 
 # Build for zephyr, default target
 .PHONY: zephyr
 zephyr: analyze generate jerryscript $(ARC)
 	@make -f Makefile.zephyr	BOARD=$(BOARD) \
 					VARIANT=$(VARIANT) \
-					MEM_STATS=$(MEM_STATS) \
 					CB_STATS=$(CB_STATS) \
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT)
@@ -266,7 +263,6 @@ NET_BUILD=$(shell grep -q BUILD_MODULE_OCF src/Makefile && echo y)
 .PHONY: qemu
 qemu: zephyr
 	make -f Makefile.zephyr qemu \
-		MEM_STATS=$(MEM_STATS) \
 		CB_STATS=$(CB_STATS) \
 		SNAPSHOT=$(SNAPSHOT) \
 		NETWORK_BUILD=$(NET_BUILD)


### PR DESCRIPTION
Using 'make rom_report' or 'make ram_report' with Zephyr targets, you
get a list of all the symbols defined and how big they are, to try to
identify space hogs.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>