### PR TITLE
[general] Fix calls to zjs_signal_callback

### DIFF
--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -142,8 +142,7 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
         case TYPE_AIO_PIN_EVENT_VALUE_CHANGE:
             handle->value = (double)pin_value;
             ZVAL num = jerry_create_number(handle->value);
-            zjs_signal_callback(handle->callback_id, &num,
-                                sizeof(jerry_value_t));
+            zjs_signal_callback(handle->callback_id, &num, sizeof(num));
             break;
         case TYPE_AIO_PIN_SUBSCRIBE:
             DBG_PRINT("subscribed to events on pin %lu\n", pin);

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -492,7 +492,7 @@ static void zjs_ble_connected(struct bt_conn *conn, uint8_t err)
         char addr[BT_ADDR_LE_STR_LEN];
         bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
         ble_conn.default_conn = bt_conn_ref(conn);
-        zjs_signal_callback(ble_conn.connected_cb_id, &addr, sizeof(addr));
+        zjs_signal_callback(ble_conn.connected_cb_id, addr, sizeof(addr));
     }
 }
 
@@ -513,7 +513,7 @@ static void zjs_ble_disconnected(struct bt_conn *conn, uint8_t reason)
         bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
         bt_conn_unref(ble_conn.default_conn);
         ble_conn.default_conn = NULL;
-        zjs_signal_callback(ble_conn.disconnected_cb_id, &addr, sizeof(addr));
+        zjs_signal_callback(ble_conn.disconnected_cb_id, addr, sizeof(addr));
     }
 }
 

--- a/src/zjs_dgram.c
+++ b/src/zjs_dgram.c
@@ -134,7 +134,7 @@ static void udp_received(struct net_context *context,
     net_nbuf_unref(net_buf);
 
     jerry_value_t args[2] = {buf_js, rinfo};
-    zjs_signal_callback(handle->message_cb_id, args, 2);
+    zjs_signal_callback(handle->message_cb_id, args, sizeof(args));
 }
 
 static jerry_value_t zjs_dgram_createSocket(const jerry_value_t function_obj,
@@ -227,7 +227,7 @@ static void udp_sent(struct net_context *context, int status, void *token,
 
         zjs_callback_id id = zjs_add_callback_once((jerry_value_t)user_data,
                                                    ZJS_UNDEFINED, NULL, NULL);
-        zjs_signal_callback(id, &rval, 1);
+        zjs_signal_callback(id, &rval, sizeof(rval));
     }
 }
 

--- a/src/zjs_fs.c
+++ b/src/zjs_fs.c
@@ -267,8 +267,7 @@ static jerry_value_t zjs_open(const jerry_value_t function_obj,
         args[0] = jerry_create_number(handle->error);
         args[1] = handle->fd_val;
 
-        zjs_signal_callback(id, args, sizeof(jerry_value_t) * 2);
-
+        zjs_signal_callback(id, args, sizeof(args))
         return ZJS_UNDEFINED;
     }
 #endif
@@ -323,7 +322,7 @@ static jerry_value_t zjs_close(const jerry_value_t function_obj,
                                                    NULL);
 
         jerry_value_t error = jerry_create_number(handle->error);
-        zjs_signal_callback(id, &error, sizeof(jerry_value_t));
+        zjs_signal_callback(id, &error, sizeof(error));
     }
 #endif
 
@@ -383,7 +382,7 @@ static jerry_value_t zjs_unlink(const jerry_value_t function_obj,
                                                    NULL);
 
         jerry_value_t error = jerry_create_number(ret);
-        zjs_signal_callback(id, &error, sizeof(jerry_value_t));
+        zjs_signal_callback(id, &error, sizeof(error));
     }
 #endif
 
@@ -488,7 +487,7 @@ static jerry_value_t zjs_read(const jerry_value_t function_obj,
                                                    this,
                                                    NULL,
                                                    NULL);
-        zjs_signal_callback(id, args, sizeof(jerry_value_t) * 3);
+        zjs_signal_callback(id, args, sizeof(args));
 
         return ZJS_UNDEFINED;
     }
@@ -603,7 +602,7 @@ static jerry_value_t zjs_write(const jerry_value_t function_obj,
 
         zjs_callback_id id = zjs_add_callback_once(argv[cbindex], this, NULL,
                                                    NULL);
-        zjs_signal_callback(id, args, sizeof(jerry_value_t) * 3);
+        zjs_signal_callback(id, args, sizeof(args));
 
         return ZJS_UNDEFINED;
     }
@@ -843,7 +842,7 @@ static jerry_value_t zjs_readdir(const jerry_value_t function_obj,
         args[0] = jerry_create_number(res);
         args[1] = array;
 
-        zjs_signal_callback(id, args, sizeof(jerry_value_t) * 2);
+        zjs_signal_callback(id, args, sizeof(args));
 
         return ZJS_UNDEFINED;
     }
@@ -907,7 +906,7 @@ static jerry_value_t zjs_stat(const jerry_value_t function_obj,
                                                    this,
                                                    NULL,
                                                    NULL);
-        zjs_signal_callback(id, args, sizeof(jerry_value_t) * 2);
+        zjs_signal_callback(id, args, sizeof(args));
 
         return ZJS_UNDEFINED;
     }
@@ -996,8 +995,7 @@ Finished:
         zjs_callback_id id = zjs_add_callback_once(argv[2], this, NULL, NULL);
 
         jerry_value_t err = jerry_create_number(error);
-
-        zjs_signal_callback(id, &err, sizeof(jerry_value_t));
+        zjs_signal_callback(id, &err, sizeof(err));
     }
 #endif
     if (data && !is_buf) {

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -140,7 +140,7 @@ static void zjs_gpio_zephyr_callback(struct device *port,
         !handle->edge_both) {
         // Signal the C callback, where we call the JS callback
         zjs_signal_callback(handle->callbackId, &handle->value,
-                            sizeof(uint32_t));
+                            sizeof(handle->value));
         handle->last = handle->value;
     }
 }

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -268,7 +268,7 @@ static void zjs_sensor_trigger_error(jerry_value_t obj,
         zjs_set_property(error_obj, "message", message_val);
         zjs_set_property(event, "error", error_obj);
         zjs_callback_id id = zjs_add_callback_once(func, obj, NULL, NULL);
-        zjs_signal_callback(id, &event, 1);
+        zjs_signal_callback(id, &event, sizeof(event));
     }
 }
 


### PR DESCRIPTION
I introduced two bugs to zjs_dgram.c because of my recent argument
validation patch, where I got confused about whether zjs_signal_callback
was taking its size in bytes (right!) vs. number of values (wrong!).

We use bytes because the callback mechanism doesn't only hold JS values
but sometimes C values that might be different sizes than 4 bytes.

I found at least one other bug, and then also cleaned up the size
calculations to not rely on magic numbers when a fixed array (etc.) was
available for the compiler to do the math, per pfalcon's suggestion.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>