### PR TITLE
[util] Run JrS garbage collection and retry upon malloc failure

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
 #endif
 {
 #ifndef ZJS_SNAPSHOT_BUILD
-    const char *script = NULL;
+    char *script = NULL;
     jerry_value_t code_eval;
     uint32_t len;
 #endif

--- a/src/snapshot.c
+++ b/src/snapshot.c
@@ -47,7 +47,7 @@ static int generate_snapshot(const char *file_name, uint8_t *buf, int buf_size)
 
 int main(int argc, char *argv[])
 {
-    const char *script = NULL;
+    char *script = NULL;
     uint32_t len;
 
     jerry_init(JERRY_INIT_EMPTY);

--- a/src/zjs_script.c
+++ b/src/zjs_script.c
@@ -7,7 +7,7 @@
 
 #include "zjs_script.h"
 
-uint8_t zjs_read_script(char *name, const char **script, uint32_t *length)
+uint8_t zjs_read_script(char *name, char **script, uint32_t *length)
 {
     if (name) {
         char *s;
@@ -55,7 +55,7 @@ uint8_t zjs_read_script(char *name, const char **script, uint32_t *length)
     return 0;
 }
 
-void zjs_free_script(const char *script)
+void zjs_free_script(char *script)
 {
     if (script) {
         zjs_free(script);

--- a/src/zjs_script.h
+++ b/src/zjs_script.h
@@ -8,8 +8,8 @@
 
 #include <stdlib.h>
 
-uint8_t zjs_read_script(char *name, const char **script, uint32_t *length);
+uint8_t zjs_read_script(char *name, char **script, uint32_t *length);
 
-void zjs_free_script(const char *script);
+void zjs_free_script(char *script);
 
 #endif /* ZJS_SCRIPT_H_ */

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -5,15 +5,12 @@
 // ZJS includes
 #include "zjs_util.h"
 
-static int zjs_malloc_error_count = 0;
-
 void *zjs_malloc_with_retry(size_t size)
 {
     void *ptr = malloc(size);
     if (!ptr) {
         // see if stale JerryScript objects are holding memory
         jerry_gc();
-        ++zjs_malloc_error_count;
         ptr = malloc(size);
     }
     return ptr;

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -5,6 +5,20 @@
 // ZJS includes
 #include "zjs_util.h"
 
+static int zjs_malloc_error_count = 0;
+
+void *zjs_malloc_with_retry(size_t size)
+{
+    void *ptr = malloc(size);
+    if (!ptr) {
+        // see if stale JerryScript objects are holding memory
+        jerry_gc();
+        ++zjs_malloc_error_count;
+        ptr = malloc(size);
+    }
+    return ptr;
+}
+
 void zjs_set_property(const jerry_value_t obj, const char *name,
                       const jerry_value_t prop)
 {

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -13,17 +13,17 @@
 
 #define ZJS_UNDEFINED jerry_create_undefined()
 
+void *zjs_malloc_with_retry(size_t size);
+
 #ifdef ZJS_LINUX_BUILD
 #define zjs_malloc(sz) malloc(sz)
-#define zjs_free(ptr) free((void *)ptr)
+#define zjs_free(ptr) free(ptr)
 #else
 #ifdef ZJS_TRACE_MALLOC
-#include <zephyr.h>
-#define zjs_malloc(sz) ({void *zjs_ptr = malloc(sz); ZJS_PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, (uint32_t)sz, zjs_ptr); zjs_ptr;})
+#define zjs_malloc(sz) ({void *zjs_ptr = zjs_malloc_with_retry(sz); ZJS_PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, (uint32_t)sz, zjs_ptr); zjs_ptr;})
 #define zjs_free(ptr) (ZJS_PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), free(ptr))
 #else
-#include <zephyr.h>
-#define zjs_malloc(sz) malloc(sz)
+#define zjs_malloc(sz) zjs_malloc_with_retry(sz)
 #define zjs_free(ptr) free(ptr)
 #endif  // ZJS_TRACE_MALLOC
 #endif  // ZJS_LINUX_BUILD

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -13,6 +13,11 @@
 
 #define ZJS_UNDEFINED jerry_create_undefined()
 
+/**
+ * Call malloc but if it fails, run JerryScript garbage collection and retry
+ *
+ * @param size  Number of bytes to allocate
+ */
 void *zjs_malloc_with_retry(size_t size);
 
 #ifdef ZJS_LINUX_BUILD
@@ -23,7 +28,7 @@ void *zjs_malloc_with_retry(size_t size);
 #define zjs_malloc(sz) ({void *zjs_ptr = zjs_malloc_with_retry(sz); ZJS_PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, (uint32_t)sz, zjs_ptr); zjs_ptr;})
 #define zjs_free(ptr) (ZJS_PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), free(ptr))
 #else
-#define zjs_malloc(sz) zjs_malloc_with_retry(sz)
+#define zjs_malloc(sz) ({void *zjs_ptr = zjs_malloc_with_retry(sz); if (!zjs_ptr) {ERR_PRINT("malloc failed");} zjs_ptr;})
 #define zjs_free(ptr) free(ptr)
 #endif  // ZJS_TRACE_MALLOC
 #endif  // ZJS_LINUX_BUILD

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -24,6 +24,7 @@ void *zjs_malloc_with_retry(size_t size);
 #define zjs_malloc(sz) malloc(sz)
 #define zjs_free(ptr) free(ptr)
 #else
+#include <zephyr.h>
 #ifdef ZJS_TRACE_MALLOC
 #define zjs_malloc(sz) ({void *zjs_ptr = zjs_malloc_with_retry(sz); ZJS_PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, (uint32_t)sz, zjs_ptr); zjs_ptr;})
 #define zjs_free(ptr) (ZJS_PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), free(ptr))


### PR DESCRIPTION
If we get a malloc failure, it may be because there are JavaScript
objects that hold references to C memory through handles that can't
be freed until they are garbage collected.

This fixes issues #757.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>