### PR TITLE
  [sensor] Add support for TemperatureSensor

### DIFF
--- a/tests/test-grovelcd-ds-manual.js
+++ b/tests/test-grovelcd-ds-manual.js
@@ -43,6 +43,7 @@ var timer = setInterval(function () {
         console.log("Testing completed");
 
         clearInterval(timer);
+        return;
     }
 
     if (index[count].length === 3) {

--- a/tests/test-grovelcd-rgb-manual.js
+++ b/tests/test-grovelcd-rgb-manual.js
@@ -59,6 +59,7 @@ var colorGradient = setInterval(function () {
             console.log("Testing completed");
 
             clearInterval(colorGradient);
+            return;
         }
 
         redFlag = colorNum[colorCount][0];


### PR DESCRIPTION
The index counter has been incremented passed the length of
the array and therefore accessing the array throws an undefined
object exception.  The fix here to simply return the function
to abort the rest of the tests after tests are complete.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>