### PR TITLE
[util] fix up add_readonly functions

### DIFF
--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -5,12 +5,35 @@
 // ZJS includes
 #include "zjs_util.h"
 
-void zjs_set_property(const jerry_value_t obj, const char *str,
+void zjs_set_property(const jerry_value_t obj, const char *name,
                       const jerry_value_t prop)
 {
-    jerry_value_t name = jerry_create_string((const jerry_char_t *)str);
-    jerry_set_property(obj, name, prop);
-    jerry_release_value(name);
+    // requires: obj is an object, name is a property name string
+    //  effects: create a new field in the object named name, and
+    //             set it to prop
+    jerry_value_t jname = jerry_create_string((const jerry_char_t *)name);
+    jerry_set_property(obj, jname, prop);
+    jerry_release_value(jname);
+}
+
+void zjs_set_readonly_property(const jerry_value_t obj, const char *name,
+                               const jerry_value_t prop)
+{
+    // requires: obj is an object, name is a property name string
+    //  effects: create a new readonly field in the object named name, and
+    //             set it to prop
+    jerry_value_t jname = jerry_create_string((const jerry_char_t *)name);
+    jerry_property_descriptor_t pd;
+    jerry_init_property_descriptor_fields(&pd);
+    pd.is_writable_defined = true;
+    pd.is_writable = false;
+    pd.is_configurable_defined = true;
+    pd.is_configurable = true;
+    pd.is_value_defined = true;
+    pd.value = prop;
+    jerry_define_own_property(obj, jname, &pd);
+    jerry_free_property_descriptor_fields(&pd);
+    jerry_release_value(jname);
 }
 
 jerry_value_t zjs_get_property(const jerry_value_t obj, const char *name)
@@ -57,6 +80,14 @@ void zjs_obj_add_boolean(jerry_value_t obj, bool flag, const char *name)
     jerry_release_value(jbool);
 }
 
+void zjs_obj_add_readonly_boolean(jerry_value_t obj, bool flag,
+                                  const char *name)
+{
+    // requires: obj is an existing JS object
+    //  effects: creates a new readonly field in parent named name, set to value
+    zjs_set_readonly_property(obj, name, jerry_create_boolean(flag));
+}
+
 void zjs_obj_add_function(jerry_value_t obj, void *func, const char *name)
 {
     // requires: obj is an existing JS object, function is a native C function
@@ -101,18 +132,7 @@ void zjs_obj_add_readonly_string(jerry_value_t obj, const char *str,
 {
     // requires: obj is an existing JS object
     //  effects: creates a new readonly field in parent named name, set to str
-    jerry_value_t jname = jerry_create_string((const jerry_char_t *)name);
-    jerry_property_descriptor_t pd;
-    jerry_init_property_descriptor_fields(&pd);
-    pd.is_writable_defined = true;
-    pd.is_writable = false;
-    pd.is_configurable_defined = true;
-    pd.is_configurable = true;
-    pd.is_value_defined = true;
-    pd.value = jerry_create_string((const jerry_char_t *)str);
-    jerry_define_own_property(obj, jname, &pd);
-    jerry_free_property_descriptor_fields(&pd);
-    jerry_release_value(jname);
+    zjs_set_readonly_property(obj, name, jerry_create_string((const jerry_char_t *)str));
 }
 
 void zjs_obj_add_number(jerry_value_t obj, double num, const char *name)
@@ -131,15 +151,7 @@ void zjs_obj_add_readonly_number(jerry_value_t obj, double num,
 {
     // requires: obj is an existing JS object
     //  effects: creates a new readonly field in parent named name, set to num
-    jerry_value_t jname = jerry_create_string((const jerry_char_t *)name);
-    jerry_property_descriptor_t pd;
-    jerry_init_property_descriptor_fields(&pd);
-    pd.is_writable = false;
-    pd.is_value_defined = true;
-    pd.value = jerry_create_number(num);
-    jerry_define_own_property(obj, jname, &pd);
-    jerry_free_property_descriptor_fields(&pd);
-    jerry_release_value(jname);
+    zjs_set_readonly_property(obj, name, jerry_create_number(num));
 }
 
 bool zjs_obj_get_boolean(jerry_value_t obj, const char *name, bool *flag)

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -27,9 +27,11 @@
 #endif  // ZJS_TRACE_MALLOC
 #endif  // ZJS_LINUX_BUILD
 
-void zjs_set_property(const jerry_value_t obj, const char *str,
+void zjs_set_property(const jerry_value_t obj, const char *name,
                       const jerry_value_t prop);
-jerry_value_t zjs_get_property (const jerry_value_t obj, const char *str);
+void zjs_set_readonly_property(const jerry_value_t obj, const char *name,
+                               const jerry_value_t prop);
+jerry_value_t zjs_get_property (const jerry_value_t obj, const char *name);
 bool zjs_delete_property(const jerry_value_t obj, const char *str);
 
 typedef struct zjs_native_func {
@@ -46,6 +48,8 @@ typedef struct zjs_native_func {
 void zjs_obj_add_functions(jerry_value_t obj, zjs_native_func_t *funcs);
 
 void zjs_obj_add_boolean(jerry_value_t obj, bool flag, const char *name);
+void zjs_obj_add_readonly_boolean(jerry_value_t obj, bool flag,
+                                  const char *name);
 void zjs_obj_add_function(jerry_value_t obj, void *function, const char *name);
 void zjs_obj_add_object(jerry_value_t parent, jerry_value_t child,
                         const char *name);


### PR DESCRIPTION
Add missing zjs_obj_add_readonly_boolean function
Add zjs_set_readonly_property function for handling generic objects

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>