### PR TITLE
[build] Fixed invalid C string genereated when SNAPSHOT=off

### DIFF
--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -75,9 +75,11 @@ do
         if [ "$char" = $'r' ] || [ "$char" = $'n' ]; then
             printf "\\\\$char" >> $OUTPUT
         fi
-    elif [ "$char" = $'\n' ] && [ $UGLIFY -eq 0 ]; then
-        # Handle new lines if uglify is not installed
-        printf "\\\n\"\n\"" >> $OUTPUT
+    elif [ "$char" = $'\n' ]; then
+        if [ $UGLIFY -eq 0 ]; then
+            # Handle new lines if uglify is not installed
+            printf "\\\n\"\n\"" >> $OUTPUT
+        fi
     else
         echo -n "$char" >> $OUTPUT
     fi


### PR DESCRIPTION
Fixed a bug in the convert.sh script where it could add a newline
to the generated C string when the input JS contains a newline at
the end of the file after running through uglifyjs.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>