### PR TITLE
[build] Fix debug build fail after make pristine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ cleanlocal:
 	@rm -f prj.conf.tmp
 	@rm -f prj.mdef
 	@rm -f zjs.conf.tmp
+	@rm -f .snapshot.last_build
 
 # Explicit clean
 .PHONY: clean

--- a/Makefile.snapshot
+++ b/Makefile.snapshot
@@ -6,7 +6,7 @@ JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 
 JERRY_FLAGS ?= --snapshot-save=on
 
-BUILD_DIR = $(ZJS_BASE)/outdir/snapshot/$(VARIANT)
+BUILD_DIR = $(ZJS_BASE)/outdir/snapshot/
 
 UNAME := $(shell uname)
 ifeq ($(UNAME),Darwin)
@@ -20,8 +20,8 @@ all: snapshot
 
 .PHONY: setup
 setup:
-	@if [ ! -d $(ZJS_BASE)/outdir/snapshot/$(VARIANT) ]; then \
-		mkdir -p $(ZJS_BASE)/outdir/snapshot/$(VARIANT); \
+	@if [ ! -d $(ZJS_BASE)/outdir/snapshot/ ]; then \
+		mkdir -p $(ZJS_BASE)/outdir/snapshot/; \
 	fi
 
 CORE_SRC +=		src/snapshot.c \
@@ -63,7 +63,6 @@ SNAPSHOT_FLAGS += 	-fno-asynchronous-unwind-tables \
 			-Wpointer-sign
 
 ifeq ($(VARIANT), debug)
-SNAPSHOT_DEFINES +=	-DDEBUG_BUILD
 SNAPSHOT_FLAGS +=	-g
 DEBUG=1
 else


### PR DESCRIPTION
The -DDEBUG_BUILD flag in the snapshot Makefile was causing
issues after make pristine, the snapshot_gen tool do not
need to a debug build anyway, so cleaning up the Makefile to
fix breakage.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>