### PR TITLE
[pwm] Require PWM period/pulseWidth to be set at the same time

### DIFF
--- a/docs/pwm.md
+++ b/docs/pwm.md
@@ -54,10 +54,8 @@ dictionary PWMInit {
 
 [NoInterfaceObject]
 interface PWMPin {
-    void setPeriod(double ms);
-    void setPeriodCycles(unsigned long cycles);
-    void setPulseWidth(double ms);
-    void setPulseWidthCycles(unsigned long cycles);
+    void setCycles(unsigned long period, unsigned long pulseWidth);
+    void setMilliseconds(double period, double pulseWidth);
 };
 ```
 
@@ -89,62 +87,34 @@ the period. *NOTE: This doesn't seem to work currently on Arduino 101.*
 The function returns a PWMPin object that can be used to change the period and
 pulse width later.
 
-### PWMPin.setPeriod
+### PWMPin.setCycles
 
-`void setPeriod(double ms);`
+`void setCycles(unsigned long period, unsigned long pulseWidth);`
 
-Sets the repeat period for the pulse signal. It is given in milliseconds, so
-these can be fractional to provide microsecond timings, etc. The actual
-resolution available will depend on the hardware, so the value you provide may
-get rounded.
+Sets the repeat period and pulse width for the signal, in terms of hardware
+cycles. One hardware cycle is the minimum amount of time the hardware supports
+having the pulse signal on (high).
+
+This version of the API is useful when the duty cycle is what matters (e.g.
+using the 'analog' model of PWM control described in the
+[Introduction](#introduction)). For example, a period of 2 with a pulse width of
+1 will make an LED at 50% brightness, with no flicker because the changes occur
+far faster than visible to the human eye.
+
+### PWMPin.setMilliseconds
+
+`void setMilliseconds(double periodMS, double pulseWidthMS);`
+
+Sets the repeat period and pulse width for the signal. It is given in
+milliseconds, so these can be fractional to provide microsecond timings, etc.
+The actual resolution available will depend on the hardware, so the value you
+provide may get rounded.
 *TODO: We could probably have the period attribute show the actual setting for
 the device when it is read back.*
 
 This version of the API is useful when the timing of the pulse matters (e.g.
 the 'servo' model of PWM control described in the
 [Introduction](#introduction)).
-
-### PWMPin.setPeriodCycles
-
-`void setPeriodCycles(unsigned long cycles);`
-
-Sets the repeat period for the pulse signal, in terms of hardware cycles. One
-hardware cycle is the minimum amount of time the hardware supports having the
-pulse signal on (high).
-
-This version of the API is useful when the duty cycle is what matters (e.g.
-using the 'analog' model of PWM control described in the
-[Introduction](#introduction)). For example, a period of 2 with a pulse width of
-1 will make an LED at 50% brightness, with no flicker because the changes occur
-far faster than visible to the human eye.
-
-### PWMPin.setPulseWidth
-
-`void setPulseWidth(double ms);`
-
-Sets the pulse width for the signal. It is given in milliseconds, so these can
-be fractional to provide microsecond timings, etc. The actual resolution
-available will depend on the hardware, so the value you provide may get rounded.
-*TODO: We could probably have the pulseWidth attribute show the actual
-setting for the device when it is read back.*
-
-This version of the API is useful when the timing of the pulse matters (e.g.
-the 'servo' model of PWM control described in the
-[Introduction](#introduction)).
-
-### PWMPin.setPulseWidthCycles
-
-`void setPulseWidthCycles(unsigned long cycles);`
-
-Sets the pulse width for the signal, in terms of hardware cycles. One hardware
-cycle is the minimum amount of time the hardware supports having the pulse
-signal on (high).
-
-This version of the API is useful when the duty cycle is what matters (e.g.
-using the 'analog' model of PWM control described in the
-[Introduction](#introduction)). For example, a period of 2 with a pulse width of
-1 will make an LED at 50% brightness, with no flicker because the changes occur
-far faster than visible to the human eye.
 
 Sample Apps
 -----------

--- a/docs/pwm.md
+++ b/docs/pwm.md
@@ -95,6 +95,8 @@ Sets the repeat period and pulse width for the signal, in terms of hardware
 cycles. One hardware cycle is the minimum amount of time the hardware supports
 having the pulse signal on (high).
 
+Throws an error if pulseWidth is greater than period.
+
 This version of the API is useful when the duty cycle is what matters (e.g.
 using the 'analog' model of PWM control described in the
 [Introduction](#introduction)). For example, a period of 2 with a pulse width of
@@ -111,6 +113,8 @@ The actual resolution available will depend on the hardware, so the value you
 provide may get rounded.
 *TODO: We could probably have the period attribute show the actual setting for
 the device when it is read back.*
+
+Throws an error if pulseWidth is greater than period.
 
 This version of the API is useful when the timing of the pulse matters (e.g.
 the 'servo' model of PWM control described in the

--- a/samples/PWM.js
+++ b/samples/PWM.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Test code for Arduino 101 that uses the PWM on IO3 to set an LED's blink
 // pattern to on for 1s, then off 1/2s, indefinitely. Another PWM on IO5 sets

--- a/samples/PWM.js
+++ b/samples/PWM.js
@@ -14,8 +14,7 @@ var pins = require("arduino101_pins");
 var led0 = pwm.open({channel: pins.IO3});
 
 // set timings in milliseconds
-led0.setPeriod(1500);
-led0.setPulseWidth(1000);
+led0.setMilliseconds(1500, 1000);
 
 // set brightness to 33% using hw cycle-based values
 var led1 = pwm.open({channel: pins.IO5, period: 3, pulseWidth: 1});
@@ -29,8 +28,7 @@ var period = maxPeriod;
 var dir = 0;
 
 // set initial state
-led2.setPeriod(period);
-led2.setPulseWidth(period / 2);
+led2.setMilliseconds(period, period / 2);
 
 setInterval(function () {
     if (dir) {
@@ -50,7 +48,5 @@ setInterval(function () {
         }
     }
 
-    led2.setPeriod(period);
-    led2.setPulseWidth(period / 2);
-
+    led2.setMilliseconds(period, period / 2);
 }, 4000);

--- a/samples/WebBluetoothDemo.js
+++ b/samples/WebBluetoothDemo.js
@@ -100,7 +100,7 @@ ColorCharacteristic._value.writeUInt8(0, 1);
 ColorCharacteristic._value.writeUInt8(0, 2);
 
 ColorCharacteristic.ledR = pwm.open({
-    channel: pins.IO3, period: 0.256, pulseWidth: 255 / 1000
+    channel: pins.IO3, period: 0.256, pulseWidth: 0.255
 });
 ColorCharacteristic.ledG = pwm.open({
     channel: pins.IO5, period: 0.256, pulseWidth: 0
@@ -129,9 +129,9 @@ ColorCharacteristic.onWriteRequest = function(data, offset, withoutResponse,
         return;
     }
 
-    this.ledR.setPulseWidth(this._value.readUInt8(0) / 1000);
-    this.ledG.setPulseWidth(this._value.readUInt8(1) / 1000);
-    this.ledB.setPulseWidth(this._value.readUInt8(2) / 1000);
+    this.ledR.setCycles(256, this._value.readUInt8(0));
+    this.ledG.setCycles(256, this._value.readUInt8(1));
+    this.ledB.setCycles(256, this._value.readUInt8(2));
     // TODO: probably only supposed to call this if withoutResponse is false?
     callback(this.RESULT_SUCCESS);
 };

--- a/samples/WebBluetoothDemo.js
+++ b/samples/WebBluetoothDemo.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Test code for Arduino 101 that replicates the WebBluetooth demo
 // using BLE to advertise temperature changes and allow LED color changes

--- a/samples/arduino/basics/Fade.js
+++ b/samples/arduino/basics/Fade.js
@@ -31,18 +31,16 @@ var pins = require("arduino101_pins");
 var led1 = pwm.open({
     channel: pins.IO3
 });
-led1.setPeriodCycles(256);
 
 var led2 = pwm.open({
     channel: pins.IO5,
     polarity: "reverse"
 });
-led2.setPeriodCycles(256);
 
 // update the brightness every 30ms
 setInterval(function () {
-    led1.setPulseWidthCycles(brightness);
-    led2.setPulseWidthCycles(brightness);
+    led1.setCycles(256, brightness);
+    led2.setCycles(256, brightness);
 
     // adjust the brightness for next time
     brightness += fadeAmount;

--- a/samples/arduino/basics/Fade.js
+++ b/samples/arduino/basics/Fade.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Reimplementation of Arduino - Basics - Fade example
 //   - Fades LEDs in and out using PWM

--- a/samples/arduino/starterkit/ColorMixingLamp.js
+++ b/samples/arduino/starterkit/ColorMixingLamp.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Reimplementation of Arduino Starter Kit's ColorMixingLamp example
 //   - Lights up an RGB LED based on the ambient light color detected by three

--- a/samples/arduino/starterkit/ColorMixingLamp.js
+++ b/samples/arduino/starterkit/ColorMixingLamp.js
@@ -43,11 +43,6 @@ var blueSensor = aio.open({
     pin: pins.A2
 });
 
-// initialize the period of the PWMs to 256 hardware cycles
-redLED.setPeriodCycles(256);
-greenLED.setPeriodCycles(256);
-blueLED.setPeriodCycles(256);
-
 setInterval(function () {
     var redValue = redSensor.read();
     var greenValue = greenSensor.read();
@@ -70,9 +65,9 @@ setInterval(function () {
                 "\tGreen: " + greenValue +
                 "\tBlue: " + blueValue);
 
-    redLED.setPulseWidthCycles(redValue);
-    greenLED.setPulseWidthCycles(greenValue);
-    blueLED.setPulseWidthCycles(blueValue);
+    redLED.setCycles(256, redValue);
+    greenLED.setCycles(256, greenValue);
+    blueLED.setCycles(256, blueValue);
 
     // FIXME: Currently, ZJS only reads analog pins once per second, so there's
     // no point in checking more often. This should be fixed soon.

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -79,7 +79,7 @@ module_t zjs_modules_array[] = {
     { "grove_lcd", zjs_grove_lcd_init, zjs_grove_lcd_cleanup },
 #endif
 #ifdef BUILD_MODULE_PWM
-    { "pwm", zjs_pwm_init },
+    { "pwm", zjs_pwm_init, zjs_pwm_cleanup },
 #endif
 #ifdef BUILD_MODULE_I2C
     { "i2c", zjs_i2c_init },

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -11,6 +11,8 @@
 #include "zjs_pwm.h"
 #include "zjs_util.h"
 
+static jerry_value_t zjs_pwm_pin_prototype;
+
 static const char *ZJS_POLARITY_NORMAL = "normal";
 static const char *ZJS_POLARITY_REVERSE = "reverse";
 
@@ -25,7 +27,8 @@ static struct device *zjs_pwm_dev[PWM_DEV_COUNT];
 void (*zjs_pwm_convert_pin)(uint32_t orig, int *dev, int *pin) =
     zjs_default_convert_pin;
 
-static void zjs_pwm_set(jerry_value_t obj, double period, double pulseWidth)
+static void zjs_pwm_set_cycles(jerry_value_t obj, uint32_t periodHW,
+                               uint32_t pulseWidthHW)
 {
     uint32_t orig_chan;
     zjs_obj_get_uint32(obj, "channel", &orig_chan);
@@ -33,181 +36,106 @@ static void zjs_pwm_set(jerry_value_t obj, double period, double pulseWidth)
     int devnum, channel;
     zjs_pwm_convert_pin(orig_chan, &devnum, &channel);
 
-    if (pulseWidth > period) {
-        ERR_PRINT("pulseWidth was greater than period\n");
-        pulseWidth = period;
+    const int BUFLEN = 10;
+    char buffer[BUFLEN];
+    if (zjs_obj_get_string(obj, "polarity", buffer, BUFLEN)) {
+        if (!strncmp(buffer, ZJS_POLARITY_REVERSE, BUFLEN)) {
+            pulseWidthHW = periodHW - pulseWidthHW;
+        }
     }
+
+    DBG_PRINT("Setting [cycles] channel=%d dev=%d, period=%lu, pulse=%lu\n",
+              channel, devnum, (uint32_t)periodHW, (uint32_t)pulseWidthHW);
+    pwm_pin_set_cycles(zjs_pwm_dev[devnum], channel, periodHW, pulseWidthHW);
+}
+
+static void zjs_pwm_set_ms(jerry_value_t obj, double period, double pulseWidth)
+{
+    uint32_t orig_chan;
+    zjs_obj_get_uint32(obj, "channel", &orig_chan);
+
+    int devnum, channel;
+    zjs_pwm_convert_pin(orig_chan, &devnum, &channel);
 
     const int BUFLEN = 10;
     char buffer[BUFLEN];
     if (zjs_obj_get_string(obj, "polarity", buffer, BUFLEN)) {
-        if (!strcmp(buffer, ZJS_POLARITY_REVERSE)) {
+        if (!strncmp(buffer, ZJS_POLARITY_REVERSE, BUFLEN)) {
             pulseWidth = period - pulseWidth;
         }
     }
 
-    DBG_PRINT("Setting [uSec] channel=%u dev=%u, period=%lu, pulse=%lu\n",
+    DBG_PRINT("Setting [uSec] channel=%d dev=%d, period=%lu, pulse=%lu\n",
               channel, devnum, (uint32_t)(period * 1000),
               (uint32_t)(pulseWidth * 1000));
     pwm_pin_set_usec(zjs_pwm_dev[devnum], channel, (uint32_t)(period * 1000),
                      (uint32_t)(pulseWidth * 1000));
 }
 
-static void zjs_pwm_set_cycles(jerry_value_t obj, uint32_t periodHW,
-                               uint32_t pulseWidthHW)
+static jerry_value_t zjs_pwm_pin_set_cycles(const jerry_value_t function_obj,
+                                            const jerry_value_t this,
+                                            const jerry_value_t argv[],
+                                            const jerry_length_t argc)
 {
-    DBG_PRINT("periodHW: %lu, pulseWidthHW: %lu\n", periodHW, pulseWidthHW);
-    uint32_t orig_chan;
-    zjs_obj_get_uint32(obj, "channel", &orig_chan);
+    // requires: this is a PWMPin object from zjs_pwm_open, takes two arguments:
+    //             the period in hardware cycles, dependent on the underlying
+    //             hardware (31.25ns each for Arduino 101), and the pulse width
+    //             in hardware cycles
+    //  effects: updates the period and pulse width of this PWM pin, using the
+    //             finest grain units provided by the platform, providing the
+    //             widest range
 
-    int devnum, channel;
-    zjs_pwm_convert_pin(orig_chan, &devnum, &channel);
+    // args: period in cycles, pulse width in cycles
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER);
+
+    double periodHW = jerry_get_number_value(argv[0]);
+    double pulseWidthHW = jerry_get_number_value(argv[1]);
 
     if (pulseWidthHW > periodHW) {
         ERR_PRINT("pulseWidth was greater than period\n");
         pulseWidthHW = periodHW;
     }
 
-    const int BUFLEN = 10;
-    char buffer[BUFLEN];
-    if (zjs_obj_get_string(obj, "polarity", buffer, BUFLEN)) {
-        if (!strcmp(buffer, ZJS_POLARITY_REVERSE)) {
-            pulseWidthHW = periodHW - pulseWidthHW;
-        }
-    }
-
-    DBG_PRINT("Setting [cycles] channel=%u dev=%u, period=%lu, pulse=%lu\n",
-              channel, devnum, (uint32_t)periodHW, (uint32_t)pulseWidthHW);
-    pwm_pin_set_cycles(zjs_pwm_dev[devnum], channel, periodHW, pulseWidthHW);
-}
-
-static void zjs_pwm_set_period_cycles(jerry_value_t obj, double periodHW)
-{
-    // requires: obj is a PWM pin object, period is in hardware cycles
-    //  effects: sets the PWM pin to the given period, records the period
-    //             in the object
-    double pulseWidth;
-    zjs_obj_get_double(obj, "pulseWidth", &pulseWidth);
-
     // update the JS object
     double period = periodHW / sys_clock_hw_cycles_per_sec * 1000;
-    zjs_obj_add_number(obj, period, "period");
+    double pulseWidth = pulseWidthHW / sys_clock_hw_cycles_per_sec * 1000;
+    zjs_obj_add_number(this, period, "period");
+    zjs_obj_add_number(this, pulseWidth, "pulseWidth");
 
-    double pulseWidthHW = pulseWidth * sys_clock_hw_cycles_per_sec / 1000;
-
-    zjs_pwm_set_cycles(obj, periodHW, pulseWidthHW);
-}
-
-static jerry_value_t zjs_pwm_pin_set_period_cycles(const jerry_value_t function_obj,
-                                                   const jerry_value_t this,
-                                                   const jerry_value_t argv[],
-                                                   const jerry_length_t argc)
-{
-    // requires: this is a PWMPin object from zjs_pwm_open, takes one
-    //             argument, the period in hardware cycles, dependent on the
-    //             underlying hardware (31.25ns each for Arduino 101)
-    //  effects: updates the period of this PWM pin, using the finest grain
-    //             units provided by the platform, providing the widest range
-
-    // args: period in cycles
-    ZJS_VALIDATE_ARGS(Z_NUMBER);
-
-    double periodHW = jerry_get_number_value(argv[0]);
-
-    zjs_pwm_set_period_cycles(this, periodHW);
+    zjs_pwm_set_cycles(this, periodHW, pulseWidthHW);
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_pwm_pin_set_period(const jerry_value_t function_obj,
-                                            const jerry_value_t this,
-                                            const jerry_value_t argv[],
-                                            const jerry_length_t argc)
+static jerry_value_t zjs_pwm_pin_set_ms(const jerry_value_t function_obj,
+                                        const jerry_value_t this,
+                                        const jerry_value_t argv[],
+                                        const jerry_length_t argc)
 {
-    // requires: this is a PWMPin object from zjs_pwm_open, takes one
-    //             argument, the period in milliseconds (float)
+    // requires: this is a PWMPin object from zjs_pwm_open, takes two arguments:
+    //             the period in milliseconds (float), and the pulse width in
+    //             milliseconds (float)
     //  effects: updates the period of this PWM pin, getting as close as
     //             possible to what is requested given hardware constraints
 
-    // args: period in milliseconds
-    ZJS_VALIDATE_ARGS(Z_NUMBER);
-
-    double pulseWidth;
-    if (!zjs_obj_get_double(this, "pulseWidth", &pulseWidth)) {
-        return zjs_error("zjs_pwm_pin_set_period: pulseWidth was not initialized");
-    }
+    // args: period in milliseconds, pulse width in milliseconds
+    ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER);
 
     double period = jerry_get_number_value(argv[0]);
-    // store the period in the pwm object
+    double pulseWidth = jerry_get_number_value(argv[1]);
+
+    if (pulseWidth > period) {
+        ERR_PRINT("pulseWidth was greater than period\n");
+        pulseWidth = period;
+    }
+
+    // store the values in the pwm object
     zjs_obj_add_number(this, period, "period");
+    zjs_obj_add_number(this, period, "pulseWidth");
 
     DBG_PRINT("period: %lu, pulse: %lu\n", (uint32_t)period,
               (uint32_t)pulseWidth);
 
-    zjs_pwm_set(this, period, pulseWidth);
-
-    return ZJS_UNDEFINED;
-}
-
-static void zjs_pwm_set_pulse_width_cycles(jerry_value_t obj,
-                                           double pulseWidthHW)
-{
-    // requires: obj is a PWM pin object, pulseWidth is in hardware cycles
-    //  effects: sets the PWM pin to the given pulse width, records the pulse
-    //             width in the object
-    double period;
-    zjs_obj_get_double(obj, "period", &period);
-
-    // update the JS object
-    double pulseWidth = pulseWidthHW / sys_clock_hw_cycles_per_sec * 1000;
-    zjs_obj_add_number(obj, pulseWidth, "pulseWidth");
-
-    double periodHW = period * sys_clock_hw_cycles_per_sec / 1000;
-
-    zjs_pwm_set_cycles(obj, periodHW, pulseWidthHW);
-}
-
-static jerry_value_t zjs_pwm_pin_set_pulse_width_cycles(const jerry_value_t function_obj,
-                                                        const jerry_value_t this,
-                                                        const jerry_value_t argv[],
-                                                        const jerry_length_t argc)
-{
-    // requires: this is a PWMPin object from zjs_pwm_open, takes one
-    //             argument, the pulse width in hardware cycles, dependent on
-    //             the underlying hardware (31.25ns each for Arduino 101)
-    //  effects: updates the pulse width of this PWM pin
-
-    // args: pulse width in cycles
-    ZJS_VALIDATE_ARGS(Z_NUMBER);
-
-    double pulseWidth = jerry_get_number_value(argv[0]);
-    // store the pulseWidth in the pwm object
-    zjs_obj_add_number(this, pulseWidth, "pulseWidth");
-
-    zjs_pwm_set_pulse_width_cycles(this, pulseWidth);
-    return ZJS_UNDEFINED;
-}
-
-static jerry_value_t zjs_pwm_pin_set_pulse_width(const jerry_value_t function_obj,
-                                                 const jerry_value_t this,
-                                                 const jerry_value_t argv[],
-                                                 const jerry_length_t argc)
-{
-    // requires: this is a PWMPin object from zjs_pwm_open, takes one
-    //             argument, the pulse width in milliseconds (float)
-    //  effects: updates the pulse width of this PWM pin
-
-    // args: pulse width in milliseconds
-    ZJS_VALIDATE_ARGS(Z_NUMBER);
-
-    double period;
-    zjs_obj_get_double(this, "period", &period);
-
-    double pulseWidth = jerry_get_number_value(argv[0]);
-    // store the pulseWidth in the pwm object
-    zjs_obj_add_number(this, pulseWidth, "pulseWidth");
-
-    zjs_pwm_set(this, period, pulseWidth);
-
+    zjs_pwm_set_ms(this, period, pulseWidth);
     return ZJS_UNDEFINED;
 }
 
@@ -254,18 +182,14 @@ static jerry_value_t zjs_pwm_open(const jerry_value_t function_obj,
 
     // create the PWMPin object
     jerry_value_t pin_obj = jerry_create_object();
-    zjs_obj_add_function(pin_obj, zjs_pwm_pin_set_period, "setPeriod");
-    zjs_obj_add_function(pin_obj, zjs_pwm_pin_set_period_cycles,
-                         "setPeriodCycles");
-    zjs_obj_add_function(pin_obj, zjs_pwm_pin_set_pulse_width, "setPulseWidth");
-    zjs_obj_add_function(pin_obj, zjs_pwm_pin_set_pulse_width_cycles,
-                         "setPulseWidthCycles");
+    jerry_set_prototype(pin_obj, zjs_pwm_pin_prototype);
+
     zjs_obj_add_number(pin_obj, channel, "channel");
     zjs_obj_add_number(pin_obj, period, "period");
     zjs_obj_add_number(pin_obj, pulseWidth, "pulseWidth");
     zjs_obj_add_string(pin_obj, polarity, "polarity");
 
-    zjs_pwm_set(pin_obj, period, pulseWidth);
+    zjs_pwm_set_ms(pin_obj, period, pulseWidth);
 
     // TODO: When we implement close, we should release the reference on this
     return pin_obj;
@@ -285,9 +209,24 @@ jerry_value_t zjs_pwm_init()
         }
     }
 
+    // create PWM pin prototype object
+    zjs_native_func_t array[] = {
+        { zjs_pwm_pin_set_ms, "setMilliseconds" },
+        { zjs_pwm_pin_set_cycles, "setCycles" },
+        { NULL, NULL }
+    };
+    zjs_pwm_pin_prototype = jerry_create_object();
+    zjs_obj_add_functions(zjs_pwm_pin_prototype, array);
+
     // create PWM object
     jerry_value_t pwm_obj = jerry_create_object();
     zjs_obj_add_function(pwm_obj, zjs_pwm_open, "open");
     return pwm_obj;
 }
+
+void zjs_pwm_cleanup()
+{
+    jerry_release_value(zjs_pwm_pin_prototype);
+}
+
 #endif // BUILD_MODULE_PWM

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -92,8 +92,8 @@ static jerry_value_t zjs_pwm_pin_set_cycles(const jerry_value_t function_obj,
     double pulseWidthHW = jerry_get_number_value(argv[1]);
 
     if (pulseWidthHW > periodHW) {
-        ERR_PRINT("pulseWidth was greater than period\n");
-        pulseWidthHW = periodHW;
+        DBG_PRINT("pulseWidth was greater than period\n");
+        return zjs_error("pulseWidth must not be greater than period");
     }
 
     // update the JS object
@@ -124,8 +124,8 @@ static jerry_value_t zjs_pwm_pin_set_ms(const jerry_value_t function_obj,
     double pulseWidth = jerry_get_number_value(argv[1]);
 
     if (pulseWidth > period) {
-        ERR_PRINT("pulseWidth was greater than period\n");
-        pulseWidth = period;
+        DBG_PRINT("pulseWidth was greater than period\n");
+        return zjs_error("pulseWidth must not be greater than period");
     }
 
     // store the values in the pwm object

--- a/src/zjs_pwm.h
+++ b/src/zjs_pwm.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_pwm_h__
 #define __zjs_pwm_h__

--- a/src/zjs_pwm.h
+++ b/src/zjs_pwm.h
@@ -7,6 +7,14 @@
 
 extern void (*zjs_pwm_convert_pin)(uint32_t num, int *dev, int *pin);
 
+/**
+ * Initialize the pwm module, or reinitialize after cleanup
+ *
+ * @return PWM API object
+ */
 jerry_value_t zjs_pwm_init();
+
+/** Release resources held by the pwm module */
+void zjs_pwm_cleanup();
 
 #endif  // __zjs_pwm_h__

--- a/tests/test-pwm.js
+++ b/tests/test-pwm.js
@@ -29,10 +29,15 @@ pinA = pwm.open({ channel: pins.IO3, period: 3, pulseWidth: 1 });
 assert(pinA !== null && typeof pinA === "object",
        "open: with period and pulseWidth");
 
-// set pulse width greater than period; impl will make them equal
-pinA.setMilliseconds(3000, 5000);
-assert(pinA.period == pinA.pulseWidth,
-       "pwmpin: set pulseWidth greater than period");
+// set pulse width greater than period
+assert.throws(function() {
+    pinA.setMilliseconds(3000, 5000);
+}, "pwmpin: set pulseWidth greater than period");
+
+// set pulse width greater than period
+assert.throws(function() {
+    pinA.setCycles(3000, 5000);
+}, "pwmpin: set pulseWidth greater than period (cycles)");
 
 pinA.setMilliseconds(3000, 1000);
 msTimer = setInterval(function () {

--- a/tests/test-pwm.js
+++ b/tests/test-pwm.js
@@ -25,22 +25,16 @@ assert.throws(function () {
 var msTrue = 0;
 var msFalse = 0;
 
-assert.throws(function () {
-    pinA.setPulseWidth(300);
-}, "pwmpin: set pulseWidth without period");
-
 pinA = pwm.open({ channel: pins.IO3, period: 3, pulseWidth: 1 });
 assert(pinA !== null && typeof pinA === "object",
        "open: with period and pulseWidth");
 
-pinA.setPeriod(3000);
+// set pulse width greater than period; impl will make them equal
+pinA.setMilliseconds(3000, 5000);
+assert(pinA.period == pinA.pulseWidth,
+       "pwmpin: set pulseWidth greater than period");
 
-assert.throws(function () {
-    pinA.setPulseWidth(3000);
-}, "pwmpin: set pulseWidth greater than period");
-
-pinA.setPulseWidth(1000);
-
+pinA.setMilliseconds(3000, 1000);
 msTimer = setInterval(function () {
     if (pinB.read()) {
         msTrue = msTrue + 1;
@@ -57,17 +51,17 @@ setTimeout(function () {
     clearInterval(msTimer);
 
     assert.throws(function () {
-        pinA.setPeriod("Value");
+        pinA.setMilliseconds("Value", 1000);
     }, "pwmpin: set period with invalid value");
 
     assert.throws(function () {
-        pinA.setPulseWidth("Value");
+        pinA.setMilliseconds(1000, "Value");
     }, "pwmpin: set pulseWidth with invalid value");
 
     // set Period and PulseWidth with cycle
     // duty cycle: 70%
     var cyclesTrue = 0;
-    var cyclesFlase = 0;
+    var cyclesFalse = 0;
     var cyclesCount = 0;
     var periodCount = 0;
     var Flag = false;
@@ -75,8 +69,7 @@ setTimeout(function () {
     pinA = pwm.open({ channel: pins.IO3, polarity: "reverse" });
     assert(pinA !== null && typeof pinA === "object", "open: reverse polarity");
 
-    pinA.setPeriodCycles(10000000);
-    pinA.setPulseWidthCycles(3000000);
+    pinA.setCycles(10000000, 3000000);
 
     cycleTimer = setInterval(function () {
        Flag = pinB.read();
@@ -87,7 +80,7 @@ setTimeout(function () {
            if (oldFlag) {
                cyclesTrue = cyclesTrue + cyclesCount;
            } else {
-               cyclesFlase = cyclesFlase + cyclesCount;
+               cyclesFalse = cyclesFalse + cyclesCount;
            }
 
            oldFlag = Flag;
@@ -98,7 +91,7 @@ setTimeout(function () {
            }
 
            if (periodCount === 3) {
-               assert((10 < cyclesFlase) && (cyclesFlase < 14) &&
+               assert((10 < cyclesFalse) && (cyclesFalse < 14) &&
                       (28 < cyclesTrue) && (cyclesTrue < 32),
                       "pwmpin: set periodCycles and pulseWidthCycles");
 
@@ -111,9 +104,9 @@ setTimeout(function () {
 }, 3040);
 
 assert.throws(function () {
-    pinA.setPeriodCycles("Value");
-}, "pwmpin: set periodCycles with invalid value");
+    pinA.setCycles("Value", 1000);
+}, "pwmpin: set period cycles with invalid value");
 
 assert.throws(function () {
-    pinA.setPulseWidthCycles("Value");
-}, "pwmpin: set pulseWidthCycles with invalid value");
+    pinA.setCycles(1000, "Value");
+}, "pwmpin: set pulseWidth cycles with invalid value");

--- a/tests/test-pwm.js
+++ b/tests/test-pwm.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 console.log("Wire IO3 to IO2");
 


### PR DESCRIPTION
This is a wise API choice because you can go through invalid states
by setting the wrong one first, where the pulse width is bigger than
the period. I convinced Zephyr itself to make this change, but we
hadn't gotten around to reflecting this in our own API.

Fixes #359.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>