### PR TITLE
[ocf/promises] Fixed OCF crash because of bug from promise patch

### DIFF
--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -98,12 +98,12 @@ void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,
 
     new->then_id = zjs_add_callback_once(ZJS_UNDEFINED,
                                          obj,
-                                         handle,
+                                         new,
                                          post_promise);
 
     new->catch_id = zjs_add_callback_once(ZJS_UNDEFINED,
                                           obj,
-                                          handle,
+                                          new,
                                           post_promise);
 
     // Add the "promise" object to the object passed as a property, because the

--- a/src/zjs_test_promise.c
+++ b/src/zjs_test_promise.c
@@ -7,15 +7,33 @@
 #include "zjs_promise.h"
 #include "zjs_util.h"
 
+typedef struct dummy_handle {
+    uint32_t value;
+} dummy_handle_t;
+
+static void post_promise(void* handle)
+{
+    if (handle) {
+        dummy_handle_t* h = (dummy_handle_t*)handle;
+        if (h->value != 42) {
+            ERR_PRINT("Handle was not valid!!!\n");
+        }
+        zjs_free(h);
+    }
+}
+
 static jerry_value_t create_promise(const jerry_value_t function_obj,
                                     const jerry_value_t this,
                                     const jerry_value_t argv[],
                                     const jerry_length_t argc)
 {
+    dummy_handle_t* handle = zjs_malloc(sizeof(dummy_handle_t));
+    handle->value = 42;
+
     jerry_value_t promise = jerry_create_object();
     ZJS_PRINT("Testing promise, object = %u\n", promise);
 
-    zjs_make_promise(promise, NULL, NULL);
+    zjs_make_promise(promise, post_promise, handle);
 
     return promise;
 }

--- a/src/zjs_test_promise.c
+++ b/src/zjs_test_promise.c
@@ -11,11 +11,13 @@ typedef struct dummy_handle {
     uint32_t value;
 } dummy_handle_t;
 
+#define TEST_VAL       42
+
 static void post_promise(void* handle)
 {
     if (handle) {
         dummy_handle_t* h = (dummy_handle_t*)handle;
-        if (h->value != 42) {
+        if (h->value != TEST_VAL) {
             ERR_PRINT("Handle was not valid!!!\n");
         }
         zjs_free(h);
@@ -28,7 +30,7 @@ static jerry_value_t create_promise(const jerry_value_t function_obj,
                                     const jerry_length_t argc)
 {
     dummy_handle_t* handle = zjs_malloc(sizeof(dummy_handle_t));
-    handle->value = 42;
+    handle->value = TEST_VAL;
 
     jerry_value_t promise = jerry_create_object();
     ZJS_PRINT("Testing promise, object = %u\n", promise);


### PR DESCRIPTION
 - Fixed OCF on linux by updating iotivity-constrained
   (client + server compiled in previously did not work)

Signed-off-by: James Prestwood <james.prestwood@intel.com>