### PR TITLE
[snapshot] Clean up snapshot tool

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -27,15 +27,10 @@ CORE_SRC +=	src/zjs_buffer.c \
 		src/zjs_unit_tests.c \
 		src/zjs_util.c
 
-ifeq ($(SNAPSHOT), on)
-CORE_SRC +=	src/zjs_snapshot_gen.c
-else
-CORE_SRC +=	src/zjs_script_gen.c
-endif
-
 CORE_OBJ =	$(CORE_SRC:%.c=%.o)
 
 LINUX_INCLUDES += 	-Isrc/ \
+			-I$(ZJS_BASE)/outdir/include \
 			-I$(JERRY_BASE)/jerry-core
 
 JERRY_LIBS += 		-l jerry-core -lm

--- a/scripts/convert.sh
+++ b/scripts/convert.sh
@@ -54,9 +54,7 @@ else
     FLAGS="-r -N 1"
 fi
 
-printf "/* This file was auto-generated */\n\n" > $OUTPUT
-printf "#include \"zjs_common.h\"\n\n" >> $OUTPUT
-printf "const char *script_gen = \"" >> $OUTPUT
+printf "\"" > $OUTPUT
 
 last_char=0
 
@@ -87,11 +85,11 @@ do
     last_char=$char
     COUNT=$((COUNT+1))
     percent $COUNT $SIZE "'$char"
-done < /tmp/gen.tmp
+done < $TMPFILE
 
 printf "\n"
 
 # Terminate the string
-printf "\";" >> $OUTPUT
+printf "\"" >> $OUTPUT
 
 rm -f $TMPFILE

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -60,12 +60,6 @@ obj-$(ZJS_OCF) += zjs_ocf_client.o \
                   zjs_ocf_common.o \
                   zjs_ocf_ble.o
 
-ifeq ($(SNAPSHOT), on)
-obj-y += zjs_snapshot_gen.o
-else
-obj-y += zjs_script_gen.o
-endif
-
 # skip for now for frdm_k64f
 ifeq ($(BOARD), arduino_101)
 	obj-$(ZJS_AIO) += zjs_aio.o

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,7 @@
 const uint32_t snapshot_bytecode[] = {
 #include "zjs_snapshot_gen.h"
 };
