### PR TITLE
[build] Re-enable warnings as errors

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -112,7 +112,7 @@ all: linux
 $(BUILD_DIR)/%.o:%.c
 	@mkdir -p $(@D)
 	@echo [CC] $@
-	@gcc -c -o $@ $< $(LINUX_INCLUDES) $(LINUX_DEFINES) $(LINUX_FLAGS)
+	@gcc -c -o $@ $< -Wall -Werror $(LINUX_INCLUDES) $(LINUX_DEFINES) $(LINUX_FLAGS)
 
 .PHONY: linux
 linux: $(BUILD_OBJ)

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -1,10 +1,12 @@
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 OCF_ROOT ?= deps/iotivity-constrained
 
-# TODO: iotivity-constrained uses legacy functions so the -Werror flag has to
-#       be removed in order for it to compile. Once iotivity-constrained has
-#       been updated to use the unified kernel API's -Werror can be added back
-ccflags-y += -Wall
+ccflags-y += -Wall -Werror
+
+# TODO: iotivity-constrained gives some warnings and until we figure out how to
+#       disable them just for iotivity-constrained, we need to turn them back
+#       into warnings
+ccflags-y += -Wno-error=format
 
 # Select extended ANSI C/POSIX function set in recent Newlib versions
 ccflags-y += -D_XOPEN_SOURCE=700

--- a/src/ashell/Makefile
+++ b/src/ashell/Makefile
@@ -38,3 +38,5 @@ obj-y += comms-shell.o
 obj-y += shell-state.o
 
 obj-y += ../../deps/ihex/kk_ihex_read.o
+
+ccflags-y += -Wall -Werror

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -90,8 +90,7 @@ static void javascript_print_error(jerry_value_t error_value)
         err_str = "[Error message too long]";
     }
 
-    jerry_port_log(JERRY_LOG_LEVEL_ERROR, err_str);
-    jerry_port_log(JERRY_LOG_LEVEL_ERROR, "\n");
+    jerry_port_log(JERRY_LOG_LEVEL_ERROR, "%s\n", err_str);
     zjs_free(msg);
 }
 

