### PR TITLE
[ashell] Adding code to free cb memory and change cleanup order

### DIFF
--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -150,7 +150,7 @@ void javascript_stop()
 
     /* Cleanup engine */
     zjs_modules_cleanup();
-    zjs_remove_all_callback();
+    zjs_remove_all_callbacks();
     zjs_ipm_free_callbacks();
     jerry_cleanup();
 

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -149,8 +149,9 @@ void javascript_stop()
     parsed_code = 0;
 
     /* Cleanup engine */
-    zjs_ipm_free_callbacks();
     zjs_modules_cleanup();
+    zjs_remove_all_callback();
+    zjs_ipm_free_callbacks();
     jerry_cleanup();
 
     restore_zjs_api();

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -326,6 +326,15 @@ void zjs_remove_callback(zjs_callback_id id)
     }
 }
 
+void zjs_remove_all_callback()
+{
+   for (int i = 0; i < cb_size; i++) {
+        if (cb_map[i]) {
+            zjs_remove_callback(i);
+        }
+    }
+}
+
 void zjs_signal_callback(zjs_callback_id id, const void *args, uint32_t size)
 {
     DBG_PRINT("pushing item to ring buffer. id=%d, args=%p, size=%lu\n", id,

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -326,7 +326,7 @@ void zjs_remove_callback(zjs_callback_id id)
     }
 }
 
-void zjs_remove_all_callback()
+void zjs_remove_all_callbacks()
 {
    for (int i = 0; i < cb_size; i++) {
         if (cb_map[i]) {

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -150,7 +150,7 @@ void zjs_remove_callback(zjs_callback_id id);
 /*
  * Remove all callbacks from memory
  */
-void zjs_remove_all_callback();
+void zjs_remove_all_callbacks();
 
 /*
  * Signal the system to make a callback. The callback will not be called

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -148,6 +148,11 @@ void zjs_edit_callback_handle(zjs_callback_id id, void* handle);
 void zjs_remove_callback(zjs_callback_id id);
 
 /*
+ * Remove all callbacks from memory
+ */
+void zjs_remove_all_callback();
+
+/*
  * Signal the system to make a callback. The callback will not be called
  * immediately, but rather once the system has time to service the callback
  * module; this allows the system to fairly share CPU time as well as prevent

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -242,6 +242,9 @@ void zjs_modules_init()
 
 void zjs_modules_cleanup()
 {
+    // stop timers first to prevent further calls
+    zjs_timers_cleanup();
+
     int modcount = sizeof(zjs_modules_array) / sizeof(module_t);
     for (int i = 0; i < modcount; i++) {
         module_t *mod = &zjs_modules_array[i];
@@ -256,7 +259,6 @@ void zjs_modules_cleanup()
 
     // clean up fixed modules
     zjs_error_cleanup();
-    zjs_timers_cleanup();
 #ifdef BUILD_MODULE_CONSOLE
     zjs_console_cleanup();
 #endif


### PR DESCRIPTION
This adds a method that ensures all callbacks are freed.  It
also changes the order of some of the cleanup functions to
ensure stability when starting / stopping apps using ashell.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>