### PR TITLE
[general] Fix format warnings that appear with SDK 0.9

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -104,7 +104,7 @@ static jerry_value_t zjs_aio_call_remote_function(zjs_ipm_message_t *send)
     }
 
     if (reply.error_code != ERROR_IPM_NONE) {
-        ERR_PRINT("error code: %lu\n", reply.error_code);
+        ERR_PRINT("error code: %u\n", (unsigned int)reply.error_code);
         return zjs_error("zjs_aio_call_remote_function: error received");
     }
 
@@ -153,7 +153,8 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
             break;
 
         default:
-            ERR_PRINT("IPM message not handled %lu\n", msg->type);
+            ERR_PRINT("IPM message not handled %u\n",
+                      (unsigned int)msg->type);
         }
     }
 }

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -722,11 +722,11 @@ static jerry_value_t zjs_ble_start_advertising(const jerry_value_t function_obj,
         }
 
         const int MAX_UUID_LENGTH = 4;
-        unsigned int size = MAX_UUID_LENGTH + 1;
+        jerry_size_t size = MAX_UUID_LENGTH + 1;
         char ubuf[size];
         zjs_copy_jstring(uuid, ubuf, &size);
         if (size != MAX_UUID_LENGTH) {
-            ERR_PRINT("SIZE: %u\n", size);
+            ERR_PRINT("SIZE: %u\n", (unsigned int)size);
             return zjs_error("zjs_ble_adv_start: unexpected uuid length");
         }
 

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -266,8 +266,8 @@ static ssize_t zjs_ble_read_attr_callback(struct bt_conn *conn,
             ERR_PRINT("buffer is empty\n");
             return BT_GATT_ERR(BT_ATT_ERR_NOT_SUPPORTED);
         } else {
-            ERR_PRINT("on read attr error %lu\n",
-                  chrc->read_cb.error_code);
+            ERR_PRINT("on read attr error %u\n",
+                      (unsigned int)chrc->read_cb.error_code);
             return BT_GATT_ERR(chrc->read_cb.error_code);
         }
     }
@@ -722,11 +722,11 @@ static jerry_value_t zjs_ble_start_advertising(const jerry_value_t function_obj,
         }
 
         const int MAX_UUID_LENGTH = 4;
-        jerry_size_t size = MAX_UUID_LENGTH + 1;
+        unsigned int size = MAX_UUID_LENGTH + 1;
         char ubuf[size];
         zjs_copy_jstring(uuid, ubuf, &size);
         if (size != MAX_UUID_LENGTH) {
-            ERR_PRINT("SIZE: %lu\n", size);
+            ERR_PRINT("SIZE: %u\n", size);
             return zjs_error("zjs_ble_adv_start: unexpected uuid length");
         }
 

