### PR TITLE
[ocf] Fix client resource property on update

### DIFF
--- a/samples/OcfClientUpdate.js
+++ b/samples/OcfClientUpdate.js
@@ -6,7 +6,6 @@
 
 var client = require('ocf').client;
 
-
 console.log("Started OCF client");
 
 client.on('error', function(error) {

--- a/samples/OcfClientUpdate.js
+++ b/samples/OcfClientUpdate.js
@@ -1,10 +1,11 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 // Sample client that works with the linux server found in iotivity-constrained
 // This sample will find the resource, then periodically retrieve and update
 // the resource
 
 var client = require('ocf').client;
+
 
 console.log("Started OCF client");
 

--- a/samples/OcfClientUpdate.js
+++ b/samples/OcfClientUpdate.js
@@ -35,7 +35,7 @@ function onfound(resource) {
     t1 = setInterval(function() {
         console.log("Updating/Retrieving...");
         lightOn = lightOn ? false : true;
-        resource.state = lightOn;
+        resource.properties.state = lightOn;
         client.update(resource).then(function(resource) {
             console.log("update successful");
             client.retrieve(resource.deviceId, { observable: false }).then(function(res) {

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -261,6 +261,8 @@ static jerry_value_t create_resource(const char *device_id, const char *path)
     if (path) {
         zjs_obj_add_string(resource, path, "resourcePath");
     }
+    ZVAL props = jerry_create_object();
+    zjs_set_property(resource, "properties", props);
 
     DBG_PRINT("id=%s, path=%s, obj number=%lu\n", device_id, path, resource);
 
@@ -710,11 +712,12 @@ static jerry_value_t ocf_update(const jerry_value_t function_val,
                     put_finished,
                     LOW_QOS,
                     h)) {
+        ZVAL props = zjs_get_property(argv[0], "properties");
         void *ret;
         // Start the root encoding object
         zjs_rep_start_root_object();
         // Encode all properties from resource (argv[0])
-        ret = zjs_ocf_props_setup(argv[0], &g_encoder, true);
+        ret = zjs_ocf_props_setup(props, &g_encoder, true);
         zjs_rep_end_root_object();
         // Free property return handle
         zjs_ocf_free_props(ret);

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifdef BUILD_MODULE_OCF
 


### PR DESCRIPTION
Fixes #810

Client update was expecting the properties to be part of
the resource object, not resource.properties as it should
be.

Signed-off-by: James Prestwood <james.prestwood@intel.com>