### PR TITLE
[trlite] Turn off paging in git commands to avoid issue

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -79,7 +79,7 @@ done
 
 echo Preserving uncommitted changes:
 cd $ZJS_BASE
-git diff HEAD --stat
+git --no-pager diff HEAD --stat
 git diff HEAD > $TRLDIR/uncommitted.patch
 cd $TRLDIR
 patch -p1 < uncommitted.patch > /dev/null
@@ -221,7 +221,7 @@ if [ "$VM2" == "y" ]; then
     TESTNUM=0
 
     # git check
-    try_command "git check" git diff --check $(git rev-list HEAD | tail -1)
+    try_command "git check" git --no-pager diff --check $(git rev-list HEAD | tail -1)
 
     # ensure only two uses of jerry_string_to_char_buffer in zjs_util.c
     try_command "jstring1" check_jstring_util


### PR DESCRIPTION
If you have a long list of files changed in your current tree, the
pager would kick in and put you in 'less' in your terminal, missing
the trlite output.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>