### PR TITLE
[build] Added uglifyjs for catch parse errors when building snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,12 @@ ifeq ($(SNAPSHOT), on)
 		make -f Makefile.snapshot; \
 	fi
 	@echo Creating snapshot bytecode from JS application...
-	@outdir/snapshot/snapshot /tmp/zjs.js src/zjs_snapshot_gen.c
+	@if [ -x /usr/bin/uglifyjs ]; then \
+		uglifyjs /tmp/zjs.js -nc -mt > /tmp/gen.tmp; \
+	else \
+		cat /tmp/zjs.js > /tmp/gen.tmp; \
+	fi
+	@outdir/snapshot/snapshot /tmp/gen.tmp src/zjs_snapshot_gen.c
 # SNAPSHOT=on, check if rebuilding JerryScript is needed
 ifeq ("$(wildcard .snapshot.last_build)", "")
 	@rm -rf $(JERRY_BASE)/build/$(BOARD)/


### PR DESCRIPTION
This gives more useful debugging messages to developers to catch
syntax errors in their Javascript.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>