### PR TITLE
[docs] Document caveat about conflict between SPI and A101 LED

### DIFF
--- a/docs/a101_pins.md
+++ b/docs/a101_pins.md
@@ -74,13 +74,15 @@ inputs or outputs.
 The Arduino 101 has three onboard LEDs that you can access as additional GPIO
 outputs.
 
-LED0 controls an onboard green LED. It is active high, and it is an alias for
-IO13, so in other words, LED0 displays the current state of IO13. So don't try
-to use both names.
+LED0 controls an onboard red fault LED. It is active *low*.
 
-LED1 controls another onboard green LED. It is active *low*.
+LED1 controls an onboard green LED. It is active *low*.
 
-LED2 controls an onboard red fault LED. It is active *low*.
+LED2 controls another onboard green LED. It is active high, and it is an alias
+for IO13, so in other words, LED0 displays the current state of IO13. So don't
+try to use both names. Also, if SPI is enabled this reconfigures the GPIO that
+controls LED2 and it will not be available. The flash filesystem uses SPI, so
+LED2 is not available when you use ashell or filesystem APIs.
 
 ### PWM Pins
 

--- a/docs/ashell.md
+++ b/docs/ashell.md
@@ -231,3 +231,6 @@ Problems and known issues
 
 ZJS will only execute timeouts or events on the first run. Sometimes there is
 a duplicated character written to the ACM.
+
+LED2 on Arduino 101 is not available in ashell mode because the GPIO it is tied
+to is being used for SPI to talk to the flash filesystem instead.

--- a/samples/ButtonLEDs.js
+++ b/samples/ButtonLEDs.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Test code for Arduino 101 that uses the two onboard LEDs for output, and
 // expects a button or similar input connected to IO4. Blinks the LEDs on and
@@ -11,10 +11,10 @@ console.log("GPIO test with two LEDs and a button...");
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-// pins 8 (LED0) and 12 (LED1) are onboard LEDs on Arduino 101
-var pinA = gpio.open({ pin: pins.LED0, activeLow: false });
-var pinB = gpio.open({ pin: pins.LED1, activeLow: true });
-var pinIn = gpio.open({ pin: pins.IO4, direction: 'in', edge: 'rising' });
+// LED1 and LED2 are onboard LEDs on Arduino 101
+var pinA = gpio.open({pin: pins.LED1, activeLow: true});
+var pinB = gpio.open({pin: pins.LED2, activeLow: false});
+var pinIn = gpio.open({pin: pins.IO4, direction: 'in', edge: 'rising'});
 
 // tick is the delay between blinks
 var tick = 1000, toggle = false;

--- a/samples/ButtonLEDsAsync.js
+++ b/samples/ButtonLEDsAsync.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // This is an asynchronous version of ButtonLEDs.js, calling gpio.openAsync
 
@@ -13,19 +13,19 @@ console.log("Async GPIO test with two LEDs and a button...");
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-// pins 8 (LED0) and 12 (LED1) are onboard LEDs on Arduino 101
+// LED1 and LED2 are onboard LEDs on Arduino 101
 var pinA = null;
 var pinB = null;
 
