### PR TITLE
[events] Changed ERR_PRINT to DBG_PRINT in trigger event

### DIFF
--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -374,7 +374,7 @@ bool zjs_trigger_event(jerry_value_t obj,
     ZVAL event_obj = zjs_get_property(map, event);
 
     if (!jerry_value_is_object(event_obj)) {
-        ERR_PRINT("event object not found\n");
+        DBG_PRINT("event object not found\n");
         return false;
     }
 


### PR DESCRIPTION
Fixes #917

If emit is called on an event object that has no events it
would print an error message. This was not really an "error",
just a message.

Signed-off-by: James Prestwood <james.prestwood@intel.com>