### PR TITLE
[sensor] Update sensor API for readings

### DIFF
--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -27,6 +27,7 @@ specific API functions.
 ```javascript
 interface Sensor {
     readonly attribute SensorState state;   // The current state of Sensor object
+    attribute double frequency;             // The frequency set
     void start();                           // Starts the sensor
     void stop();                            // Stops the sensor
     attribute ChangeCallback onchange;      // Callback handler for change events
@@ -50,7 +51,7 @@ interface SensorErrorEvent {
     attribute Error error;
 };
 
-callback ChangeCallback = void(SensorReading value);
+callback ChangeCallback = void();
 callback ActivateCallback = void();
 callback ErrorCallback = void(SensorErrorEvent error);
 ```
@@ -58,21 +59,15 @@ callback ErrorCallback = void(SensorErrorEvent error);
 ```javascript
 [Constructor(optional AccelerometerOptions accelerometerOptions)]
 interface Accelerometer : Sensor {
-    attribute AccelerometerReading reading;
     attribute boolean includesGravity;
-};
-
-dictionary AccelerometerOptions : SensorOptions  {
-   boolean includeGravity = true;  // not supported, will throw an error if set
-};
-
-interface AccelerometerrReading : SensorReading {
     readonly attribute double x;
     readonly attribute double y;
     readonly attribute double z;
 };
 
-callback ChangeCallback = void(AccelerometerReading value);
+dictionary AccelerometerOptions : SensorOptions  {
+   boolean includeGravity = true;  // not supported, will throw an error if set
+};
 ```
 ####GyroscopeSensor Interface
 ```javascript
@@ -86,25 +81,18 @@ interface GyroscopeSensorReading : SensorReading {
     readonly attribute double y;
     readonly attribute double z;
 };
-
-callback ChangeCallback = void(GyroscopeReading value);
 ```
 ####AmbientLightSensor Interface
 ```javascript
 [Constructor(optional SensorOptions sensorOptions)]
 interface AmbientLightSensor : Sensor {
-    attribute AmbientLightSensorReading reading;
+    readonly attribute unsigned long pin;
+    readonly attribute double illuminance;
 };
 
 dictionary AmbientLightSensorOptions : SensorOptions  {
     unsigned long pin;  // analog pin where the light is connected
 };
-
-interface AmbientLightSensorReading : SensorReading {
-    readonly attribute double illuminance;
-};
-
-callback ChangeCallback = void(AmbientLightSensorReading value);
 ```
 
 API Documentation

--- a/modules/GenericSensor.js
+++ b/modules/GenericSensor.js
@@ -93,41 +93,38 @@ function GenericSensor() {
             if (event === "activated") changeFlag = true;
         };
 
