### PR TITLE
[buffer] Fix bug in big-endian Buffer functions

### DIFF
--- a/samples/SensorBLEDemo.js
+++ b/samples/SensorBLEDemo.js
@@ -42,9 +42,9 @@ SensorCharacteristic.valueChange = function(isAccel, x, y, z) {
     var data = new Buffer(13);
     data.writeUInt8(isAccel, 0);
 
-    data.writeUInt32BE(xval, 1, true);
-    data.writeUInt32BE(yval, 5, true);
-    data.writeUInt32BE(zval, 9, true);
+    data.writeUInt32BE(xval, 1);
+    data.writeUInt32BE(yval, 5);
+    data.writeUInt32BE(zval, 9);
 
     if (this._onChange) {
         this._onChange(data);

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -89,7 +89,9 @@ static jerry_value_t zjs_buffer_write_bytes(const jerry_value_t this,
     // args: value[, offset]
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_OPTIONAL Z_NUMBER);
 
-    uint32_t value = (uint32_t)(int32_t)jerry_get_number_value(argv[0]);
+    // technically negatives aren't supported but this makes them behave better
+    double dval = jerry_get_number_value(argv[0]);
+    uint32_t value = (uint32_t)(dval < 0 ? (int32_t)dval : dval);
 
     uint32_t offset = 0;
     if (argc > 1)

--- a/tests/test-buffer.js
+++ b/tests/test-buffer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Buffer Testing
 

--- a/tests/test-buffer.js
+++ b/tests/test-buffer.js
@@ -83,13 +83,17 @@ assert.throws(function () {
     buff.toString("utf8");
 }, "Error thrown when 'hex' is not given to toString()");
 
+/*
+ * We don't support Math functions currently or noAssert option to buffer writes
+ *
 var buff = new Buffer(4);
 var writeValue = -0.232;
-// write negative float value (14 bit precision) as uint32 by disabling noAssert.
-buff.writeUInt32BE((writeValue * Math.pow(2, 32-14)) << 1, 0, true);
+// write negative float value (14 bit precision) as uint32 by disabling noAssert
+buff.writeUInt32BE((writeValue * Math.pow(2, 32-14)) << 1, 0);
 var readValue = (buff.readUInt32BE(0) >> 1) / Math.pow(2, 32-14);
 assert(writeValue.toPrecision(3) === readValue.toPrecision(3),
        "The value of readUInt32BE() with precision 3 expected: "
        + writeValue + " got: " + readValue.toPrecision(3));
 
 assert.result();
+*/


### PR DESCRIPTION
A bug was introduced by recent negative numbers patch; high positive
numbers were being treated as negatives and limited to 0x7fffffff.

Also, clean up a couple other things from that patch: mistaken assumption
that we support noAssert flag in these calls, and a test that uses
unsupported calls. I left it in, commented out, because it seems
interesting once we do support those calls.

Fixes #851.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>