### PR TITLE
[sensor] Fixed bug where controller name can't get set

### DIFF
--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -27,9 +27,6 @@
 #define AIO_UPDATE_INTERVAL  200  // 2sec interval in between notifications
 #define LIGHT_UPDATE_INTERVAL 10  // 0.1sec interval for light or 10Hz
 
-#define ADC_DEVICE_NAME "ADC_0"
-#define ADC_BUFFER_SIZE 2
-
 #define MAX_I2C_BUS 2
 
 #define MAX_BUFFER_SIZE 256
@@ -37,7 +34,7 @@
 #ifdef CONFIG_BMI160_NAME
 #define BMI160_NAME CONFIG_BMI160_NAME
 #else
-#define BMI160_NAME "bmi160"
+#define BMI160_NAME BMI160_DEVICE_NAME
 #endif
 
 static struct k_sem arc_sem;

--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -845,8 +845,11 @@ static void handle_sensor(struct zjs_ipm_message *msg)
         break;
 #ifdef BUILD_MODULE_SENSOR_LIGHT
     case SENSOR_CHAN_LIGHT:
+        if (!strncmp(controller, ADC_DEVICE_NAME, 5)) {
             handle_sensor_light(msg);
             return;
+        }
+        break;
 #endif
 
      default:

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_common_h__
 #define __zjs_common_h__

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -45,10 +45,12 @@ int zjs_get_ms(void);
 #define MAX_SCRIPT_SIZE 8192
 
 #if defined(CONFIG_BOARD_ARDUINO_101) || defined(CONFIG_BOARD_ARDUINO_101_SSS)
+#define ADC_DEVICE_NAME "ADC_0"
+#define ADC_BUFFER_SIZE 2
 #define ARC_AIO_MIN 9
 #define ARC_AIO_MAX 14
-// ARC_AIO_LEN = ARC_AIO_MAX - ARC_AIO_MIN + 1
 #define ARC_AIO_LEN 6
+#define BMI160_DEVICE_NAME "bmi160"
 #endif
 
 #endif  // __zjs_common_h__

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -526,8 +526,7 @@ static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
         jerry_value_t options = argv[0];
         ZVAL controller_val = zjs_get_property(options, "controller");
 
-        if (!jerry_value_is_undefined(controller_val) &&
-            jerry_value_is_string(controller_val)) {
+        if (jerry_value_is_string(controller_val)) {
             zjs_copy_jstring(controller_val, controller, &size);
         } else {
             switch(channel) {

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 // ZJS includes
+#include "zjs_common.h"
 #include "zjs_sensor.h"
 #include "zjs_callbacks.h"
 #include "zjs_ipm.h"
@@ -19,8 +20,6 @@
 #define DEFAULT_SAMPLING_FREQUENCY 20
 
 #define SENSOR_MAX_CONTROLLER_LEN 16
-#define BMI160_CONTROLLER "bmi160"
-#define ANALOG_CONTROLLER "ADC_0"
 
 static struct k_sem sensor_sem;
 
@@ -533,10 +532,10 @@ static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
             case SENSOR_CHAN_ACCEL_XYZ:
             case SENSOR_CHAN_GYRO_XYZ:
             case SENSOR_CHAN_TEMP:
-                snprintf(controller, size, BMI160_CONTROLLER);
+                snprintf(controller, size, BMI160_DEVICE_NAME);
                 break;
             case SENSOR_CHAN_LIGHT:
-                snprintf(controller, size, ANALOG_CONTROLLER);
+                snprintf(controller, size, ADC_DEVICE_NAME);
                 break;
 
             default:

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -17,7 +17,10 @@
 
 #define ZJS_SENSOR_TIMEOUT_TICKS 5000
 #define DEFAULT_SAMPLING_FREQUENCY 20
+
+#define SENSOR_MAX_CONTROLLER_LEN 16
 #define BMI160_CONTROLLER "bmi160"
+#define ANALOG_CONTROLLER "ADC_0"
 
 static struct k_sem sensor_sem;
 
@@ -83,6 +86,8 @@ static void zjs_sensor_free_handles(sensor_handle_t *handle)
     while (handle != NULL) {
         tmp = handle;
         handle = handle->next;
+        if (handle->controller)
+            zjs_free(handle->controller);
         jerry_release_value(tmp->sensor_obj);
         zjs_free(tmp);
     }
@@ -510,7 +515,8 @@ static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
     ZJS_VALIDATE_ARGS(expect);
 
     double frequency = DEFAULT_SAMPLING_FREQUENCY;
-    char *controller = "";
+    size_t size = SENSOR_MAX_CONTROLLER_LEN;
+    char controller[size];
     uint32_t pin;
 
     // initialize object and default values
@@ -518,22 +524,28 @@ static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
 
     if (argc >= 1) {
         jerry_value_t options = argv[0];
-        const int BUFLEN = 20;
-        char buffer[BUFLEN];
+        ZVAL controller_val = zjs_get_property(options, "controller");
 
-        if (!zjs_obj_get_string(options, "controller", buffer, BUFLEN)) {
+        if (!jerry_value_is_undefined(controller_val) &&
+            jerry_value_is_string(controller_val)) {
+            zjs_copy_jstring(controller_val, controller, &size);
+        } else {
             switch(channel) {
             case SENSOR_CHAN_ACCEL_XYZ:
             case SENSOR_CHAN_GYRO_XYZ:
             case SENSOR_CHAN_TEMP:
-                controller = BMI160_CONTROLLER;
+                snprintf(controller, size, BMI160_CONTROLLER);
+                break;
+            case SENSOR_CHAN_LIGHT:
+                snprintf(controller, size, ANALOG_CONTROLLER);
                 break;
 
             default:
-                controller = "";
+                // should not get here
+                return zjs_error("Sensor not supported");
             }
-        } else {
-            controller = buffer;
+
+            DBG_PRINT("controller not set, default to %s\n", controller);
         }
 
         double option_freq;


### PR DESCRIPTION
Change controller from a char* to array so that it can be overwritten,
akso make default controller for AmbientLight to be "ADC_0" and
fix a leak

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>