### PR TITLE
[build] Make ROM default 256 to minimize need for specifying it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BOARD ?= arduino_101
 RAM ?= 55
-ROM ?= 144
+ROM ?= 256
 
 # Dump memory information: on = print allocs, full = print allocs + dump pools
 TRACE ?= off


### PR DESCRIPTION
Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>