### PR TITLE
[trlite] Check that copyrights have been updated in modified files

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2016, Intel Corporation.
+# Copyright (c) 2016-2017, Intel Corporation.
 # Author: Geoff Gustafson <geoff@linux.intel.com>
 
 # trlite - a local version of the tests we run in Travis
@@ -61,6 +61,9 @@ rm -rf $TRLDIR
 echo Building ZJS tree: "$ZJS_BASE"
 echo Cloning git tree...
 git clone -l $ZJS_BASE $TRLDIR > /dev/null 2>&1
+
+# we need to refer to master later for diffs
+cp $ZJS_BASE/.git/refs/heads/master $TRLDIR/.git/refs/heads
 
 echo Cloning git submodules...
 cd $TRLDIR/deps
@@ -217,6 +220,37 @@ function check_jstring_others() {
     fi
 }
 
+function check_copyright() {
+    SRCFILES=$(find arc modules samples src tests | grep -v outdir | grep "\.js$\|\.[ch]$" | sort)
+
+    YEAR=$(date +%G)
+    RVAL=0
+
+    if [ -z $TRAVIS_COMMIT_RANGE ]; then
+        NAMES=$(git diff --name-only master)
+    else
+        # work around issue https://github.com/travis-ci/travis-ci/issues/4596
+        NAMES=$(git diff --name-only ${TRAVIS_COMMIT_RANGE/.../..})
+    fi
+
+    # find intersection of NAMES and SRCFILES (requires sorted lists)
+    MATCHES=$(comm -12 <(echo $NAMES | tr ' ' '\n') <(echo $SRCFILES | tr ' ' '\n'))
+
+    for f in $MATCHES; do
+        # check for Copyright comment
+        if ! $(head -1 $f | grep -q Copyright); then
+            echo No copyright found in first line of $f!
+            RVAL=1
+        # if found, make sure current date is there
+        elif ! $(head -1 $f | grep -q $YEAR); then
+            echo Copyright needs to be updated in $f!
+            RVAL=1
+        fi
+    done
+
+    return $RVAL
+}
+
 if [ "$VM2" == "y" ]; then
     TESTNUM=0
 
@@ -228,6 +262,9 @@ if [ "$VM2" == "y" ]; then
 
     # ensure no other source file uses jerry-string_to_char_buffer
     try_command "jstring2" check_jstring_others
+
+    # check that updated files have updated copyrights
+    try_command "copyright" check_copyright
 
     # linux build tests
     try_command "linux" make $VERBOSE BOARD=linux

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -226,15 +226,17 @@ function check_copyright() {
     YEAR=$(date +%G)
     RVAL=0
 
+    echo TRAVIS_COMMIT_RANGE: $TRAVIS_COMMIT_RANGE
     if [ -z $TRAVIS_COMMIT_RANGE ]; then
         NAMES=$(git diff --name-only master)
     else
         # work around issue https://github.com/travis-ci/travis-ci/issues/4596
         NAMES=$(git diff --name-only ${TRAVIS_COMMIT_RANGE/.../..})
     fi
-
+    echo NAMES: $NAMES
+    
     # find intersection of NAMES and SRCFILES (requires sorted lists)
-    MATCHES=$(comm -12 <(echo $NAMES | tr ' ' '\n') <(echo $SRCFILES | tr ' ' '\n'))
+    MATCHES=$(comm -12 <(echo $NAMES | tr ' ' '\n' | sort) <(echo $SRCFILES | tr ' ' '\n'))
 
     for f in $MATCHES; do
         # check for Copyright comment

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -226,11 +226,14 @@ function check_copyright() {
     YEAR=$(date +%G)
     RVAL=0
 
-    if [ -z $TRAVIS_BRANCH ]; then
+    echo TRAVIS_COMMIT_RANGE: $TRAVIS_COMMIT_RANGE
+    if [ -z $TRAVIS_COMMIT_RANGE ]; then
         NAMES=$(git diff --name-only master)
     else
-        NAMES=$(git diff --name-only $TRAVIS_BRANCH)
+        # work around issue https://github.com/travis-ci/travis-ci/issues/4596
+        NAMES=$(git diff --name-only ${TRAVIS_COMMIT_RANGE/.../..})
     fi
+    echo NAMES: $NAMES
 
     # find intersection of NAMES and SRCFILES (requires sorted lists)
     MATCHES=$(comm -12 <(echo $NAMES | tr ' ' '\n' | sort) <(echo $SRCFILES | tr ' ' '\n'))

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -231,7 +231,7 @@ function check_copyright() {
         NAMES=$(git diff --name-only master)
     else
         # work around issue https://github.com/travis-ci/travis-ci/issues/4596
-        NAMES=$(git diff --name-only ${TRAVIS_COMMIT_RANGE/.../..})
+        NAMES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
     fi
     echo NAMES: $NAMES
 
@@ -241,11 +241,11 @@ function check_copyright() {
     for f in $MATCHES; do
         # check for Copyright comment
         if ! $(head -1 $f | grep -q Copyright); then
-            echo No copyright found in first line of $f!
+            echo Error: Add copyright to first line of $f!
             RVAL=1
         # if found, make sure current date is there
         elif ! $(head -1 $f | grep -q $YEAR); then
-            echo Copyright needs to be updated in $f!
+            echo Error: Add $YEAR to copyright in $f!
             RVAL=1
         fi
     done

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -226,14 +226,12 @@ function check_copyright() {
     YEAR=$(date +%G)
     RVAL=0
 
-    echo TRAVIS_COMMIT_RANGE: $TRAVIS_COMMIT_RANGE
     if [ -z $TRAVIS_COMMIT_RANGE ]; then
         NAMES=$(git diff --name-only master)
     else
         # work around issue https://github.com/travis-ci/travis-ci/issues/4596
         NAMES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
     fi
-    echo NAMES: $NAMES
 
     # find intersection of NAMES and SRCFILES (requires sorted lists)
     MATCHES=$(comm -12 <(echo $NAMES | tr ' ' '\n' | sort) <(echo $SRCFILES | tr ' ' '\n'))

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -234,7 +234,7 @@ function check_copyright() {
         NAMES=$(git diff --name-only ${TRAVIS_COMMIT_RANGE/.../..})
     fi
     echo NAMES: $NAMES
-    
+
     # find intersection of NAMES and SRCFILES (requires sorted lists)
     MATCHES=$(comm -12 <(echo $NAMES | tr ' ' '\n' | sort) <(echo $SRCFILES | tr ' ' '\n'))
 

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -226,14 +226,11 @@ function check_copyright() {
     YEAR=$(date +%G)
     RVAL=0
 
-    echo TRAVIS_COMMIT_RANGE: $TRAVIS_COMMIT_RANGE
-    if [ -z $TRAVIS_COMMIT_RANGE ]; then
+    if [ -z $TRAVIS_BRANCH ]; then
         NAMES=$(git diff --name-only master)
     else
-        # work around issue https://github.com/travis-ci/travis-ci/issues/4596
-        NAMES=$(git diff --name-only ${TRAVIS_COMMIT_RANGE/.../..})
+        NAMES=$(git diff --name-only $TRAVIS_BRANCH)
     fi
-    echo NAMES: $NAMES
 
     # find intersection of NAMES and SRCFILES (requires sorted lists)
     MATCHES=$(comm -12 <(echo $NAMES | tr ' ' '\n' | sort) <(echo $SRCFILES | tr ' ' '\n'))


### PR DESCRIPTION
Only works for .c, .h, and .js files currently. Checks files modified in the
current commit. Checks that the very first line contains a copyright and that
it contains the current year in it.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>