### PR TITLE
[buffer] Return an error when out of memory in zjs_buffer_create

### DIFF
--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -308,11 +308,14 @@ static void zjs_ble_write_c_callback(void *handle, const void *argv)
 
     ZVAL_MUTABLE buf_obj;
     if (cb->buffer && cb->buffer_size > 0) {
-        buf_obj = zjs_buffer_create(cb->buffer_size);
-        zjs_buffer_t *buf = zjs_buffer_find(buf_obj);
-
+        zjs_buffer_t *buf;
+        buf_obj = zjs_buffer_create(cb->buffer_size, &buf);
         if (buf) {
             memcpy(buf->buffer, cb->buffer, cb->buffer_size);
+        }
+        else {
+            // can't pass object with error flag as a JS arg
+            jerry_value_clear_error_flag(&buf_obj);
         }
     }
     else {

--- a/src/zjs_buffer.h
+++ b/src/zjs_buffer.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_buffer_h__
 #define __zjs_buffer_h__
@@ -21,6 +21,16 @@ typedef struct zjs_buffer {
 
 zjs_buffer_t *zjs_buffer_find(const jerry_value_t obj);
 
-jerry_value_t zjs_buffer_create(uint32_t size);
+
+/**
+ * Create a new Buffer object
+ *
+ * @param size     Buffer size in bytes
+ * @param ret_buf  Output pointer to receive new buffer handle, or NULL
+ *
+ * @return  New JS Buffer or Error object, and sets *ret_buf to C handle or
+ *            NULL, if given
+ */
+jerry_value_t zjs_buffer_create(uint32_t size, zjs_buffer_t **ret_buf);
 
 #endif  // __zjs_buffer_h__

--- a/src/zjs_dgram.c
+++ b/src/zjs_dgram.c
@@ -123,9 +123,9 @@ static void udp_received(struct net_context *context,
     net_addr_ntop(family, addr, addr_str, sizeof(addr_str));
 
     zjs_buffer_t *buf;
-    ZVAL buf_js = zjs_buffer_create(recv_len, &buf);
+    ZVAL_MUTABLE buf_js = zjs_buffer_create(recv_len, &buf);
+    ZVAL rinfo = jerry_create_object();
     if (buf) {
-        ZVAL rinfo = jerry_create_object();
         zjs_obj_add_number(rinfo, ntohs(NET_UDP_BUF(net_buf)->src_port),
                            "port");
         zjs_obj_add_string(rinfo, family == AF_INET ? "IPv4" : "IPv6",

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -107,11 +107,13 @@ static void uart_c_callback(void *h, const void *args)
         return;
     }
     if (handle->size >= handle->min) {
-        handle->buf_obj = zjs_buffer_create(handle->size);
-        zjs_buffer_t *buffer = zjs_buffer_find(handle->buf_obj);
+        zjs_buffer_t *buffer;
+        handle->buf_obj = zjs_buffer_create(handle->size, &buffer);
 
-        memcpy(buffer->buffer, args, handle->size);
+        if (buffer) {
+            memcpy(buffer->buffer, args, handle->size);
 
+        }
         zjs_trigger_event_now(handle->uart_obj, "read", &handle->buf_obj, 1,
                               post_event, NULL);
 


### PR DESCRIPTION
Also, return the handle in a new out param to simplify detecting the
error case from the caller.

Addresses a request in #916.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>