### PR TITLE
[snapshot] Fixed bug that passes incorrect length using snapshot

### DIFF
--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -63,7 +63,7 @@ int main(int argc, char *argv[])
     }
 
     size_t size = jerry_parse_and_save_snapshot((jerry_char_t *)script,
-                                                strlen(script),
+                                                len,
                                                 true,
                                                 false,
                                                 snapshot_buf,


### PR DESCRIPTION
Fixed a bug in snapshot tool that incorrectly passes the length
of script which results in the tool failing to parse certain JS samples.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>