### PR TITLE
[build] Changing DEV to ASHELL to make things clearer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ EXT_JERRY_FLAGS += -DFEATURE_JS_PARSER=OFF
 endif
 endif
 
+ifneq (,$(DEV))
+$(error DEV= is no longer supported, please use make ide or make ashell)
+endif
+
 ifndef ZJS_BASE
 $(error ZJS_BASE not defined. You need to source zjs-env.sh)
 endif

--- a/Makefile
+++ b/Makefile
@@ -360,6 +360,8 @@ help:
 	@echo "Build targets:"
 	@echo "    all:       Build for either Zephyr or Linux depending on BOARD"
 	@echo "    zephyr:    Build Zephyr for the given BOARD (A101 is default)"
+	@echo "    ide        Build Zephyr in development mode for the IDE"
+	@echo "    ashell     Build Zephyr in development mode for the command line"
 	@echo "    arc:       Build just the ARC Zephyr target for Arduino 101"
 	@echo "    linux:     Build the Linux target"
 	@echo "    dfu:       Flash x86 and arc images to A101 with dfu-util"

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ EXT_JERRY_FLAGS ?=	-DENABLE_ALL_IN_ONE=ON \
 # Settings for ashell builds
 ifneq (,$(filter $(MAKECMDGOALS),ide ashell))
 CONFIG ?= fragments/zjs.conf.dev
-DEV=ashell
+ASHELL=y
 endif
 
 ifeq ($(BOARD), arduino_101)
@@ -141,7 +141,7 @@ zephyr: analyze generate jerryscript $(ARC)
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT) \
 					BLE_ADDR=$(BLE_ADDR) \
-					DEV=$(DEV)
+					ASHELL=$(ASHELL)
 ifeq ($(BOARD), arduino_101)
 	@echo
 	@echo -n Creating dfu images...
@@ -188,7 +188,7 @@ analyze: $(JS)
 	@if [ "$(SNAPSHOT)" = "on" ]; then \
 		echo "ccflags-y += -DZJS_SNAPSHOT_BUILD" >> src/Makefile; \
 	fi
-	@echo "ccflags-y += $(shell ./scripts/analyze.sh $(BOARD) $(JS) $(CONFIG) $(DEV))" | tee -a src/Makefile arc/src/Makefile
+	@echo "ccflags-y += $(shell ./scripts/analyze.sh $(BOARD) $(JS) $(CONFIG) $(ASHELL))" | tee -a src/Makefile arc/src/Makefile
 	@sed -i '/This is a generated file/r./zjs.conf.tmp' src/Makefile
 	@# Add the include for the OCF Makefile only if the script is using OCF
 	@if grep BUILD_MODULE_OCF src/Makefile; then \
@@ -211,7 +211,7 @@ setup:
 ifeq ($(BOARD), qemu_x86)
 	@cat fragments/prj.conf.qemu_x86 >> prj.conf
 else
-ifeq ($(DEV), ashell)
+ifeq ($(ASHELL), y)
 	@cat fragments/prj.conf.ashell >> prj.conf
 	@cat fragments/prj.mdef.ashell >> prj.mdef
 ifeq ($(filter ide,$(MAKECMDGOALS)),ide)

--- a/docs/ashell.md
+++ b/docs/ashell.md
@@ -17,8 +17,11 @@ due the constraints of the micro-controller.
 Compilation
 ------------
 
-This command will enable the shell compilation:
-`make DEV=ashell`
+This command will enable the shell compilation for use with the IDE:
+`make ide`
+
+To use the shell via the command line use:
+'make ashell'
 
 Dev mode will append all the functionality from ZJS, so it might not fit in ROM.
 

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -28,7 +28,7 @@ MODULES=''
 BOARD=$1
 SCRIPT=$2
 CONFIG=$3
-DEV=$4
+ASHELL=$4
 SDK_VERSION=$(cat ${ZEPHYR_SDK_INSTALL_DIR}/sdk_version)
 
 echo "# Modules found in $SCRIPT:" > $PRJFILE
@@ -203,7 +203,7 @@ if check_for_require uart || check_config_file ZJS_UART; then
         echo "CONFIG_USB_DW=y" >> $PRJFILE
         echo "CONFIG_USB_DEVICE_STACK=y" >> $PRJFILE
         echo "CONFIG_SYS_LOG_USB_DW_LEVEL=0" >> $PRJFILE
-        if [ "$DEV" != "ashell" ]; then
+        if [ "$ASHELL" != "y" ]; then
             echo "CONFIG_USB_CDC_ACM=y" >> $PRJFILE
         fi
         echo "CONFIG_SYS_LOG_USB_LEVEL=0" >> $PRJFILE
@@ -314,9 +314,9 @@ if [ $? -eq 0 ] || check_config_file ZJS_SENSOR; then
     >&2 echo Using module: Sensor
     MODULES+=" -DBUILD_MODULE_SENSOR"
     echo "export ZJS_SENSOR=y" >> $CONFFILE
-    if [[ $BOARD = "arduino_101" ]] || [[ $DEV = "ashell" ]]; then
+    if [[ $BOARD = "arduino_101" ]] || [[ $ASHELL = "y" ]]; then
         bmi160=$(grep -E Accelerometer\|Gyroscope $SCRIPT)
-        if [[ $? -eq 0 ]] || [[ $DEV = "ashell" ]]; then
+        if [[ $? -eq 0 ]] || [[ $ASHELL = "y" ]]; then
             echo "CONFIG_SENSOR=y" >> $ARCPRJFILE
             echo "CONFIG_GPIO=y" >> $ARCPRJFILE
             echo "CONFIG_SPI=y" >> $ARCPRJFILE
@@ -332,7 +332,7 @@ if [ $? -eq 0 ] || check_config_file ZJS_SENSOR; then
             echo "CONFIG_BMI160_TRIGGER_OWN_THREAD=y" >> $ARCPRJFILE
         fi
         grovelight=$(grep -E AmbientLightSensor $SCRIPT)
-        if [[ $? -eq 0 ]] || [[ $DEV = "ashell" ]]; then
+        if [[ $? -eq 0 ]] || [[ $ASHELL = "y" ]]; then
             MODULES+=" -DBUILD_MODULE_SENSOR_LIGHT"
             echo "CONFIG_ADC=y" >> $ARCPRJFILE
             # Workaround for the Zephyr issue ZEP-1882: ADC doesn't work with

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -86,7 +86,7 @@ obj-$(CONFIG_BOARD_ARDUINO_101) += \
 obj-$(CONFIG_BOARD_FRDM_K64F) += \
 	zjs_k64f_pins.o
 
-ifeq ($(DEV), ashell)
+ifeq ($(ASHELL), y)
 $(info Insecure Mode (development))
 export JERRY_INCLUDE = $(JERRY_BASE)/jerry-core/
 obj-y += ashell/


### PR DESCRIPTION
This will also cause DEV=ashell to no longer be supported. This
helps remove confusion about building ashell the proper way.

Signed-off-by: Brian Jones <brian.j.jones@intel.com>