### PR TITLE
[Grove LCD] Fixed Grove LCD broken after Zephyr update

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -218,7 +218,6 @@ if check_for_require grove_lcd || check_config_file ZJS_GROVE_LCD; then
         echo "CONFIG_GROVE=y" >> arc/prj.conf.tmp
         echo "CONFIG_GROVE_LCD_RGB=y" >> arc/prj.conf.tmp
         echo "CONFIG_GROVE_LCD_RGB_INIT_PRIORITY=90" >> arc/prj.conf.tmp
-        echo "CONFIG_GROVE_LCD_RGB_I2C_MASTER_DEV_NAME=\"I2C_SS_0\"" >> arc/prj.conf.tmp
     else
         echo "CONFIG_I2C=y" >> prj.conf.tmp
         echo "CONFIG_GROVE=y" >> prj.conf.tmp


### PR DESCRIPTION
Zephyr has updated which the previous fix the Grove LCD is no
longer needed and will not run properly if kept, thus removing
the existing config.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>