### PR TITLE
[assert] Demote AssertionError from standard to custom error

### DIFF
--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -239,9 +239,9 @@ static jerry_value_t console_assert(const jerry_value_t function_obj,
     if (!b) {
         if (argc > 1) {
             value2str(argv[1], message, MAX_STR_LENGTH, false);
-            return ASSERTION_ERROR(message);
+            return zjs_custom_error("AssertionError", message);
         } else {
-            return ASSERTION_ERROR("console.assert");
+            return zjs_custom_error("AssertionError", "console.assert");
         }
     }
     return ZJS_UNDEFINED;

--- a/src/zjs_error.c
+++ b/src/zjs_error.c
@@ -9,7 +9,6 @@ typedef struct {
 } zjs_error_t;
 
 static zjs_error_t error_types[] = {
-    { "AssertionError" },
     { "NetworkError" },
     { "NotSupportedError" },
     { "RangeError" },

--- a/src/zjs_error.h
+++ b/src/zjs_error.h
@@ -6,7 +6,6 @@
 #include "jerry-api.h"
 
 typedef enum zjs_error_type {
-    AssertionError,
     NetworkError,
     NotSupportedError,
     RangeError,
@@ -46,7 +45,6 @@ jerry_value_t zjs_standard_error(zjs_error_type_t type, const char *message);
 
 #define zjs_error(msg)          (zjs_standard_error(Error, (msg)))
 
-#define ASSERTION_ERROR(msg)    (zjs_standard_error(AssertionError, (msg)))
 #define SECURITY_ERROR(msg)     (zjs_standard_error(SecurityError, (msg)))
 #define NOTSUPPORTED_ERROR(msg) (zjs_standard_error(NotSupportedError, (msg)))
 #define SYNTAX_ERROR(msg)       (zjs_standard_error(SyntaxError, (msg)))


### PR DESCRIPTION
This means instanceof AssertionError won't work but you can still test
the name; since this comes from one console function it doesn't seem
like it should be considered a standard error.

Fixes issue #735.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>