### PR TITLE
[callbacks] Add check if JS function is undefined (#797)

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -483,10 +483,12 @@ void zjs_call_callback(zjs_callback_id id, const void *data, uint32_t sz)
             int i;
             jerry_value_t *values = (jerry_value_t *)data;
             if (GET_JS_TYPE(cb_map[id]->flags) == JS_TYPE_SINGLE) {
-                ZVAL rval = jerry_call_function(cb_map[id]->js_func,
-                                                cb_map[id]->this, values, sz);
-                if (jerry_value_has_error_flag(rval)) {
-                    zjs_print_error_message(rval);
+                if (!jerry_value_is_undefined(cb_map[id]->js_func)) {
+                    ZVAL rval = jerry_call_function(cb_map[id]->js_func,
+                            cb_map[id]->this, values, sz);
+                    if (jerry_value_has_error_flag(rval)) {
+                        zjs_print_error_message(rval);
+                    }
                 }
             } else if (GET_JS_TYPE(cb_map[id]->flags) == JS_TYPE_LIST) {
                 for (i = 0; i < cb_map[id]->num_funcs; ++i) {


### PR DESCRIPTION
 - Promises add undefined functions for then/catch, and if
   then/catch are never called, callbacks was signaling on
   an undefined function.

Signed-off-by: James Prestwood <james.prestwood@intel.com>