### PR TITLE
[error] Make missing JS module a NotSupportedError in linux build

### DIFF
--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -156,7 +156,7 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
 
     if (zjs_read_script(full_path, &str, &len)) {
         ERR_PRINT("could not read module %s\n", full_path);
-        return SYSTEM_ERROR("native_require_handler: could not read module script");
+        return NOTSUPPORTED_ERROR("native_require_handler: could not read module script");
     }
     jerry_value_t code_eval = jerry_parse((jerry_char_t *)str, len, false);
     if (jerry_value_has_error_flag(code_eval)) {


### PR DESCRIPTION
This is to match behavior of a module not being built into a real
build, so that test-error.js will see the same error type.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>