### PR TITLE
[build] Fixed failed to require JS modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,6 @@ PRINT_FLOAT ?= off
 ifeq ($(BOARD), linux)
 	SNAPSHOT = off
 endif
-ifeq ($(BOARD), linux)
-	SNAPSHOT = off
-endif
 
 # If target is one of these, ensure ZEPHYR_BASE is set
 ZEPHYR_TARGETS = zephyr arc debug
@@ -219,7 +216,7 @@ ifeq ($(SNAPSHOT), on)
 		make -f Makefile.snapshot; \
 	fi
 	@echo Creating snapshot bytecode from JS application...
-	@outdir/snapshot/snapshot $(JS) src/zjs_snapshot_gen.c
+	@outdir/snapshot/snapshot /tmp/zjs.js src/zjs_snapshot_gen.c
 # SNAPSHOT=on, check if rebuilding JerryScript is needed
 ifeq ("$(wildcard .snapshot.last_build)", "")
 	@rm -rf $(JERRY_BASE)/build/$(BOARD)/


### PR DESCRIPTION
There's a bug in the build when snapshot is enabled,
it generates snapshot from the JS that's passed, but
it should be generating from the /tmp/zjs.js file which
contains other JS modules.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>