-const size_t snapshot_len = sizeof(snapshot_bytecode) / sizeof(uint32_t);
+const size_t snapshot_len = sizeof(snapshot_bytecode);
 #else
 const char script_jscode[] = {
 #include "zjs_script_gen.h"

--- a/src/main.c
+++ b/src/main.c
@@ -41,10 +41,14 @@
 #define ZJS_MAX_PRINT_SIZE      512
 
 #ifdef ZJS_SNAPSHOT_BUILD
-extern const uint32_t snapshot_bytecode[];
-extern const size_t snapshot_len;
+const uint32_t snapshot_bytecode[] = {
+#include "zjs_snapshot_gen.h"
+};
+const size_t snapshot_len = sizeof(snapshot_bytecode) / sizeof(uint32_t);
 #else
-extern const char *script_gen;
+const char script_jscode[] = {
+#include "zjs_script_gen.h"
+};
 #endif
 
 // native eval handler
@@ -191,13 +195,13 @@ int main(int argc, char *argv[])
     // slightly tricky: reuse next section as else clause
 #endif
     {
-        len = strnlen(script_gen, MAX_SCRIPT_SIZE);
+        len = strnlen(script_jscode, MAX_SCRIPT_SIZE);
 #ifdef ZJS_LINUX_BUILD
         script = zjs_malloc(len + 1);
-        memcpy(script, script_gen, len);
+        memcpy(script, script_jscode, len);
         script[len] = '\0';
 #else
-        script = script_gen;
+        script = script_jscode;
 #endif
         if (len == MAX_SCRIPT_SIZE) {
             ERR_PRINT("Script size too large! Increase MAX_SCRIPT_SIZE.\n");

--- a/tools/Makefile.snapshot
+++ b/tools/Makefile.snapshot
@@ -24,7 +24,7 @@ setup:
 		mkdir -p $(ZJS_BASE)/outdir/snapshot/; \
 	fi
 
-CORE_SRC +=		src/snapshot.c \
+CORE_SRC +=		tools/snapshot.c \
 			src/zjs_common.c \
 			src/zjs_script.c
 
@@ -37,7 +37,7 @@ JERRY_LIBS += 		-l jerry-core -lm
 
 JERRY_LIB_PATH += 	-L $(JERRY_BASE)/build/lib/
 
-SNAPSHOT_LIBS += $(JERRY_LIBS) -pthread
+SNAPSHOT_LIBS +=	$(JERRY_LIBS) -pthread
 
 SNAPSHOT_DEFINES +=	-DZJS_LINUX_BUILD \
 			-DZJS_PRINT_FLOATS

--- a/tools/snapshot.c
+++ b/tools/snapshot.c
@@ -12,7 +12,7 @@ static uint32_t snapshot_buf[SNAPSHOT_BUFFER_SIZE];
 
 static void generate_snapshot(uint32_t *buf, int buf_size)
 {
-    for (int i = 0; i < buf_size; i++)
+    for (int i = 0; i < buf_size / sizeof(uint32_t); i++)
     {
         if (i > 0) {
             printf(",");

--- a/tools/snapshot.c
+++ b/tools/snapshot.c
@@ -7,39 +7,18 @@
 #include "jerryscript.h"
 
 #define SNAPSHOT_BUFFER_SIZE 51200
-#define SNAPSHOT_SOURCE_FILE "src/zjs_snapshot_gen.c"
 
 static uint32_t snapshot_buf[SNAPSHOT_BUFFER_SIZE];
 
-static int generate_snapshot(const char *file_name, uint32_t *buf, int buf_size)
+static void generate_snapshot(uint32_t *buf, int buf_size)
 {
-    // create or overwite the existing the src file that
-    // initialize the array to stores the byte code
-    // to be executed by jerryscript
-    FILE *f = fopen(file_name, "w+");
-    if (!f) {
-        ERR_PRINT("error opening file\n");
-        return 1;
-    }
-
-    fputs("/* This file was auto-generated */\n\n", f);
-    fputs("#include \"zjs_common.h\"\n\n", f);
-    fputs("const uint32_t snapshot_bytecode[] = {\n", f);
-
     for (int i = 0; i < buf_size; i++)
     {
         if (i > 0) {
-            fputs(",", f);
+            printf(",");
         }
-        fprintf(f, "0x%08lx", (unsigned long)buf[i]);
+        printf("0x%08lx", (unsigned long)buf[i]);
     }
-
-    fputs("\n};\n\n", f);
-    fputs("const int snapshot_len = sizeof(snapshot_bytecode) / ", f);
-    fputs("sizeof(snapshot_bytecode[0]);\n", f);
-    fclose(f);
-
-    return 0;
 }
 
 int main(int argc, char *argv[])
@@ -74,13 +53,10 @@ int main(int argc, char *argv[])
     }
 
     // store the snapshot as byte array in header
-    if (generate_snapshot(SNAPSHOT_SOURCE_FILE, snapshot_buf, size) != 0) {
-        ERR_PRINT("failed to generate %s\n", SNAPSHOT_SOURCE_FILE);
-        return 1;
-    }
+    generate_snapshot(snapshot_buf, size);
 
-    ZJS_PRINT("Source code %lu bytes\n", len);
-    ZJS_PRINT("Byte code %d bytes\n", size);
+    DBG_PRINT("Source code %lu bytes\n", len);
+    DBG_PRINT("Byte code %d bytes\n", size);
 
     return 0;
 }


### PR DESCRIPTION
Move the source and Makefile to tools directory, update snapshot tool
and convert.sh to generate just the needed bytes into header file, and
clean up the Makefile to build using the generated header in the outdir,
this should clean up all the generated src files in the root directory

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>