### PR TITLE
[ble] Enable BLE from ble_init function

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -238,14 +238,6 @@ int main(int argc, char *argv[])
     jerry_release_value(exports_obj);
     jerry_release_value(result);
 
-#ifndef ZJS_LINUX_BUILD
-#ifndef QEMU_BUILD
-#ifdef BUILD_MODULE_BLE
-    zjs_ble_enable();
-#endif
-#endif
-#endif // ZJS_LINUX_BUILD
-
 #ifdef ZJS_LINUX_BUILD
     uint8_t last_serviced = 1;
 #endif

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -30,6 +30,7 @@
 #define ZJS_BLE_TIMEOUT_TICKS                  5000
 
 static struct k_sem ble_sem;
+static bool bt_enabled = false;
 
 typedef void (*ccc_cfg_changed_func)(const struct bt_gatt_attr *attr,
                                      uint16_t value);
@@ -1343,6 +1344,11 @@ jerry_value_t zjs_ble_init()
     ble_conn.connected_cb_id = zjs_add_c_callback(&ble_conn, zjs_ble_connected_c_callback);
     ble_conn.disconnected_cb_id = zjs_add_c_callback(&ble_conn, zjs_ble_disconnected_c_callback);
     ble_conn.ble_obj = jerry_acquire_value(ble_obj);
+
+    if (!bt_enabled) {
+        zjs_ble_enable();
+        bt_enabled = true;
+    }
 
     return ble_obj;
 }


### PR DESCRIPTION
We used to enable it from outside the BLE module, but on ashell
this meant the module hadn't been initialized yet, because there is
no JS running with a require() call initially.

This fixed a spurious zjs_call_callback() error message on ashell
startup, and also allows apps like BLE.js to be run from ashell!

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>