### PR TITLE
[dgram] Fix error introduced by ZVAL patch, add dgram to trlite

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -135,7 +135,8 @@ if [ "$VM1" == "y" ]; then
     ROMSIZE=215
 
     # individually test build modules with short names (ten chars or less)
-    SHORTMODULES=(aio ble events gpio grove_lcd i2c k64f_pins ocf pwm uart)
+    SHORTMODULES=(aio ble dgram events gpio grove_lcd i2c k64f_pins ocf pwm \
+                      uart)
     for index in "${!SHORTMODULES[@]}"; do
         MODULE=${SHORTMODULES[index]}
         echo "var module = require('$MODULE');" > $TMPFILE

--- a/src/zjs_dgram.c
+++ b/src/zjs_dgram.c
@@ -215,7 +215,7 @@ static void udp_sent(struct net_context *context, int status, void *token,
     DBG_PRINT("udp_sent: %p, st=%d udata=%p\n", context, status, user_data);
 
     if (user_data) {
-        ZVAL rval = ZJS_UNDEFINED;
+        ZVAL_MUTABLE rval = ZJS_UNDEFINED;
         if (status != 0) {
             char errbuf[8];
             snprintf(errbuf, sizeof(errbuf), "%d", status);


### PR DESCRIPTION
Now dgram module will build in trlite to catch future bugs earlier.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>