--- a/src/ashell/webusb-handler.c
+++ b/src/ashell/webusb-handler.c
@@ -123,8 +123,8 @@ const uint8_t webusb_origin_url_2[] = {
  *
  * @return  0 on success, negative errno code on fail
  */
-int webusb_custom_handler(struct usb_setup_packet *pSetup,
-		int *len, uint8_t **data)
+int webusb_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
+                          uint8_t **data)
 {
     if (GET_DESC_TYPE(pSetup->wValue) == DESCRIPTOR_TYPE_BOS) {
         *data = (uint8_t *)(&webusb_bos_descriptor);
@@ -145,8 +145,8 @@ int webusb_custom_handler(struct usb_setup_packet *pSetup,
  *
  * @return  0 on success, negative errno code on fail.
  */
-int webusb_vendor_handler(struct usb_setup_packet *pSetup,
-		int *len, uint8_t **data)
+int webusb_vendor_handler(struct usb_setup_packet *pSetup, int32_t *len,
+                          uint8_t **data)
 {
     /* Get Allowed origins request */
     if (pSetup->bRequest == 0x01 && pSetup->wIndex == 0x01) {

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -205,7 +205,7 @@ static jerry_value_t zjs_ble_read_callback_function(const jerry_value_t function
     return ZJS_UNDEFINED;
 }
 
-static void zjs_ble_read_c_callback(void *handle, void *argv)
+static void zjs_ble_read_c_callback(void *handle, const void *argv)
 {
     ble_characteristic_t *chrc = (ble_characteristic_t *)handle;
     ble_handle_t *cb = &chrc->read_cb;
@@ -301,7 +301,7 @@ static jerry_value_t zjs_ble_write_callback_function(const jerry_value_t functio
     return ZJS_UNDEFINED;
 }
 
-static void zjs_ble_write_c_callback(void *handle, void *argv)
+static void zjs_ble_write_c_callback(void *handle, const void *argv)
 {
     ble_characteristic_t *chrc = (ble_characteristic_t *)handle;
     ble_handle_t *cb = &chrc->write_cb;
@@ -402,7 +402,7 @@ static jerry_value_t zjs_ble_update_value_callback_function(const jerry_value_t 
     return zjs_error("updateValueCallback: buffer not found or empty");
 }
 
-static void zjs_ble_subscribe_c_callback(void *handle, void *argv)
+static void zjs_ble_subscribe_c_callback(void *handle, const void *argv)
 {
     ble_characteristic_t *chrc = (ble_characteristic_t *)handle;
     ble_notify_handle_t *cb = &chrc->subscribe_cb;
@@ -418,7 +418,7 @@ static void zjs_ble_subscribe_c_callback(void *handle, void *argv)
     }
 }
 
-static void zjs_ble_unsubscribe_c_callback(void *handle, void *argv)
+static void zjs_ble_unsubscribe_c_callback(void *handle, const void *argv)
 {
     ble_characteristic_t *chrc = (ble_characteristic_t *)handle;
     ble_notify_handle_t *cb = &chrc->unsubscribe_cb;
@@ -429,7 +429,7 @@ static void zjs_ble_unsubscribe_c_callback(void *handle, void *argv)
     }
 }
 
-static void zjs_ble_notify_c_callback(void *handle, void *argv)
+static void zjs_ble_notify_c_callback(void *handle, const void *argv)
 {
     ble_characteristic_t *chrc = (ble_characteristic_t *)handle;
     ble_notify_handle_t *cb = &chrc->notify_cb;
@@ -474,7 +474,7 @@ static void zjs_ble_blvl_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16
     }
 }
 
-static void zjs_ble_connected_c_callback(void *handle, void *argv)
+static void zjs_ble_connected_c_callback(void *handle, const void *argv)
 {
     char *addr = (char *)argv;
     ZVAL arg = jerry_create_string((jerry_char_t *)addr);
@@ -496,7 +496,7 @@ static void zjs_ble_connected(struct bt_conn *conn, uint8_t err)
     }
 }
 
-static void zjs_ble_disconnected_c_callback(void *handle, void *argv)
+static void zjs_ble_disconnected_c_callback(void *handle, const void *argv)
 {
     char *addr = (char *)argv;
     ZVAL arg = jerry_create_string((jerry_char_t *)addr);
@@ -535,7 +535,7 @@ static struct bt_conn_auth_cb zjs_ble_auth_cb_display = {
         .cancel = zjs_ble_auth_cancel,
 };
 
-static void zjs_ble_ready_c_callback(void *handle, void *argv)
+static void zjs_ble_ready_c_callback(void *handle, const void *argv)
 {
     ZVAL arg = jerry_create_string((jerry_char_t *)"poweredOn");
     zjs_trigger_event(ble_conn.ble_obj, "stateChange", &arg, 1, NULL, NULL);

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -469,7 +469,7 @@ void print_callbacks(void)
 #define print_callbacks() do {} while (0)
 #endif
 
-void zjs_call_callback(zjs_callback_id id, void *data, uint32_t sz)
+void zjs_call_callback(zjs_callback_id id, const void *data, uint32_t sz)
 {
     if (id == -1 || id > cb_size || !cb_map[id]) {
         ERR_PRINT("callback %d does not exist\n", id);

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -32,7 +32,7 @@ typedef void (*zjs_post_callback_func)(void *handle);
  *
  * @param handle        Handle registered by zjs_add_c_callback()
  */
-typedef void (*zjs_c_callback_func)(void *handle, void *args);
+typedef void (*zjs_c_callback_func)(void *handle, const void *args);
 
 /*
  * Initialize the callback module
@@ -192,7 +192,7 @@ zjs_callback_id zjs_add_c_callback(void *handle, zjs_c_callback_func callback);
  * @param data          Callback arguments
  * @param sz            Size of callback arguments in bytes
  */
-void zjs_call_callback(zjs_callback_id id, void *data, uint32_t sz);
+void zjs_call_callback(zjs_callback_id id, const void *data, uint32_t sz);
 
 /*
  * Service the callback module. Any callback's that have been signaled will

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -365,7 +365,7 @@ static jerry_value_t get_listeners(const jerry_value_t function_obj,
 
 bool zjs_trigger_event(jerry_value_t obj,
                        const char *event,
-                       const jerry_value_t *argv,
+                       const jerry_value_t argv[],
                        uint32_t argc,
                        zjs_post_event post,
                        void *h)
@@ -405,7 +405,7 @@ bool zjs_trigger_event(jerry_value_t obj,
 
 bool zjs_trigger_event_now(jerry_value_t obj,
                            const char *event,
-                           jerry_value_t argv[],
+                           const jerry_value_t argv[],
                            uint32_t argc,
                            zjs_post_event post,
                            void *h)

--- a/src/zjs_event.h
+++ b/src/zjs_event.h
@@ -32,7 +32,8 @@ void zjs_make_event(jerry_value_t obj, jerry_value_t prototype);
  * @param event         Name of new/existing event
  * @param listener      Function to be called when the event is triggered
  */
-void zjs_add_event_listener(jerry_value_t obj, const char *event, jerry_value_t listener);
+void zjs_add_event_listener(jerry_value_t obj, const char *event,
+                            jerry_value_t listener);
 
 /**
  * Trigger an event
@@ -52,12 +53,9 @@ void zjs_add_event_listener(jerry_value_t obj, const char *event, jerry_value_t 
  *
  * @return              True if there were listeners
  */
-bool zjs_trigger_event(jerry_value_t obj,
-                       const char *event,
-                       const jerry_value_t *args,
-                       uint32_t args_cnt,
-                       zjs_post_event post,
-                       void *handle);
+bool zjs_trigger_event(jerry_value_t obj, const char *event,
+                       const jerry_value_t argv[], uint32_t argc,
+                       zjs_post_event post, void *handle);
 
 /**
  * Call any registered event listeners immediately
@@ -71,12 +69,9 @@ bool zjs_trigger_event(jerry_value_t obj,
  *
  * @return              True if there were listeners
  */
-bool zjs_trigger_event_now(jerry_value_t obj,
-                           const char *event,
-                           jerry_value_t argv[],
-                           uint32_t argc,
-                           zjs_post_event post,
-                           void *h);
+bool zjs_trigger_event_now(jerry_value_t obj, const char *event,
+                           const jerry_value_t argv[], uint32_t argc,
+                           zjs_post_event post, void *h);
 
 /**
  * Initialize the event module

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -101,7 +101,7 @@ static jerry_value_t lookup_pin(const jerry_value_t pin_obj,
 }
 
 // C callback from task context in response to GPIO input interrupt
-static void zjs_gpio_c_callback(void *h, void *args)
+static void zjs_gpio_c_callback(void *h, const void *args)
 {
     gpio_handle_t *handle = (gpio_handle_t *)h;
     if (handle->closed) {

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -158,7 +158,7 @@ static jerry_value_t native_require_handler(const jerry_value_t function_obj,
     // Linux can pass in the script at runtime, so we have to read in/parse any
     // JS modules now rather than at compile time
     char full_path[size + 9];
-    char *str;
+    const char *str;
     uint32_t len;
     sprintf(full_path, "modules/%s", module);
     full_path[size + 8] = '\0';

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -112,7 +112,8 @@ void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,
               handle);
 }
 
-void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
+void zjs_fulfill_promise(jerry_value_t obj, const jerry_value_t argv[],
+                         uint32_t argc)
 {
     zjs_promise_t *handle = NULL;
     ZVAL promise_obj = zjs_get_property(obj, "promise");
@@ -134,7 +135,8 @@ void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
     }
 }
 
-void zjs_reject_promise(jerry_value_t obj, jerry_value_t argv[], uint32_t argc)
+void zjs_reject_promise(jerry_value_t obj, const jerry_value_t argv[],
+                        uint32_t argc)
 {
     zjs_promise_t *handle = NULL;
     ZVAL promise_obj = zjs_get_property(obj, "promise");

--- a/src/zjs_promise.h
+++ b/src/zjs_promise.h
@@ -20,7 +20,7 @@ typedef void (*zjs_post_promise_func)(void *handle);
  * @param handle        Handle passed to post function
  */
 void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,
-                         void *handle);
+                      void *handle);
 
 /*
  * Fulfill a promise
@@ -29,7 +29,8 @@ void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,
  * @param args          Array of args that will be given to then()
  * @param argc          Number of arguments in args
  */
-void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t args[], uint32_t argc);
+void zjs_fulfill_promise(jerry_value_t obj, const jerry_value_t args[],
+                         uint32_t argc);
 
 /*
  * Reject a promise
@@ -38,6 +39,7 @@ void zjs_fulfill_promise(jerry_value_t obj, jerry_value_t args[], uint32_t argc)
  * @param args          Array of args that will be given to catch()
  * @param argc          Number of arguments in args
  */
-void zjs_reject_promise(jerry_value_t obj, jerry_value_t args[], uint32_t argc);
+void zjs_reject_promise(jerry_value_t obj, const jerry_value_t args[],
+                        uint32_t argc);
 
 #endif /* __zjs_promises_h__ */

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -213,7 +213,7 @@ static void zjs_sensor_set_state(jerry_value_t obj, enum sensor_state state)
 
 static void zjs_sensor_update_reading(jerry_value_t obj,
                                       enum sensor_channel channel,
-                                      void *reading)
+                                      const void *reading)
 {
     // update reading property and trigger onchange event
     ZVAL reading_obj = jerry_create_object();
@@ -272,7 +272,7 @@ static void zjs_sensor_trigger_error(jerry_value_t obj,
     }
 }
 
-static void zjs_sensor_onchange_c_callback(void *h, void *argv)
+static void zjs_sensor_onchange_c_callback(void *h, const void *argv)
 {
     sensor_handle_t *handle = (sensor_handle_t *)h;
     if (!handle) {
@@ -354,7 +354,7 @@ static void zjs_sensor_callback_free(uintptr_t handle)
     zjs_free((sensor_handle_t *)handle);
 }
 
-static void zjs_sensor_onstart_c_callback(void *h, void *argv)
+static void zjs_sensor_onstart_c_callback(void *h, const void *argv)
 {
     sensor_handle_t *handle = (sensor_handle_t *)h;
     if (!handle) {
@@ -392,7 +392,7 @@ static void zjs_sensor_onstart_c_callback(void *h, void *argv)
     zjs_sensor_set_state(obj, SENSOR_STATE_ACTIVATED);
 }
 
-static void zjs_sensor_onstop_c_callback(void *h, void *argv)
+static void zjs_sensor_onstop_c_callback(void *h, const void *argv)
 {
     sensor_handle_t *handle = (sensor_handle_t *)h;
     if (!handle) {

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -100,7 +100,7 @@ static void post_event(void *h)
     jerry_release_value(handle->buf_obj);
 }
 
-static void uart_c_callback(void *h, void *args)
+static void uart_c_callback(void *h, const void *args)
 {
     if (!handle) {
         DBG_PRINT("UART handle not found\n");
@@ -112,7 +112,8 @@ static void uart_c_callback(void *h, void *args)
 
         memcpy(buffer->buffer, args, handle->size);
 
-        zjs_trigger_event_now(handle->uart_obj, "read", &handle->buf_obj, 1, post_event, NULL);
+        zjs_trigger_event_now(handle->uart_obj, "read", &handle->buf_obj, 1,
+                              post_event, NULL);
 
         handle->size = 0;
     }


### PR DESCRIPTION
Add one exception for format errors to allow iotivity-constrained build
to succeed, but we should follow up with a patch to that project.

Also, add the flags to linux and ashell builds, for the first time.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>