-gpio.openAsync({ pin: pins.LED0, activeLow: false }).then(function(pin) {
+gpio.openAsync({pin: pins.LED1, activeLow: true}).then(function(pin) {
     pinA = pin;
 });
 
-gpio.openAsync({ pin: pins.LED1, activeLow: true }).then(function(pin) {
+gpio.openAsync({pin: pins.LED2, activeLow: false}).then(function(pin) {
     pinB = pin;
 });
 
-gpio.openAsync({ pin: pins.IO4, direction: 'in', edge: 'rising' }).then(function(pin) {
+gpio.openAsync({pin: pins.IO4, direction: 'in', edge: 'rising'}).then(function(pin) {
     // tick is the delay between blinks
     var tick = 1000, toggle = false;
 

--- a/samples/RGB.js
+++ b/samples/RGB.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Sample to drive an RGB LED, namely this one:
 //   http://www.mouser.com/ds/2/216/WP154A4SUREQBFZGW-67444.pdf
@@ -20,7 +20,7 @@ var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
 // LED0 is an onboard LED on the Arduino101
-var led = gpio.open({pin: pins.LED0, direction: 'out'});
+var led = gpio.open({pin: pins.LED0, direction: 'out', activeLow: true});
 
 var red = gpio.open({pin: pins.IO2, direction: 'out'});
 var green = gpio.open({pin: pins.IO7, direction: 'out'});

--- a/samples/TrafficLight.js
+++ b/samples/TrafficLight.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Reimplementation of Arduino - Basics - Blink example
 //   - Toggles onboard LEDs as if they were a traffic light
@@ -26,9 +26,9 @@ console.log("Starting TrafficLight example...");
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-var red    = gpio.open({pin: pins.LED2, direction: 'out', activeLow: true});
+var red    = gpio.open({pin: pins.LED0, direction: 'out', activeLow: true});
 var yellow = gpio.open({pin: pins.LED1, direction: 'out', activeLow: true});
-var green  = gpio.open({pin: pins.LED0, direction: 'out', activeLow: false});
+var green  = gpio.open({pin: pins.LED2, direction: 'out', activeLow: false});
 
 var elapsed = 0;
 

--- a/samples/TwoButtons.js
+++ b/samples/TwoButtons.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Test code for Arduino 101 that uses two buttons on IO3 and IO4 to control
 // the two onboard LEDs.
@@ -13,14 +13,14 @@ console.log("GPIO test with two buttons controlling two LEDs...");
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-// pins 8 (LED0) and 12 (LED1) are onboard LEDs on Arduino 101
-var led1 = gpio.open({ pin: pins.LED0, activeLow: false });
-var led2 = gpio.open({ pin: pins.LED1, activeLow: true });
-var btn1 = gpio.open({ pin: pins.IO3, direction: 'in', edge: 'any' });
-var btn2 = gpio.open({ pin: pins.IO4, direction: 'in', edge: 'any' });
+// LED1 and LED2 are onboard LEDs on Arduino 101
+var led1 = gpio.open({pin: pins.LED1, activeLow: true});
+var led2 = gpio.open({pin: pins.LED2, activeLow: false});
+var btn1 = gpio.open({pin: pins.IO3, direction: 'in', edge: 'any'});
+var btn2 = gpio.open({pin: pins.IO4, direction: 'in', edge: 'any'});
 
 // turn off LED #2 initially
-led2.write(false);
+led1.write(false);
 
 btn1.onchange = function (event) {
     led1.write(event.value);

--- a/samples/arduino/basics/Blink.js
+++ b/samples/arduino/basics/Blink.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Reimplementation of Arduino - Basics - Blink example
 //   - Toggles an onboard LED on and off every second
@@ -24,12 +24,9 @@ console.log("Starting Blink example...");
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-// pin 8 is one of the onboard LEDs on the Arduino 101
+// LED0 is one of the onboard LEDs on the Arduino 101
 // 'out' direction is default, could be left out
-var pin = gpio.open({
-    pin: pins.LED0,
-    direction: 'out'
-});
+var pin = gpio.open({pin: pins.LED0, direction: 'out', activeLow: true});
 
 // remember the current state of the LED
 var toggle = false;

--- a/samples/arduino/digital/Button.js
+++ b/samples/arduino/digital/Button.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Reimplementation of Arduino - Digital - Button example
 //   - Turns on an LED whenever a button is being pressed
@@ -16,15 +16,8 @@ console.log("Starting Button example...");
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-var led = gpio.open({
-    pin: pins.LED0,
-    direction: 'out'
-});
-var button = gpio.open({
-    pin: pins.IO4,
-    direction: 'in',
-    edge: 'any'
-});
+var led = gpio.open({pin: pins.LED0, direction: 'out', activeLow: true});
+var button = gpio.open({pin: pins.IO4, direction: 'in', edge: 'any'});
 
 button.onchange = function(event) {
     led.write(event.value);

--- a/samples/tests/ButtonEnable.js
+++ b/samples/tests/ButtonEnable.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Test code for Arduino 101 that uses two buttons on IO2 and IO4 to control
 // the two onboard LEDs.
@@ -17,13 +17,13 @@ console.log("Button enable test...");
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 
-var led1 = gpio.open({ pin: pins.LED0, activeLow: false });
-var led2 = gpio.open({ pin: pins.LED1, activeLow: true });
-var btn1 = gpio.open({ pin: pins.IO2, direction: 'in', edge: 'any' });
-var btn2 = gpio.open({ pin: pins.IO4, direction: 'in', edge: 'any' });
+var led1 = gpio.open({pin: pins.LED1, activeLow: true});
+var led2 = gpio.open({pin: pins.LED2, activeLow: false});
+var btn1 = gpio.open({pin: pins.IO2, direction: 'in', edge: 'any'});
+var btn2 = gpio.open({pin: pins.IO4, direction: 'in', edge: 'any'});
 
 // turn off LED #2 initially
-led2.write(false);
+led1.write(false);
 
 btn1.onchange = function (event) {
     var value = btn1.read();

--- a/src/zjs_a101_pins.c
+++ b/src/zjs_a101_pins.c
@@ -1,4 +1,5 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
+
 #ifdef BUILD_MODULE_A101
 // Zephyr includes
 #include <zephyr.h>
@@ -86,9 +87,13 @@ jerry_value_t zjs_a101_init()
     zjs_obj_add_number(obj, 8,  "IO13");  // output also displayed on LED0
 
     // These are onboard LEDs
-    zjs_obj_add_number(obj, 8,  "LED0");
+    zjs_obj_add_number(obj, 26, "LED0");  // active low, red fault LED
     zjs_obj_add_number(obj, 12, "LED1");  // active low
-    zjs_obj_add_number(obj, 26, "LED2");  // active low, red fault LED
+    // LED2 is unavailable when SPI is in use because that reconfigures pin
+    //   IO13 which this is tied to. The filesystem uses SPI to talk to the
+    //   flash chip, so when you use filesystem APIs or ashell (which always
+    //   uses the filesystem) this LED will not work.
+    zjs_obj_add_number(obj, 8,  "LED2");
 
     // These cannot currently be used as GPIOs because they are controlled by
     // the ARC side and we don't have support for that. But they can be used as

--- a/tests/test-a101-pins.js
+++ b/tests/test-a101-pins.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Test Arduino101Pins API
 
@@ -43,9 +43,9 @@ for(var i = 0; i < GPIOPins.length; i++) {
 }
 
 // LEDs
-var LEDs = [["LED0", false],
-            ["LED1", true ],
-            ["LED2", true ]];
+var LEDs = [["LED0", true],
+            ["LED1", true],
+            ["LED2", false]];
 for(var i = 0; i < LEDs.length; i++) {
     var pinName = LEDs[i][0];
 
@@ -53,7 +53,7 @@ for(var i = 0; i < LEDs.length; i++) {
 
     // activeLow
     var lowFlag = LEDs[i][1];
-    var pin = gpio.open({ pin: pins[pinName], activeLow: lowFlag });
+    var pin = gpio.open({pin: pins[pinName], activeLow: lowFlag});
     var pinValue = pin.read();
     var lowStr = lowFlag ? "high" : "low";
     assert(pinValue,
@@ -63,9 +63,9 @@ for(var i = 0; i < LEDs.length; i++) {
     assert(pin.read() != pinValue,
           "Arduino101Pins: " + pinName + " output");
 
-    if (pinName == "LED0") {
+    if (pinName == "LED2") {
         pinValue = pin.read();
-        var io13 = gpio.open({ pin: pins.IO13, activeLow: lowFlag });
+        var io13 = gpio.open({pin: pins.IO13, activeLow: lowFlag});
         io13.write(!pinValue);
         assert(pin.read() != pinValue,
             "Arduino101Pins: " + pinName + " displays current state of IO13");


### PR DESCRIPTION
Also, rename the LEDs so the "bad" LED that breaks when SPI is enabled
is LED2 instead of LED0. Update samples to use the new names or switch
to using LED0 as the default.

Fixes #693.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>