-        sensor.onchange = function(event) {
+        sensor.onchange = function() {
             if (changeFlag === true) {
-                assert(typeof event === "object" && event !== null,
-                       "sensor: callback value for 'onchange'");
-
                 if (sensorType === "AmbientLight") {
-                    assert(typeof event.reading.illuminance === "number" &&
-                           typeof event.reading.illuminance !== null,
+                    assert(typeof sensor.illuminance === "number" &&
+                           typeof sensor.illuminance !== null,
                            "sensor: reading value for '" + sensorType + "'");
 
-                    middleNum = event.reading.illuminance;
-                    event.reading.illuminance = middleNum + 1;
-                    assert(event.reading.illuminance === middleNum,
+                    middleNum = sensor.illuminance;
+                    sensor.illuminance = middleNum + 1;
+                    assert(sensor.illuminance === middleNum,
                            "sensor: reading is readonly property");
 
-                    console.log(sensorType + ": " + event.reading.illuminance);
+                    console.log(sensorType + ": " + sensor.illuminance);
                 } else if (sensorType === "Accelerometer" ||
                            sensorType === "Gyroscope") {
-                    assert(typeof event.reading.x === "number" &&
-                           typeof event.reading.x !== null &&
-                           typeof event.reading.y === "number" &&
-                           typeof event.reading.y !== null &&
-                           typeof event.reading.z === "number" &&
-                           typeof event.reading.z !== null,
+                    assert(typeof sensor.x === "number" &&
+                           typeof sensor.x !== null &&
+                           typeof sensor.y === "number" &&
+                           typeof sensor.y !== null &&
+                           typeof sensor.z === "number" &&
+                           typeof sensor.z !== null,
                            "sensor: reading value for '" + sensorType + "'");
 
-                    middleNum = event.reading.x;
-                    event.reading.x = middleNum + 1;
-                    assert(event.reading.x === middleNum,
+                    middleNum = sensor.x;
+                    sensor.x = middleNum + 1;
+                    assert(sensor.x === middleNum,
                            "sensor: reading is readonly property");
 
                     console.log(sensorType + ": " +
-                                " x=" + event.reading.x +
-                                " y=" + event.reading.y +
-                                " z=" + event.reading.z);
+                                " x=" + sensor.x +
+                                " y=" + sensor.y +
+                                " z=" + sensor.z);
                 }
 
                 changeFlag = false;

--- a/samples/Accelerometer.js
+++ b/samples/Accelerometer.js
@@ -12,11 +12,11 @@ var sensor = new Accelerometer({
     frequency: updateFrequency
 });
 
-sensor.onchange = function(event) {
+sensor.onchange = function() {
     console.log("acceleration (m/s^2): " +
-                " x=" + event.reading.x +
-                " y=" + event.reading.y +
-                " z=" + event.reading.z);
+                " x=" + sensor.x +
+                " y=" + sensor.y +
+                " z=" + sensor.z);
 };
 
 sensor.onstatechange = function(event) {

--- a/samples/AmbientLight.js
+++ b/samples/AmbientLight.js
@@ -35,7 +35,7 @@ var sensor = new AmbientLightSensor({
 });
 
 sensor.onchange = function(event) {
-    var val = event.reading.illuminance;
+    var val = sensor.illuminance;
     if (val <= 1) {
         console.log("(very dark): " + event.reading.illuminance);
     } else if (val > 1 && val <= 50) {

--- a/samples/Gyroscope.js
+++ b/samples/Gyroscope.js
@@ -11,11 +11,11 @@ var sensor = new Gyroscope({
     frequency: updateFrequency
 });
 
-sensor.onchange = function(event) {
+sensor.onchange = function() {
     console.log("rotation (rad/s): " +
-                " x=" + event.reading.x +
-                " y=" + event.reading.y +
-                " z=" + event.reading.z);
+                " x=" + sensor.x +
+                " y=" + sensor.y +
+                " z=" + sensor.z);
 };
 
 sensor.onstatechange = function(event) {

--- a/samples/SensorBLEDemo.js
+++ b/samples/SensorBLEDemo.js
@@ -102,12 +102,12 @@ var gyro = new Gyroscope({
     frequency: updateFrequency
 });
 
-accel.onchange = function(event) {
-    SensorCharacteristic.valueChange(1, event.reading.x, event.reading.y, event.reading.z);
+accel.onchange = function() {
+    SensorCharacteristic.valueChange(1, accel.x, accel.y, accel.z);
 };
 
-gyro.onchange = function(event) {
-    SensorCharacteristic.valueChange(0, event.reading.x, event.reading.y, event.reading.z);
+gyro.onchange = function() {
+    SensorCharacteristic.valueChange(0, gyro.x, gyro.y, gyro.z);
 };
 
 accel.onerror = function(event) {

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -407,12 +407,12 @@ static void zjs_sensor_onstop_c_callback(void *h, void *argv)
     jerry_value_t null_val = jerry_create_null();
     switch(handle->channel) {
     case SENSOR_CHAN_ACCEL_XYZ:
-    case SENSOR_CHAN_GYRO_XYZ: ;
+    case SENSOR_CHAN_GYRO_XYZ:
         zjs_set_readonly_property(obj, "x", null_val);
         zjs_set_readonly_property(obj, "y", null_val);
         zjs_set_readonly_property(obj, "z", null_val);
         break;
-    case SENSOR_CHAN_LIGHT: ;
+    case SENSOR_CHAN_LIGHT:
         zjs_set_readonly_property(obj, "illuminance", null_val);
         break;
 

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -216,20 +216,21 @@ static void zjs_sensor_update_reading(jerry_value_t obj,
                                       void *reading)
 {
     // update object's internal properties and trigger onchange event
+    double x, y, z, d;
     switch(channel) {
     case SENSOR_CHAN_ACCEL_XYZ:
-    case SENSOR_CHAN_GYRO_XYZ: ;
+    case SENSOR_CHAN_GYRO_XYZ:
         // reading is a ptr to an array of 3 double values
-        double x = ((double *)reading)[0];
-        double y = ((double *)reading)[1];
-        double z = ((double *)reading)[2];
+        x = ((double *)reading)[0];
+        y = ((double *)reading)[1];
+        z = ((double *)reading)[2];
         zjs_obj_add_readonly_number(obj, x, "x");
         zjs_obj_add_readonly_number(obj, y, "y");
         zjs_obj_add_readonly_number(obj, z, "z");
         break;
-    case SENSOR_CHAN_LIGHT: ;
+    case SENSOR_CHAN_LIGHT:
         // reading is a ptr to double
-        double d = *((double *)reading);
+        d = *((double *)reading);
         zjs_obj_add_readonly_number(obj, d, "illuminance");
         break;
 


### PR DESCRIPTION
The readings no longer are passed to the event object
in the onchange() callback, but instead stored
as a internal property in the object itself in the
latest W3C spec.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>