### PR TITLE
[util] Add macros/functions to standardize argument validation

### DIFF
--- a/docs/fs.md
+++ b/docs/fs.md
@@ -91,7 +91,7 @@ Remove a directory from the file system.
 `path` is the name of the directory.
 
 ### FS.writeSync
-`number writeSync(object fd, [String|Buffer] data, number offset, number length, optional number position);`
+`number writeSync(object fd, Buffer data, number offset, number length, optional number position);`
 
 Write bytes to an opened file.
 

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -209,12 +209,8 @@ static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj,
                                     const jerry_value_t argv[],
                                     const jerry_length_t argc)
 {
-    if (argc < 2 ||
-        !jerry_value_is_string(argv[0]) ||
-        (!jerry_value_is_function(argv[1]) &&
-         !jerry_value_is_null(argv[1]))) {
-        return zjs_error("zjs_aio_pin_on: invalid argument");
-    }
+    // args: event name, callback
+    ZJS_VALIDATE_ARGS(Z_STRING, Z_FUNCTION Z_NULL);
 
     uint32_t pin;
     zjs_obj_get_uint32(this, "pin", &pin);
@@ -258,8 +254,8 @@ static jerry_value_t zjs_aio_pin_read_async(const jerry_value_t function_obj,
                                             const jerry_value_t argv[],
                                             const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_function(argv[0]))
-        return zjs_error("zjs_aio_pin_read_async: invalid argument");
+    // args: callback
+    ZJS_VALIDATE_ARGS(Z_FUNCTION);
 
     uint32_t device, pin;
     zjs_obj_get_uint32(this, "device", &device);
@@ -284,8 +280,8 @@ static jerry_value_t zjs_aio_open(const jerry_value_t function_obj,
                                   const jerry_value_t argv[],
                                   const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_object(argv[0]))
-        return zjs_error("zjs_aio_open: invalid argument");
+    // args: initialization object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     jerry_value_t data = argv[0];
 

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -176,6 +176,8 @@ static jerry_value_t zjs_ble_read_callback_function(const jerry_value_t function
                                                     const jerry_value_t argv[],
                                                     const jerry_length_t argc)
 {
+    // TODO: couldn't use ZJS_VALIDATE_ARGS here because it needs to give the
+    //   semaphore on error case
     if (argc != 2 ||
         !jerry_value_is_number(argv[0]) ||
         !jerry_value_is_object(argv[1])) {
@@ -283,6 +285,8 @@ static jerry_value_t zjs_ble_write_callback_function(const jerry_value_t functio
                                                      const jerry_value_t argv[],
                                                      const jerry_length_t argc)
 {
+    // TODO: couldn't use ZJS_VALIDATE_ARGS here because it needs to give the
+    //   semaphore on error case
     if (argc != 1 ||
         !jerry_value_is_number(argv[0])) {
         k_sem_give(&ble_sem);
@@ -383,10 +387,8 @@ static jerry_value_t zjs_ble_update_value_callback_function(const jerry_value_t 
                                                             const jerry_value_t argv[],
                                                             const jerry_length_t argc)
 {
-    if (argc != 1 ||
-        !jerry_value_is_object(argv[0])) {
-        return zjs_error("zjs_ble_update_value_call_function: invalid arguments");
-    }
+    // args: buffer
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     // expects a Buffer object
     zjs_buffer_t *buf = zjs_buffer_find(argv[0]);
@@ -679,12 +681,7 @@ static jerry_value_t zjs_ble_start_advertising(const jerry_value_t function_obj,
     // arg 0 should be the device name to advertise, e.g. "Arduino101"
     // arg 1 should be an array of UUIDs (short, 4 hex chars)
     // arg 2 should be a short URL (typically registered with Google, I think)
-    if (argc < 2 ||
-        !jerry_value_is_string(argv[0]) ||
-        !jerry_value_is_object(argv[1]) ||
-        (argc >= 3 && !jerry_value_is_string(argv[2]))) {
-        return zjs_error("zjs_ble_adv_start: invalid arguments");
-    }
+    ZJS_VALIDATE_ARGS(Z_STRING, Z_ARRAY, Z_OPTIONAL Z_STRING);
 
     jerry_value_t array = argv[1];
     if (!jerry_value_is_array(array)) {
@@ -1158,15 +1155,8 @@ static jerry_value_t zjs_ble_set_services(const jerry_value_t function_obj,
 {
     // arg 0 should be an array of services
     // arg 1 is optionally an callback function
-    if (argc < 1 ||
-        !jerry_value_is_array(argv[0]) ||
-        (argc > 1 && !jerry_value_is_function(argv[1]))) {
-        return zjs_error("zjs_ble_set_services: invalid arguments");
-    }
+    ZJS_VALIDATE_ARGS(Z_ARRAY, Z_OPTIONAL Z_FUNCTION);
 
-    // FIXME: currently hard-coded to work with demo
-    // which has only 1 primary service and 2 characteristics
-    // add support for multiple services
     jerry_value_t v_services = argv[0];
     int array_size = jerry_get_array_length(v_services);
     if (array_size == 0) {
@@ -1262,9 +1252,8 @@ static jerry_value_t zjs_ble_primary_service(const jerry_value_t function_obj,
                                              const jerry_value_t argv[],
                                              const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_object(argv[0])) {
-        return zjs_error("zjs_ble_primary_service: invalid arguments");
-    }
+    // args: initialization object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     return jerry_acquire_value(argv[0]);
 }
@@ -1275,9 +1264,8 @@ static jerry_value_t zjs_ble_characteristic(const jerry_value_t function_obj,
                                             const jerry_value_t argv[],
                                             const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_object(argv[0])) {
-        return zjs_error("zjs_ble_characterstic: invalid arguments");
-    }
+    // args: initialization object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     // FIXME: Taking over the incoming object isn't really right; one side
     //   effect will be if they've stored a reference to the object they
@@ -1320,9 +1308,8 @@ static jerry_value_t zjs_ble_descriptor(const jerry_value_t function_obj,
                                         const jerry_value_t argv[],
                                         const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_object(argv[0])) {
-        return zjs_error("zjs_ble_descriptor: invalid arguments");
-    }
+    // args: initialization object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     return jerry_acquire_value(argv[0]);
 }

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -41,8 +41,9 @@ static jerry_value_t zjs_buffer_read_bytes(const jerry_value_t this,
     //  effects: reads bytes from the buffer associated with this JS object, if
     //             found, at the given offset, if within the bounds of the
     //             buffer; otherwise returns an error
-    if (argc >= 1 && !jerry_value_is_number(argv[0]))
-        return zjs_error("zjs_buffer_read_bytes: invalid argument");
+
+    // args: offset
+    ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_NUMBER);
 
     uint32_t offset = 0;
     if (argc >= 1)
@@ -84,10 +85,9 @@ static jerry_value_t zjs_buffer_write_bytes(const jerry_value_t this,
     //  effects: writes bytes into the buffer associated with this JS object, if
     //             found, at the given offset, if within the bounds of the
     //             buffer; otherwise returns an error
-    if (argc < 1 || !jerry_value_is_number(argv[0]) ||
-        (argc >= 2 && !jerry_value_is_number(argv[1]))) {
-        return zjs_error("zjs_buffer_write_bytes: invalid argument");
-    }
+
+    // args: value[, offset]
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_OPTIONAL Z_NUMBER);
 
     uint32_t value = jerry_get_number_value(argv[0]);
 
@@ -209,12 +209,13 @@ static jerry_value_t zjs_buffer_to_string(const jerry_value_t function_obj,
                                           const jerry_length_t argc)
 {
     // requires: this must be a JS buffer object, if an argument is present it
-    //             must be the string 'hex', as that is the only supported
-    //             encoding for now
+    //             must be the string 'ascii' or 'hex', as those are the only
+    //             supported encodings for now
     //  effects: if the buffer object is found, converts its contents to a hex
-    //             string and returns it in ret_val_p
-    if (argc > 1 || (argc == 1 && !jerry_value_is_string(argv[0])))
-        return zjs_error("zjs_buffer_to_string: invalid argument");
+    //             string and returns it
+
+    // args: [encoding]
+    ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_STRING);
 
     zjs_buffer_t *buf = zjs_buffer_find(this);
     if (buf && argc == 0) {
@@ -260,7 +261,7 @@ static void zjs_buffer_callback_free(uintptr_t handle)
     zjs_free(item);
 }
 
-static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_val,
+static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj,
                                              const jerry_value_t this,
                                              const jerry_value_t argv[],
                                              const jerry_length_t argc)
@@ -273,11 +274,9 @@ static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj_va
     //  effects: writes string to buf at offset according to the character
     //             encoding in encoding.
 
-    if (argc < 1 || !jerry_value_is_string(argv[0]) ||
-        (argc > 1 && !jerry_value_is_number(argv[1])) ||
-        (argc > 2 && !jerry_value_is_number(argv[2])) ||
-        (argc > 3 && !jerry_value_is_string(argv[3])))
-        return zjs_error("zjs_buffer_write_string: invalid argument");
+    // args: data[, offset[, length[, encoding]]]
+    ZJS_VALIDATE_ARGS(Z_STRING, Z_OPTIONAL Z_NUMBER, Z_OPTIONAL Z_NUMBER,
+                      Z_OPTIONAL Z_STRING);
 
     // Check if the encoding string is anything other than utf8
     if (argc > 3) {
@@ -376,11 +375,9 @@ static jerry_value_t zjs_buffer(const jerry_value_t function_obj,
     //  effects: constructs a new JS Buffer object, and an associated buffer
     //             tied to it through a zjs_buffer_t struct stored in a global
     //             list
-    if (argc != 1 ||
-        !(jerry_value_is_number(argv[0]) ||
-        jerry_value_is_array(argv[0]) ||
-        jerry_value_is_string(argv[0])))
-        return zjs_error("zjs_buffer: invalid argument");
+
+    // args: initial size or initialization data
+    ZJS_VALIDATE_ARGS(Z_NUMBER Z_ARRAY Z_STRING);
 
     if (jerry_value_is_number(argv[0])) {
         // treat a number argument as a length

--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -182,9 +182,8 @@ static jerry_value_t console_time(const jerry_value_t function_obj,
                                   const jerry_value_t argv[],
                                   const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_string(argv[0])) {
-        return TYPE_ERROR("invalid argument");
-    }
+    // args: label
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     uint32_t start = zjs_port_timer_get_uptime();
 
@@ -199,9 +198,8 @@ static jerry_value_t console_time_end(const jerry_value_t function_obj,
                                       const jerry_value_t argv[],
                                       const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_string(argv[0])) {
-        return TYPE_ERROR("invalid argument");
-    }
+    // args: label
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     jerry_value_t num = jerry_get_property(gbl_time_obj, argv[0]);
     jerry_delete_property(gbl_time_obj, argv[0]);
@@ -231,10 +229,10 @@ static jerry_value_t console_assert(const jerry_value_t function_obj,
                                     const jerry_value_t argv[],
                                     const jerry_length_t argc)
 {
+    // args: validity[, output]
+    ZJS_VALIDATE_ARGS(Z_BOOL, Z_OPTIONAL Z_ANY);
+
     char message[MAX_STR_LENGTH];
-    if (!jerry_value_is_boolean(argv[0])) {
-        return TYPE_ERROR("invalid parameter");
-    }
     bool b = jerry_get_boolean_value(argv[0]);
     if (!b) {
         if (argc > 1) {

--- a/src/zjs_error.c
+++ b/src/zjs_error.c
@@ -24,6 +24,9 @@ static jerry_value_t error_handler(const jerry_value_t function_obj,
                                    const jerry_value_t argv[],
                                    const jerry_length_t argc)
 {
+    // args: message
+    ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_STRING);
+
     int count = sizeof(error_types) / sizeof(zjs_error_t);
     bool found = false;
     for (int i=0; i<count; i++) {
@@ -39,7 +42,7 @@ static jerry_value_t error_handler(const jerry_value_t function_obj,
         return zjs_error("error_handler: unknown type");
     }
 
-    if (argc >= 1 && jerry_value_is_string(argv[0])) {
+    if (argc >= 1) {
         zjs_set_property(this, "message", argv[0]);
     }
 

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -128,10 +128,9 @@ static jerry_value_t add_listener(const jerry_value_t function_obj,
                                   const jerry_value_t argv[],
                                   const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0]) ||
-        !jerry_value_is_function(argv[1])) {
-        return zjs_error("invalid argument");
-    }
+    // args: event name, callback
+    ZJS_VALIDATE_ARGS(Z_STRING, Z_FUNCTION);
+
     jerry_size_t size = ZJS_MAX_EVENT_NAME_SIZE;
     char name[size];
     zjs_copy_jstring(argv[0], name, &size);
@@ -147,9 +146,8 @@ static jerry_value_t emit_event(const jerry_value_t function_obj,
                                 const jerry_value_t *argv,
                                 const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0])) {
-        return zjs_error("parameter is not a string");
-    }
+    // args: event name[, additional pass-through args]
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     jerry_size_t size = ZJS_MAX_EVENT_NAME_SIZE;
     char event[size];
@@ -169,12 +167,8 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
                                      const jerry_value_t argv[],
                                      const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0])) {
-        return zjs_error("event name must be first parameter");
-    }
-    if (!jerry_value_is_function(argv[1])) {
-        return zjs_error("event listener must be second parameter");
-    }
+    // args: event name, callback
+    ZJS_VALIDATE_ARGS(Z_STRING, Z_FUNCTION);
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
 
@@ -216,9 +210,8 @@ static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
                                           const jerry_value_t argv[],
                                           const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0])) {
-        return zjs_error("event name must be first parameter");
-    }
+    // args: event name
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
 
@@ -313,9 +306,9 @@ static jerry_value_t set_max_listeners(const jerry_value_t function_obj,
                                        const jerry_value_t argv[],
                                        const jerry_length_t argc)
 {
-    if (!jerry_value_is_number(argv[0])) {
-        return zjs_error("max listeners count must be first parameter");
-    }
+    // args: max count
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
+
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
 
     double num = jerry_get_number_value(argv[0]);
@@ -334,9 +327,8 @@ static jerry_value_t get_listener_count(const jerry_value_t function_obj,
                                         const jerry_value_t argv[],
                                         const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0])) {
-        return zjs_error("event name must be first parameter");
-    }
+    // args: event name
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
 
@@ -377,9 +369,8 @@ static jerry_value_t get_listeners(const jerry_value_t function_obj,
                                    const jerry_value_t argv[],
                                    const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0])) {
-        return zjs_error("event name must be first parameter");
-    }
+    // args: event name
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     jerry_value_t event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
 

--- a/src/zjs_fs.c
+++ b/src/zjs_fs.c
@@ -658,7 +658,6 @@ static jerry_value_t zjs_mkdir(const jerry_value_t function_obj,
     }
 #endif
 
-    uint32_t mode = MODE_A_PLUS;
     jerry_size_t size;
 
     size = MAX_PATH_LENGTH;

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -195,6 +195,10 @@ static jerry_value_t zjs_gpio_pin_write(const jerry_value_t function_obj,
     // requires: this is a GPIOPin object from zjs_gpio_open, takes one arg,
     //             the logical boolean value to set to the pin (true = active)
     //  effects: writes the logical value to the pin
+
+    // args: pin value
+    ZJS_VALIDATE_ARGS(Z_BOOL);
+
     uintptr_t ptr;
     if (jerry_get_object_native_handle(this, &ptr)) {
         gpio_handle_t *handle = (gpio_handle_t *)ptr;
@@ -202,9 +206,6 @@ static jerry_value_t zjs_gpio_pin_write(const jerry_value_t function_obj,
             return zjs_error("zjs_gpio_pin_write: pin closed");
         }
     }
-
-    if (argc < 1 || !jerry_value_is_boolean(argv[0]))
-        return zjs_error("zjs_gpio_pin_write: invalid argument");
 
     bool logical = jerry_get_boolean_value(argv[0]);
 
@@ -284,8 +285,9 @@ static jerry_value_t zjs_gpio_open(const jerry_value_t function_obj,
     // requires: arg 0 is an object with these members: pin (int), direction
     //             (defaults to "out"), activeLow (defaults to false),
     //             edge (defaults to "any"), pull (default to undefined)
-    if (argc < 1 || !jerry_value_is_object(argv[0]))
-        return zjs_error("zjs_gpio_open: invalid argument");
+
+    // args: initialization object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     // data input object
     jerry_value_t data = argv[0];

--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -1,4 +1,5 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
+
 #ifdef BUILD_MODULE_GROVE_LCD
 #ifndef QEMU_BUILD
 #ifndef ZJS_LINUX_BUILD
@@ -25,9 +26,8 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
                                     const jerry_value_t argv[],
                                     const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_string(argv[0])) {
-        return zjs_error("zjs_glcd_print: invalid argument");
-    }
+    // args: text
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -65,11 +65,8 @@ static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj,
                                              const jerry_value_t argv[],
                                              const jerry_length_t argc)
 {
-    if (argc != 2 ||
-        !jerry_value_is_number(argv[0]) ||
-        !jerry_value_is_number(argv[1])) {
-        return zjs_error("invalid argument");
-    }
+    // args: column, row
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER);
 
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -87,9 +84,8 @@ static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj,
                                            const jerry_value_t argv[],
                                            const jerry_length_t argc)
 {
-    if (argc != 1 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_glcd_select_color: invalid argument");
-    }
+    // args: predefined color index
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -106,12 +102,8 @@ static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj,
                                         const jerry_value_t argv[],
                                         const jerry_length_t argc)
 {
-    if (argc != 3 ||
-        !jerry_value_is_number(argv[0]) ||
-        !jerry_value_is_number(argv[1]) ||
-        !jerry_value_is_number(argv[2])) {
-        return zjs_error("zjs_glcd_set_color: invalid argument");
-    }
+    // args: red, green, blue
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER, Z_NUMBER);
 
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -130,9 +122,8 @@ static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj,
                                            const jerry_value_t argv[],
                                            const jerry_length_t argc)
 {
-    if (argc != 1 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_glcd_set_function: invalid argument");
-    }
+    // args: predefined function number
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -163,10 +154,6 @@ static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj
                                                 const jerry_value_t argv[],
                                                 const jerry_length_t argc)
 {
-    if (argc != 1 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_glcd_set_display_state: invalid argument");
-    }
-
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
     }
@@ -196,9 +183,8 @@ static jerry_value_t zjs_glcd_set_input_state(const jerry_value_t function_obj,
                                               const jerry_value_t argv[],
                                               const jerry_length_t argc)
 {
-    if (argc != 1 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_glcd_set_input_state: invalid argument");
-    }
+    // args: predefined numeric constants
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     if (!glcd) {
         return zjs_error("Grove LCD device not found");

--- a/src/zjs_grove_lcd_ipm.c
+++ b/src/zjs_grove_lcd_ipm.c
@@ -1,4 +1,5 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
+
 #ifdef BUILD_MODULE_GROVE_LCD
 #ifndef QEMU_BUILD
 #ifndef ZJS_LINUX_BUILD
@@ -105,9 +106,8 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
                                     const jerry_value_t argv[],
                                     const jerry_length_t argc)
 {
-    if (argc < 1 || !jerry_value_is_string(argv[0])) {
-        return zjs_error("zjs_glcd_print: invalid argument");
-    }
+    // args: text
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     jerry_size_t size = MAX_BUFFER_SIZE;
     char *buffer = zjs_alloc_from_jstring(argv[0], &size);
@@ -142,11 +142,8 @@ static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj,
                                              const jerry_value_t argv[],
                                              const jerry_length_t argc)
 {
-    if (argc != 2 ||
-        !jerry_value_is_number(argv[0]) ||
-        !jerry_value_is_number(argv[1])) {
-        return zjs_error("zjs_glcd_set_cursor_pos: invalid argument");
-    }
+    // args: column, row
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER);
 
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -162,9 +159,8 @@ static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj,
                                            const jerry_value_t argv[],
                                            const jerry_length_t argc)
 {
-    if (argc != 1 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_glcd_select_color: invalid argument");
-    }
+    // args: predefined color index
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -179,12 +175,8 @@ static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj,
                                         const jerry_value_t argv[],
                                         const jerry_length_t argc)
 {
-    if (argc != 3 ||
-        !jerry_value_is_number(argv[0]) ||
-        !jerry_value_is_number(argv[1]) ||
-        !jerry_value_is_number(argv[2])) {
-        return zjs_error("zjs_glcd_set_color: invalid argument");
-    }
+    // args: red, green, blue
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER, Z_NUMBER);
 
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -201,9 +193,8 @@ static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj,
                                            const jerry_value_t argv[],
                                            const jerry_length_t argc)
 {
-    if (argc != 1 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_glcd_set_function: invalid argument");
-    }
+    // args: predefined function number
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -231,9 +222,8 @@ static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj
                                                 const jerry_value_t argv[],
                                                 const jerry_length_t argc)
 {
-    if (argc != 1 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_glcd_set_display_state: invalid argument");
-    }
+    // args: predefined numeric constants
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -261,9 +251,8 @@ static jerry_value_t zjs_glcd_set_input_state(const jerry_value_t function_obj,
                                               const jerry_value_t argv[],
                                               const jerry_length_t argc)
 {
-    if (argc != 1 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_glcd_set_input_state: invalid argument");
-    }
+    // args: predefined numeric constants
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     // send IPM message to the ARC side
     zjs_ipm_message_t send;

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -1,4 +1,5 @@
 // Copyright (c) 2016-2017, Intel Corporation.
+
 #ifndef QEMU_BUILD
 
 // Zephyr includes
@@ -16,13 +17,12 @@
 #include "zjs_i2c_ipm_handler.h"
 #endif
 
-
 static jerry_value_t zjs_i2c_prototype;
 
 static jerry_value_t zjs_i2c_read_base(const jerry_value_t this,
                                        const jerry_value_t argv[],
                                        const jerry_length_t argc,
-                                       bool                 burst)
+                                       bool burst)
 {
     // requires: Requires three arguments and has an optional fourth.
     //           arg[0] - Address of the I2C device you wish to read from.
@@ -34,18 +34,13 @@ static jerry_value_t zjs_i2c_read_base(const jerry_value_t this,
     //           from the register address. Returns a buffer object
     //           that size containing the data.
 
-    if (argc < 2 || !jerry_value_is_number(argv[0]) ||
-        !jerry_value_is_number(argv[1])) {
-        return zjs_error("zjs_i2c_read_base: missing arguments");
-    }
+    // args: device, length[, register]
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER, Z_OPTIONAL Z_NUMBER);
 
     uint32_t register_addr = 0;
     uint32_t size = (uint32_t)jerry_get_number_value(argv[1]);
 
     if (argc >= 3) {
-        if (!jerry_value_is_number(argv[2])) {
-            return zjs_error("zjs_i2c_read_base: register is not a number");
-        }
         register_addr = (uint32_t)jerry_get_number_value(argv[2]);
     }
 
@@ -145,22 +140,13 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
     //  effects: Writes the number of bytes requested to the I2C device
     //           at the register address. Returns an error if unsuccessful.
 
-    if (argc < 2 || !jerry_value_is_number(argv[0])) {
-        return zjs_error("zjs_i2c_write: missing arguments");
-    }
-
-    if (!jerry_value_is_object(argv[1])) {
-        return zjs_error("zjs_i2c_write: message buffer is invalid");
-    }
+    // args: device, buffer[, register]
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_OBJECT, Z_OPTIONAL Z_NUMBER);
 
     uint32_t register_addr = 0;
 
     if (argc >= 3) {
-        if (!jerry_value_is_number(argv[2])) {
-            return zjs_error("zjs_i2c_read: register is not a number");
-        } else {
-            register_addr = (uint32_t)jerry_get_number_value(argv[2]);
-        }
+        register_addr = (uint32_t)jerry_get_number_value(argv[2]);
     }
 
     uint32_t bus;
@@ -215,9 +201,8 @@ static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
     //           arg[1] - Bus speed in kbps.
     //  effects: Creates a I2C object connected to the bus number specified.
 
-    if (argc < 1 || !jerry_value_is_object(argv[0])) {
-        return zjs_error("zjs_i2c_open: invalid argument");
-    }
+    // args: initialization object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     jerry_value_t data = argv[0];
     uint32_t bus;

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -130,9 +130,8 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
                                             const jerry_value_t argv[],
                                             const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0])) {
-        return TYPE_ERROR("native_require_handler: string expected");
-    }
+    // args: module name
+    ZJS_VALIDATE_ARGS(Z_STRING);
 
     const int MAX_MODULE_LEN = 32;
     jerry_size_t size = MAX_MODULE_LEN;

