### PR TITLE
[trlite] Fix to return error value properly

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -110,32 +110,15 @@ function try_command()
     LABEL=$1
     shift
     banner "$LABEL"
-    if ! $*; then
-        CODE=$?
-        echo Error: Failed in $LABEL \(subtest \#$TESTNUM\)!
+
+    # run the command
+    $*
+    CODE=$?
+    if [ $CODE -ne 0 ]; then
+        echo Error: Failed in $LABEL \(subtest \#$TESTNUM\) error $? $CODE!
         exit $CODE
     fi
     echo Success: $LABEL
-}
-
-# requires: first arg is a <=10-char label, second arg is function to run
-#  effects: runs banner with label, then runs the function; if it fails, prints
-#             label before exiting
-function try_func()
-{
-    TESTNUM=$((TESTNUM + 1))
-    if [ "$TESTNUM" -lt "$START" ]; then
-        echo "Skipping test #$TESTNUM"
-        return
-    fi
-
-    banner $1
-    if ! $2; then
-        CODE=$?
-        echo Error: Failed in $1!
-        exit $CODE
-    fi
-    echo Success: $1
 }
 
 #
@@ -241,10 +224,10 @@ if [ "$VM2" == "y" ]; then
     try_command "git check" git diff --check $(git rev-list HEAD | tail -1)
 
     # ensure only two uses of jerry_string_to_char_buffer in zjs_util.c
-    try_func "jstring1" check_jstring_util
+    try_command "jstring1" check_jstring_util
 
     # ensure no other source file uses jerry-string_to_char_buffer
-    try_func "jstring2" check_jstring_others
+    try_command "jstring2" check_jstring_others
 
     # linux build tests
     try_command "linux" make $VERBOSE BOARD=linux


### PR DESCRIPTION
The script was returning a zero value even on failure, so Travis always
succeeded, which felt warm and fuzzy, but wasn't.

Also, realized try_func is no different than try_command, so it could
be removed.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>