### PR TITLE
[demo] Increase sensor frequency to 100

### DIFF
--- a/samples/SensorBLEDemo.js
+++ b/samples/SensorBLEDemo.js
@@ -90,11 +90,11 @@ ble.on('disconnect', function(clientAddress) {
 });
 
 var accel = new Accelerometer({
-    frequency: 20
+    frequency: 100
 });
 
 var gyro = new Gyroscope({
-    frequency: 20
+    frequency: 100
 });
 
 accel.onchange = function(event) {


### PR DESCRIPTION
It looks like without any prints, we can achieve a maximum of 100hz
for sending sensor data over BLE, seeing only a few dropped ring buffer
errors.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>