### PR TITLE
[build] Fix building of SNAPSHOT=on

### DIFF
--- a/Makefile.snapshot
+++ b/Makefile.snapshot
@@ -6,7 +6,7 @@ JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 
 JERRY_FLAGS ?= --snapshot-save=on
 
-BUILD_DIR = $(ZJS_BASE)/outdir/snapshot/$(VARIANT)
+BUILD_DIR = $(ZJS_BASE)/outdir/snapshot/
 
 UNAME := $(shell uname)
 ifeq ($(UNAME),Darwin)
@@ -20,11 +20,12 @@ all: snapshot
 
 .PHONY: setup
 setup:
-	@if [ ! -d $(ZJS_BASE)/outdir/snapshot/$(VARIANT) ]; then \
-		mkdir -p $(ZJS_BASE)/outdir/snapshot/$(VARIANT); \
+	@if [ ! -d $(ZJS_BASE)/outdir/snapshot/ ]; then \
+		mkdir -p $(ZJS_BASE)/outdir/snapshot/; \
 	fi
 
 CORE_SRC +=		src/snapshot.c \
+			src/zjs_common.c \
 			src/zjs_script.c
 
 CORE_OBJ =		$(CORE_SRC:%.c=%.o)
@@ -62,7 +63,6 @@ SNAPSHOT_FLAGS += 	-fno-asynchronous-unwind-tables \
 			-Wpointer-sign
 
 ifeq ($(VARIANT), debug)
-SNAPSHOT_DEFINES +=	-DDEBUG_BUILD
 SNAPSHOT_FLAGS +=	-g
 DEBUG=1
 else

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     }
 
     size_t size = jerry_parse_and_save_snapshot((jerry_char_t *)script,
-                                                strlen(script),
+                                                len,
                                                 true,
                                                 false,
                                                 snapshot_buf,


### PR DESCRIPTION
Backported patch from master that fixes building with SNAPSHOT=on
and make the default build to use the snapshot feature.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>