### PR TITLE
[sensor] Proper fix of BMI160 and update Zephyr

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -255,8 +255,8 @@ if [ $? -eq 0 ] || check_config_file ZJS_SENSOR; then
         if [ $? -eq 0 ]; then
             echo "CONFIG_SENSOR=y" >> arc/prj.conf.tmp
             echo "CONFIG_GPIO=y" >> arc/prj.conf.tmp
-            echo "CONFIG_GPIO_QMSI_SS_0_NAME=\"GPIO_SS_0\"" >> arc/prj.conf.tmp
             echo "CONFIG_SPI=y" >> arc/prj.conf.tmp
+            echo "CONFIG_SPI_SS_1_NAME=\"SPI_SS_1\"" >> arc/prj.conf.tmp
             echo "CONFIG_BMI160=y" >> arc/prj.conf.tmp
             echo "CONFIG_BMI160_NAME=\"bmi160\"" >> arc/prj.conf.tmp
             echo "CONFIG_BMI160_SPI_PORT_NAME=\"SPI_SS_1\"" >> arc/prj.conf.tmp


### PR DESCRIPTION
The previous patch accidentally downgraded the commit of Zephyr,
and the patch the fixes the bmi160 sensor was not the correct one
since it wasn't a valid test, this is the correct fix and also
revert Zephyr commit to latest.

Also filed bug on Zephyr upstream and submitted fix ZEP-1704

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>