### PR TITLE
[sensor] support for different controllers in constructor

### DIFF
--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_ipm_h__
 #define __zjs_ipm_h__
@@ -108,6 +108,7 @@ typedef struct zjs_ipm_message {
         // SENSOR
         struct sensor_data {
             enum sensor_channel channel;
+            char *controller;
             uint32_t pin;
             uint32_t frequency;
             union sensor_reading {


### PR DESCRIPTION
Allow app to pass sensor driver name by setting controller
string in constructor, for Accelerometer and Gyroscope, the
default controller is "bmi160"

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>