### PR TITLE
[sensor] Added default state "unconnected"

### DIFF
--- a/modules/GenericSensor.js
+++ b/modules/GenericSensor.js
@@ -153,7 +153,7 @@ function GenericSensor() {
         setTimeout(function() {
             startState = sensor.state;
             assert(defaultState !== startState &&
-                   defaultState === "idle" &&
+                   defaultState === "unconnected" &&
                    startState === "activated",
                    "sensor: be started");
         }, 1000);

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -149,7 +149,7 @@ static void zjs_sensor_set_state(jerry_value_t obj, enum sensor_state state)
     }
 
     // update state property and trigger onstatechange event
-    const char* state_str = NULL;
+    char* state_str = NULL;
     switch(state) {
     case SENSOR_STATE_UNCONNECTED:
         state_str = "unconnected";

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -149,7 +149,7 @@ static void zjs_sensor_set_state(jerry_value_t obj, enum sensor_state state)
     }
 
     // update state property and trigger onstatechange event
-    char* state_str = NULL;
+    const char *state_str = NULL;
     switch(state) {
     case SENSOR_STATE_UNCONNECTED:
         state_str = "unconnected";


### PR DESCRIPTION
The default state is no longer "idle" and should be "unconnected",
also it should be a readonly property, and readings should also
be readonly as well

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>