### PR TITLE
[ocf] Fix ocf.setBleAddress() and BLE_ADDR

### DIFF
--- a/docs/ocf.md
+++ b/docs/ocf.md
@@ -76,6 +76,10 @@ Zephyr boards with BLE capabilities (e.g. Arduino 101).
 The `address` parameter should be a MAC address string in the format
 `XX:XX:XX:XX:XX:XX` where each character is in HEX format (0-9, A-F).
 
+Note: If the image was built with the `BLE_ADDR` flag, this API has
+no effect. Using the `BLE_ADDR` hard codes the supplied address into
+the image which cannot be changed.
+
 OCF Server
 ----------
 ```javascript

--- a/src/zjs_ocf_ble.c
+++ b/src/zjs_ocf_ble.c
@@ -59,6 +59,7 @@ jerry_value_t zjs_ocf_set_ble_address(const jerry_value_t function_val,
                                       const jerry_value_t argv[],
                                       const jerry_length_t argc)
 {
+#ifndef ZJS_CONFIG_BLE_ADDRESS
     // args: address
     ZJS_VALIDATE_ARGS(Z_STRING);
 
@@ -78,7 +79,7 @@ jerry_value_t zjs_ocf_set_ble_address(const jerry_value_t function_val,
     DBG_PRINT("BLE addr is set to: %s\n", addr);
     BT_ADDR_SET_STATIC(&id_addr.a);
     bt_storage_register(&storage);
-
+#endif
     return ZJS_UNDEFINED;
 }
 

--- a/src/zjs_ocf_ble.h
+++ b/src/zjs_ocf_ble.h
@@ -3,7 +3,9 @@
 #ifndef SRC_ZJS_OCF_BLE_H_
 #define SRC_ZJS_OCF_BLE_H_
 
+#ifndef ZJS_LINUX_BUILD
 #include <bluetooth/storage.h>
+#endif
 
 #include "zjs_util.h"
 

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifdef BUILD_MODULE_OCF
 

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -11,6 +11,7 @@
 #include "zjs_ocf_server.h"
 #include "zjs_ocf_common.h"
 #include "zjs_ocf_encoder.h"
+#include "zjs_ocf_ble.h"
 
 #include "oc_api.h"
 #include <stdio.h>
@@ -457,7 +458,7 @@ jerry_value_t zjs_ocf_init()
     zjs_set_property(ocf_object, "server", server);
 #endif
 
-#ifdef ZJS_CONFIG_BLE_ADDRESS
+#ifndef ZJS_LINUX_BUILD
     zjs_obj_add_function(ocf_object, zjs_ocf_set_ble_address, "setBleAddress");
 #endif
     return ocf_object;


### PR DESCRIPTION
 - Setting the BLE address was broken due to these two
   configurations conflicting

Signed-off-by: James Prestwood <james.prestwood@intel.com>