--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -53,8 +53,8 @@ static bool value2str(const jerry_value_t value, char *buf, int maxlen,
     //  returns: true if the representation was complete or false if it
     //             was abbreviated
     if (jerry_value_is_array(value)) {
-        uint32_t len = jerry_get_array_length(value);
-        sprintf(buf, "[Array - length %lu]", len);
+        unsigned int len = jerry_get_array_length(value);
+        sprintf(buf, "[Array - length %u]", len);
         return false;
     }
     else if (jerry_value_is_boolean(value)) {
@@ -71,20 +71,15 @@ static bool value2str(const jerry_value_t value, char *buf, int maxlen,
             double num = jerry_get_number_value(value);
             sprintf(buf, "%f", num);
 #else
-            int32_t num = (int32_t)jerry_get_number_value(value);
-            sprintf(buf, "[Float ~%li]", num);
+            int num = (int)jerry_get_number_value(value);
+            sprintf(buf, "[Float ~%d]", num);
 #endif
         } else if (type == IS_UINT) {
-            uint32_t num = (uint32_t)jerry_get_number_value(value);
-            sprintf(buf, "%lu", num);
+            unsigned int num = jerry_get_number_value(value);
+            sprintf(buf, "%u", num);
         } else if (type == IS_INT) {
-            int32_t num = (int32_t)jerry_get_number_value(value);
-            // Linux and Zephyr print int32_t's differently if %li is used
-#ifdef ZJS_LINUX_BUILD
-            sprintf(buf, "%i", num);
-#else
-            sprintf(buf, "%li", num);
-#endif
+            int num = jerry_get_number_value(value);
+            sprintf(buf, "%d", num);
         }
     }
     else if (jerry_value_is_null(value)) {
@@ -97,7 +92,7 @@ static bool value2str(const jerry_value_t value, char *buf, int maxlen,
     else if (jerry_value_is_string(value)) {
         jerry_size_t size = jerry_get_string_size(value);
         if (size >= maxlen) {
-            sprintf(buf, "[String - length %lu]", size);
+            sprintf(buf, "[String - length %u]", (unsigned int)size);
         }
         else {
             char buffer[++size];
@@ -207,7 +202,7 @@ static jerry_value_t console_time_end(const jerry_value_t function_obj,
     }
 
     uint32_t start = (uint32_t)jerry_get_number_value(num);
-    uint32_t milli = zjs_port_timer_get_uptime() - start;
+    unsigned int milli = zjs_port_timer_get_uptime() - start;
 
     char *label = zjs_alloc_from_jstring(argv[0], NULL);
     const char *const_label = "unknown";
@@ -215,7 +210,8 @@ static jerry_value_t console_time_end(const jerry_value_t function_obj,
         const_label = label;
     }
 
-    ZJS_PRINT("%s: %lums\n", const_label, milli);
+    // this print is part of the expected behavior for the user, don't remove
+    ZJS_PRINT("%s: %ums\n", const_label, milli);
     zjs_free(label);
     return ZJS_UNDEFINED;
 }

--- a/src/zjs_grove_lcd_ipm.c
+++ b/src/zjs_grove_lcd_ipm.c
@@ -60,7 +60,7 @@ static jerry_value_t zjs_glcd_call_remote_function(zjs_ipm_message_t *send)
     }
 
     if (reply.error_code != ERROR_IPM_NONE) {
-        ERR_PRINT("error code: %lu\n", reply.error_code);
+        ERR_PRINT("error code: %u\n", (unsigned int)reply.error_code);
         return zjs_error("zjs_glcd_call_remote_function: error received");
     }
 

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -119,7 +119,7 @@ void zjs_fulfill_promise(jerry_value_t obj, const jerry_value_t argv[],
     ZVAL promise_obj = zjs_get_property(obj, "promise");
 
     if (!jerry_value_is_object(promise_obj)) {
-        ERR_PRINT("'promise' not found in object %lu\n", obj);
+        ERR_PRINT("'promise' not found in object\n");
         return;
     }
 
@@ -142,7 +142,7 @@ void zjs_reject_promise(jerry_value_t obj, const jerry_value_t argv[],
     ZVAL promise_obj = zjs_get_property(obj, "promise");
 
     if (!jerry_value_is_object(promise_obj)) {
-        ERR_PRINT("'promise' not found in object %lu\n", obj);
+        ERR_PRINT("'promise' not found in object\n");
         return;
     }
 

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -250,7 +250,7 @@ char *zjs_alloc_from_jstring(jerry_value_t jstr, jerry_size_t *maxlen)
     jerry_size_t size = jerry_get_string_size(jstr);
     char *buffer = zjs_malloc(size + 1);
     if (!buffer) {
-        ERR_PRINT("allocation failed (%lu bytes)\n", size + 1);
+        ERR_PRINT("allocation failed (%u bytes)\n", (unsigned int)(size + 1));
         return NULL;
     }
 


### PR DESCRIPTION
uint32_t is now (properly) defined as unsigned int, instead of unsigned
long, which we'd worked around with incorrect format specifiers for the
last year.

Fixed the warnings from building HelloWorld and WebBT demo so far.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>