### PR TITLE
[build] Adjust RAM allocation boundary between x86 and arc

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,22 +248,30 @@ configure the heap size available to the ZJS API.
 ## Getting more space on your Arduino 101
 Arduino 101 comes with a **144K** X86 partition, but we're able to use more
 space by telling Zephyr there is more space and then splicing the images we
-flash to the device. You can control this with the SIZE= flag to make. So if
-you want to allocated 256KB for x86, use SIZE=256.
+flash to the device. You can control this with the ROM= flag to make. So if
+you want to allocated 256KB for x86, use ROM=256.
 
 You can also just build without it until you see a message like this:
 ```
 lfiamcu/5.2.1/real-ld: region `ROM' overflowed by 53728 bytes
 ```
 
-That implies you need an extra 53K of space, so you could try passing SIZE=200.
-If it's the ARC image that needs more space, you should decrease the SIZE you're
+That implies you need an extra 53K of space, so you could try passing ROM=200.
+If it's the ARC image that needs more space, you should decrease the ROM you're
 passing instead.
 
 **NOTE**: Earlier, we would physically repartition the device and install a new
 bootloader that knew about it. This is no longer necessary, so if you have such
 a device you should restore it to factory condition with the 256-to-144
 flashpack.
+
+You can also influence the amount of RAM allocated to the X86 side with a new
+RAM= argument. Here the default is 55 but it can theoretically go as high as
+79 if ARC was disabled; realistically up to maybe 75 or so depending on how
+few modules you require in the ARC build.
+
+The RAM and ROM sizes being used are now displayed at the top of the make
+output when you do build for Arduino 101.
 
 ## Building system images
 The ZJS project uses a top-level Makefile to control the building of code from

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -149,10 +149,10 @@ if [ "$VM1" == "y" ]; then
     try_command "traffic" make $VERBOSE JS=samples/TrafficLight.js
     try_command "pwm" make $VERBOSE JS=samples/PWM.js
     try_command "i2c" make $VERBOSE JS=samples/I2C.js
-    try_command "uart" make $VERBOSE JS=samples/UART.js SIZE=160
+    try_command "uart" make $VERBOSE JS=samples/UART.js
     try_command "events" make $VERBOSE JS=samples/tests/Events.js
     try_command "perf" make $VERBOSE JS=tests/test-performance.js
-    try_command "btgrove" make $VERBOSE JS=samples/WebBluetoothGroveLcdDemo.js SIZE=256
+    try_command "btgrove" make $VERBOSE JS=samples/WebBluetoothGroveLcdDemo.js ROM=256
 
     # k64f build tests
     git clean -dfx
@@ -214,7 +214,7 @@ if [ "$VM3" == "y" ]; then
 
     # ashell tests
     git clean -dfx
-    try_command "ashell" make $VERBOSE DEV=ashell SIZE=256
+    try_command "ashell" make $VERBOSE DEV=ashell ROM=256
 fi
 
 # clean up on success


### PR DESCRIPTION
Akin to recent patch to make ROM allocation configurable in the make
command, do the same for RAM. By default in Zephyr on Arduino 101, the
first 1K of 80K RAM is allocated for special purposes, then the next
24K is allocated for ARC and the next 55K for X86. Now we allow this
to be overridden with the RAM= command line argument. It specifies the
X86 RAM so it can range from 55-79. (It could be made lower if we see
the need for that later.)

Also, change the new SIZE argument to be ROM to distinguish it from
the new RAM option.

Add some output at the beginning of an Arduino 101 build that reports
the RAM/ROM values being used.

Revert part of the other patch that added SIZE argument to UART
builds in Travis/trlite because it doesn't seem necessary after all.

Update the README to reflect the changes, and the travis and trlite
scripts to use the renamed ROM setting.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>