--- a/src/zjs_ocf_ble.c
+++ b/src/zjs_ocf_ble.c
@@ -59,9 +59,9 @@ static jerry_value_t ocf_set_ble_address(const jerry_value_t function_val,
                                          const jerry_value_t argv[],
                                          const jerry_length_t argc)
 {
-    if (!jerry_value_is_string(argv[0])) {
-        return zjs_error("invalid arguments");
-    }
+    // args: address
+    ZJS_VALIDATE_ARGS(Z_STRING);
+
     jerry_size_t size = 18;
     char addr[size];
     zjs_copy_jstring(argv[0], addr, &size);

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -215,6 +215,9 @@ static jerry_value_t ocf_respond(const jerry_value_t function_val,
                                  const jerry_value_t argv[],
                                  const jerry_length_t argc)
 {
+    // args: properties object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
+
     jerry_value_t promise = jerry_create_object();
     struct ocf_handler* h;
     jerry_value_t request = this;
@@ -223,13 +226,6 @@ static jerry_value_t ocf_respond(const jerry_value_t function_val,
 
     if (!jerry_get_object_native_handle(request, (uintptr_t*)&h)) {
         ERR_PRINT("native handle not found\n");
-        REJECT(promise, "TypeMismatchError", "native handle not found", h);
-        oc_send_response(h->req, OC_STATUS_INTERNAL_SERVER_ERROR);
-        return promise;
-    }
-
-    if (!jerry_value_is_object(data)) {
-        ERR_PRINT("properties is not an object\n");
         REJECT(promise, "TypeMismatchError", "native handle not found", h);
         oc_send_response(h->req, OC_STATUS_INTERNAL_SERVER_ERROR);
         return promise;
@@ -246,7 +242,8 @@ static jerry_value_t ocf_respond(const jerry_value_t function_val,
 
     oc_send_response(h->req, OC_STATUS_OK);
 
-    DBG_PRINT("responding to method type=%u, properties=%lu\n", h->resp->method, data);
+    DBG_PRINT("responding to method type=%u, properties=%lu\n", h->resp->method,
+              data);
 
     zjs_make_promise(promise, NULL, NULL);
 
@@ -372,6 +369,9 @@ static jerry_value_t ocf_notify(const jerry_value_t function_val,
                                 const jerry_value_t argv[],
                                 const jerry_length_t argc)
 {
+    // args: resource object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
+
     struct server_resource* resource;
     if (!jerry_get_object_native_handle(argv[0], (uintptr_t*)&resource)) {
         DBG_PRINT("native handle not found\n");
@@ -399,16 +399,14 @@ static jerry_value_t ocf_register(const jerry_value_t function_val,
                                   const jerry_value_t argv[],
                                   const jerry_length_t argc)
 {
+    // args: resource object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
+
     struct server_resource* resource;
     int i;
     jerry_value_t promise = jerry_create_object();
     struct ocf_handler* h;
 
-    if (!jerry_value_is_object(argv[0])) {
-        ERR_PRINT("first parameter must be resource object\n");
-        REJECT(promise, "TypeMismatchError", "first parameter must be resource object", h);
-        return promise;
-    }
     // Required
     jerry_value_t resource_path_val = zjs_get_property(argv[0], "resourcePath");
     if (!jerry_value_is_string(resource_path_val)) {

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -39,9 +39,8 @@ static jerry_value_t promise_resolve(const jerry_value_t function_obj,
                                      const jerry_length_t argc,
                                      uint8_t fulfill)
 {
-    if (!jerry_value_is_function(argv[0])) {
-        return zjs_error("invalid arguments");
-    }
+    // args: callback
+    ZJS_VALIDATE_ARGS(Z_FUNCTION);
 
     zjs_promise_t *handle = NULL;
     jerry_value_t promise_obj = zjs_get_property(this, "promise");

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -1,4 +1,5 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
+
 #ifdef BUILD_MODULE_PWM
 // Zephyr includes
 #include <zephyr.h>
@@ -107,8 +108,9 @@ static jerry_value_t zjs_pwm_pin_set_period_cycles(const jerry_value_t function_
     //             underlying hardware (31.25ns each for Arduino 101)
     //  effects: updates the period of this PWM pin, using the finest grain
     //             units provided by the platform, providing the widest range
-    if (argc < 1 || !jerry_value_is_number(argv[0]))
-        return zjs_error("zjs_pwm_pin_set_period_cycles: invalid argument");
+
+    // args: period in cycles
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     double periodHW = jerry_get_number_value(argv[0]);
 
@@ -125,8 +127,9 @@ static jerry_value_t zjs_pwm_pin_set_period(const jerry_value_t function_obj,
     //             argument, the period in milliseconds (float)
     //  effects: updates the period of this PWM pin, getting as close as
     //             possible to what is requested given hardware constraints
-    if (argc < 1 || !jerry_value_is_number(argv[0]))
-        return zjs_error("zjs_pwm_pin_set_period: invalid argument");
+
+    // args: period in milliseconds
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     double pulseWidth;
     if (!zjs_obj_get_double(this, "pulseWidth", &pulseWidth)) {
@@ -172,8 +175,9 @@ static jerry_value_t zjs_pwm_pin_set_pulse_width_cycles(const jerry_value_t func
     //             argument, the pulse width in hardware cycles, dependent on
     //             the underlying hardware (31.25ns each for Arduino 101)
     //  effects: updates the pulse width of this PWM pin
-    if (argc < 1 || !jerry_value_is_number(argv[0]))
-        return zjs_error("zjs_pwm_pin_set_pulse_width_cycles: invalid argument");
+
+    // args: pulse width in cycles
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     double pulseWidth = jerry_get_number_value(argv[0]);
     // store the pulseWidth in the pwm object
@@ -191,8 +195,9 @@ static jerry_value_t zjs_pwm_pin_set_pulse_width(const jerry_value_t function_ob
     // requires: this is a PWMPin object from zjs_pwm_open, takes one
     //             argument, the pulse width in milliseconds (float)
     //  effects: updates the pulse width of this PWM pin
-    if (argc < 1 || !jerry_value_is_number(argv[0]))
-        return zjs_error("zjs_pwm_pin_set_pulse_width: invalid argument");
+
+    // args: pulse width in milliseconds
+    ZJS_VALIDATE_ARGS(Z_NUMBER);
 
     double period;
     zjs_obj_get_double(this, "period", &period);
@@ -215,8 +220,9 @@ static jerry_value_t zjs_pwm_open(const jerry_value_t function_obj,
     //             hardware cycles (defaults to 255), pulse width in hardware
     //             cycles (defaults to 0), polarity (defaults to "normal")
     //  effects: returns a new PWMPin object representing the given channel
-    if (argc < 1 || !jerry_value_is_object(argv[0]))
-        return zjs_error("zjs_pwm_open: invalid argument");
+
+    // args: initialization object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     // data input object
     jerry_value_t data = argv[0];

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -1,4 +1,5 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
+
 #ifdef BUILD_MODULE_SENSOR
 #ifndef QEMU_BUILD
 #ifndef ZJS_LINUX_BUILD
@@ -495,19 +496,19 @@ static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
                                        const jerry_length_t argc,
                                        enum sensor_channel channel)
 {
+    // args: [initialization object]
+    char *expect = Z_OPTIONAL Z_OBJECT;
+    if (channel == SENSOR_CHAN_LIGHT) {
+        // arg is required for AmbientLightSensor
+        expect = Z_OBJECT;
+    }
+    ZJS_VALIDATE_ARGS(expect);
+
     double frequency = DEFAULT_SAMPLING_FREQUENCY;
     bool hasPin = false;
     uint32_t pin;
 
-    if (argc < 1 && channel == SENSOR_CHAN_LIGHT) {
-        // AmbientLightSensor requires ADC pin object
-        return zjs_error("zjs_sensor_create: invalid argument\n");
-    }
-
     if (argc >= 1) {
-        if (!jerry_value_is_object(argv[0]))
-            return zjs_error("zjs_sensor_create: invalid argument");
-
         jerry_value_t options = argv[0];
 
         double option_freq;

--- a/src/zjs_test_promise.c
+++ b/src/zjs_test_promise.c
@@ -45,6 +45,9 @@ static jerry_value_t test_fulfill(const jerry_value_t function_obj,
                                   const jerry_value_t argv[],
                                   const jerry_length_t argc)
 {
+    // args: promise object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
+
     zjs_fulfill_promise(argv[0], NULL, 0);
     return ZJS_UNDEFINED;
 }
@@ -54,6 +57,9 @@ static jerry_value_t test_reject(const jerry_value_t function_obj,
                                  const jerry_value_t argv[],
                                  const jerry_length_t argc)
 {
+    // args: promise object
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
+
     zjs_reject_promise(argv[0], NULL, 0);
     return ZJS_UNDEFINED;
 }

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -145,9 +145,8 @@ static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
                                       const jerry_value_t argv[],
                                       bool repeat)
 {
-    if (argc < 2 || !jerry_value_is_function(argv[0]) ||
-            !jerry_value_is_number(argv[1]))
-        return zjs_error("native_set_interval_handler: invalid arguments");
+    // args: callback, time in milliseconds[, pass-through args]
+    ZJS_VALIDATE_ARGS(Z_FUNCTION, Z_NUMBER);
 
     uint32_t interval = (uint32_t)(jerry_get_number_value(argv[1]));
     jerry_value_t callback = argv[0];
@@ -194,13 +193,12 @@ static jerry_value_t native_clear_interval_handler(const jerry_value_t function_
                                                    const jerry_value_t argv[],
                                                    const jerry_length_t argc)
 {
+    // args: timer object
+    // FIXME: timers should be ints, not objects!
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
+
     jerry_value_t timer_obj = argv[0];
     zjs_timer_t *handle;
-
-    if (!jerry_value_is_object(argv[0])) {
-        ERR_PRINT("invalid arguments\n");
-        return jerry_create_undefined();
-    }
 
     if (!jerry_get_object_native_handle(timer_obj, (uintptr_t*)&handle)) {
         return zjs_error("native_clear_interval_handler(): native handle not found");
@@ -209,7 +207,7 @@ static jerry_value_t native_clear_interval_handler(const jerry_value_t function_
     if (!delete_timer(handle->callback_id))
         return zjs_error("native_clear_interval_handler: timer not found");
 
-    return jerry_create_undefined();
+    return ZJS_UNDEFINED;
 }
 
 uint8_t zjs_timers_process_events()

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -432,6 +432,8 @@ static int zjs_validate_arg(const char *expectation, jerry_value_t arg)
         if (zjs_type_map[type_index](arg)) {
             return optional ? ZJS_VALID_OPTIONAL : ZJS_VALID_REQUIRED;
         }
+
+        ++index;
     }
 
     return optional ? ZJS_SKIP_OPTIONAL : ZJS_INVALID_ARG;

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -127,9 +127,9 @@ enum {
     ZJS_VALID_REQUIRED,
     ZJS_VALID_OPTIONAL,
     ZJS_SKIP_OPTIONAL,
-    ZJS_INVALID_ARG = -1,
-    ZJS_INSUFFICIENT_ARGS = -2,
-    ZJS_INTERNAL_ERROR = -3
+    ZJS_INTERNAL_ERROR = -1,
+    ZJS_INVALID_ARG = -2,
+    ZJS_INSUFFICIENT_ARGS = -3
 };
 
 int zjs_validate_args(const char *expectations[], const jerry_length_t argc,
@@ -156,11 +156,8 @@ int zjs_validate_args(const char *expectations[], const jerry_length_t argc,
     const char *zjs_expectations[] = { __VA_ARGS__, NULL };             \
     int optcount = zjs_validate_args(zjs_expectations, argc - offset,   \
                                      argv + offset);                    \
-    if (optcount == ZJS_INVALID_ARG) {                                  \
-        return TYPE_ERROR("invalid argument");                          \
-    }                                                                   \
-    if (optcount == ZJS_INSUFFICIENT_ARGS) {                            \
-        return zjs_error("insufficient arguments");                     \
+    if (optcount <= ZJS_INVALID_ARG) {                                  \
+        return TYPE_ERROR("invalid arguments");                         \
     }
 
 // Use this if you need an offset

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -38,7 +38,8 @@ typedef struct zjs_native_func {
 } zjs_native_func_t;
 
 /**
- * Add a series of functions described in array funcs to obj
+ * Add a series of functions described in array funcs to obj.
+ *
  * @param obj    JerryScript object to add the functions to
  * @param funcs  Array of zjs_native_func_t, terminated with {NULL, NULL}
  */
@@ -101,5 +102,77 @@ uint16_t zjs_compress_32_to_16(uint32_t num);
 uint32_t zjs_uncompress_16_to_32(uint16_t num);
 
 void zjs_print_error_message(jerry_value_t error);
+
+//
+// ztypes (for argument validation)
+//
+
+// Z_OPTIONAL means the argument isn't required, this must come first if present
+#define Z_OPTIONAL  "?"
+
+// Z_ANY matches any type (i.e. ignores it) - only makes sense for required arg
+#define Z_ANY       "a"
+
+// the rest all match specific type by calling jerry_value_is_* function
+#define Z_ARRAY     "b"
+#define Z_BOOL      "c"
+#define Z_FUNCTION  "d"
+#define Z_NULL      "e"
+#define Z_NUMBER    "f"
+#define Z_OBJECT    "g"
+#define Z_STRING    "h"
+#define Z_UNDEFINED "i"
+
+enum {
+    ZJS_VALID_REQUIRED,
+    ZJS_VALID_OPTIONAL,
+    ZJS_SKIP_OPTIONAL,
+    ZJS_INVALID_ARG = -1,
+    ZJS_INSUFFICIENT_ARGS = -2,
+    ZJS_INTERNAL_ERROR = -3
+};
+
+int zjs_validate_args(const char *expectations[], const jerry_length_t argc,
+                      const jerry_value_t argv[]);
+/**
+ * Macro to validate existing argv based on a list of expected argument types.
+ *
+ * NOTE: Expects argc and argv to exist as in a JerryScript native function.
+ *
+ * @param optcount  A pointer to an int to receive count of optional args found,
+ *                    or NULL if not needed.
+ * @param offset    Integer offset of arg in argv to start with (normally 0)
+ * @param typestr   Each remaining comma-separated argument to the macro
+ *                    corresponds to an argument in argv; each argument should
+ *                    be a space-separated list of "ztypes" from defines above.
+ *
+ * Example: ZJS_VALIDATE_ARGS(Z_NUMBER, Z_OBJECT Z_NULL, Z_OPTIONAL Z_FUNCTION);
+ * This requires argv[0] to be a number type, argv[1] to be an object type
+ *   or null,  and argv[2] may or may not exist, but if it does it must be a
+ *   function type. (Implicitly, argc will have to be at least 2.) Arguments
+ *   beyond what are specified are allowed and ignored.
+ */
+#define ZJS_VALIDATE_ARGS_FULL(optcount, offset, ...)                   \
+    const char *zjs_expectations[] = { __VA_ARGS__, NULL };             \
+    int optcount = zjs_validate_args(zjs_expectations, argc - offset,   \
+                                     argv + offset);                    \
+    if (optcount == ZJS_INVALID_ARG) {                                  \
+        return TYPE_ERROR("invalid argument");                          \
+    }                                                                   \
+    if (optcount == ZJS_INSUFFICIENT_ARGS) {                            \
+        return zjs_error("insufficient arguments");                     \
+    }
+
+// Use this if you need an offset
+#define ZJS_VALIDATE_ARGS_OFFSET(offset, ...)           \
+    ZJS_VALIDATE_ARGS_FULL(zjs_validate_rval, offset, __VA_ARGS__)
+
+// Use this if you need the number of optional args found
+#define ZJS_VALIDATE_ARGS_OPTCOUNT(optcount, ...)       \
+    ZJS_VALIDATE_ARGS_FULL(optcount, 0, __VA_ARGS__)
+
+// Normally use this as a shortcut
+#define ZJS_VALIDATE_ARGS(...)                      \
+    ZJS_VALIDATE_ARGS_FULL(zjs_validate_rval, 0, __VA_ARGS__)
 
 #endif  // __zjs_util_h__

--- a/tests/test-buffer-rw.js
+++ b/tests/test-buffer-rw.js
@@ -17,18 +17,12 @@ buf.writeUInt8(0xab, 7);
 
 // test readUInt8 / writeUInt8
 assert.throws(function () {
-    buf.readUInt8('whale');
-}, "readUInt8: invalid argument");
-assert.throws(function () {
     buf.readUInt8(9);
 }, "readUInt8: out of bounds");
 
 assert.throws(function () {
-    buf.writeUInt8('bowl');
+    buf.writeUInt8('petunias');
 }, "writeUInt8: invalid first argument");
-assert.throws(function () {
-    buf.writeUInt8(42, 'petunias');
-}, "writeUInt8: invalid second argument");
 assert.throws(function () {
     buf.writeUInt8(42, 9);
 }, "readUInt8: out of bounds");


### PR DESCRIPTION
The new ZJS_VALIDATE_ARGS macro and related macros are to be used at
the top of any JerryScript C binding to verify the quantity and types
of arguments, and return standard exceptions if there is a problem.

The comments above the macros in zjs_util.h explain the details of how
they are to be used.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>