### PR TITLE
[i2c] Disallow invalid bus #1 on Arduino 101

### DIFF
--- a/src/zjs_i2c_handler.c
+++ b/src/zjs_i2c_handler.c
@@ -2,9 +2,6 @@
 #include "zjs_i2c_handler.h"
 #include "zjs_common.h"
 
-#define I2C_0 0
-#define I2C_1 1
-
 #ifdef CONFIG_BOARD_ARDUINO_101_SSS
 #define MAX_I2C_BUS 1
 #else

--- a/src/zjs_i2c_handler.c
+++ b/src/zjs_i2c_handler.c
@@ -2,6 +2,8 @@
 #include "zjs_i2c_handler.h"
 #include "zjs_common.h"
 
+// The Arduino 101 has two I2C busses, but I2C_SS_1 isn't connected to anything.
+// So we have disabled the ability to connect to it, to avoid user confusion
 #ifdef CONFIG_BOARD_ARDUINO_101_SSS
 #define MAX_I2C_BUS 1
 #else

--- a/src/zjs_i2c_handler.c
+++ b/src/zjs_i2c_handler.c
@@ -4,7 +4,12 @@
 
 #define I2C_0 0
 #define I2C_1 1
+
+#ifdef CONFIG_BOARD_ARDUINO_101_SSS
+#define MAX_I2C_BUS 1
+#else
 #define MAX_I2C_BUS 2
+#endif
 
 #define I2C_BUS "I2C_"
 


### PR DESCRIPTION
I2C will now throw an error if you try and access the
I2C_SS_1 bus on Arduino 101, since it's not connected
to anything.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>