### PR TITLE
[util] Fix add_readonly_string to set configurable

### DIFF
--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -24,6 +24,17 @@ jerry_value_t zjs_get_property(const jerry_value_t obj, const char *name)
     return rval;
 }
 
+bool zjs_delete_property(const jerry_value_t obj, const char *name)
+{
+    // requires: obj is an object, name is a property name string
+    //  effects: looks up the property name in obj, and deletes it; return true
+    //             if success, false otherwise
+    jerry_value_t jname = jerry_create_string((const jerry_char_t *)name);
+    bool rval = jerry_delete_property(obj, jname);
+    jerry_release_value(jname);
+    return rval;
+}
+
 void zjs_obj_add_functions(jerry_value_t obj, zjs_native_func_t *funcs)
 {
     // requires: obj is an existing JS object
@@ -93,7 +104,10 @@ void zjs_obj_add_readonly_string(jerry_value_t obj, const char *str,
     jerry_value_t jname = jerry_create_string((const jerry_char_t *)name);
     jerry_property_descriptor_t pd;
     jerry_init_property_descriptor_fields(&pd);
+    pd.is_writable_defined = true;
     pd.is_writable = false;
+    pd.is_configurable_defined = true;
+    pd.is_configurable = true;
     pd.is_value_defined = true;
     pd.value = jerry_create_string((const jerry_char_t *)str);
     jerry_define_own_property(obj, jname, &pd);

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -30,6 +30,7 @@
 void zjs_set_property(const jerry_value_t obj, const char *str,
                       const jerry_value_t prop);
 jerry_value_t zjs_get_property (const jerry_value_t obj, const char *str);
+bool zjs_delete_property(const jerry_value_t obj, const char *str);
 
 typedef struct zjs_native_func {
     void *function;


### PR DESCRIPTION
This allow the readonly properties to be modifiable in native
so objects can update the property or delete them if needed.

Also adding a new helper method that can delete a property.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>