### PR TITLE
[trlite] Update to build ashell the new way

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -246,7 +246,10 @@ if [ "$VM3" == "y" ]; then
 
     # ashell tests
     git clean -dfx
-    try_command "ashell" make $VERBOSE DEV=ashell ROM=256
+    try_command "ashell" make $VERBOSE ashell ROM=250
+
+    # build ide version
+    try_command "ide" make $VERBOSE ide ROM=250
 fi
 
 # clean up on success

--- a/src/ashell/Makefile
+++ b/src/ashell/Makefile
@@ -39,4 +39,7 @@ obj-y += shell-state.o
 
 obj-y += ../../deps/ihex/kk_ihex_read.o
 
+# Select extended ANSI C/POSIX function set in recent Newlib versions
+ccflags-y += -D_XOPEN_SOURCE=700
+
 ccflags-y += -Wall -Werror

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -13,7 +13,6 @@
 #include <ctype.h>
 
 /* JerryScript includes */
-#include "jerry-api.h"
 #include "jerry-port.h"
 
 #include "file-utils.h"

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -138,7 +138,7 @@ int32_t ashell_disk_usage(char *buf)
     ssize_t size = fs_size(file);
     fs_close(file);
 
-    printf("%5ld %s\n", size, filename);
+    printf("%5d %s\n", (unsigned int)size, filename);
     return RET_OK;
 }
 
@@ -220,7 +220,7 @@ int32_t ashell_list_dir(char *buf)
 
     res = fs_opendir(&dp, filename);
     if (res) {
-        printf("Error opening dir [%lu]\n", res);
+        printf("Error opening dir [%d]\n", (int)res);
         return res;
     }
 
@@ -242,8 +242,7 @@ int32_t ashell_list_dir(char *buf)
             for (; *p; ++p)
                 *p = tolower((int)*p);
 
-            printf("%5lu %s\n",
-                   entry.size, entry.name);
+            printf("%5u %s\n", (unsigned int)entry.size, entry.name);
         }
     }
 


### PR DESCRIPTION
Instead of DEV=ashell you now pass an ashell or ide target. Currently,
then only differ by one config line but I build both in Travis to catch
possible future changes.

Also, fixed a build error and a few format warnings w/ 0.9 SDK.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>