### PR TITLE
[tests] Fix exception thrown after grove lcd manual tests

### DIFF
--- a/tests/test-grovelcd-ds-manual.js
+++ b/tests/test-grovelcd-ds-manual.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 console.log("test GroveLCD display");
 

--- a/tests/test-grovelcd-ds-manual.js
+++ b/tests/test-grovelcd-ds-manual.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2017, Intel Corporation.
 
 console.log("test GroveLCD display");
 
@@ -43,6 +43,7 @@ var timer = setInterval(function () {
         console.log("Testing completed");
 
         clearInterval(timer);
+        return;
     }
 
     if (index[count].length === 3) {

--- a/tests/test-grovelcd-rgb-manual.js
+++ b/tests/test-grovelcd-rgb-manual.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2017, Intel Corporation.
 
 console.log("test RGB color");
 
@@ -59,6 +59,7 @@ var colorGradient = setInterval(function () {
             console.log("Testing completed");
 
             clearInterval(colorGradient);
+            return;
         }
 
         redFlag = colorNum[colorCount][0];

--- a/tests/test-grovelcd-rgb-manual.js
+++ b/tests/test-grovelcd-rgb-manual.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 console.log("test RGB color");
 


### PR DESCRIPTION
The index counter has been incremented passed the length of
the array and therefore accessing the array throws an undefined
object exception.  The fix here to simply return the function
to abort the rest of the tests after tests are complete.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>