### PR TITLE
[buffer] Return buffer as out parameter to zjs_buffer_create()

### DIFF
--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -363,7 +363,7 @@ jerry_value_t zjs_buffer_create(uint32_t size, zjs_buffer_t **ret_buf)
     // watch for the object getting garbage collected, and clean up
     jerry_set_object_native_handle(buf_obj, (uintptr_t)buf_item,
                                    zjs_buffer_callback_free);
-
+    *ret_buf = buf_item;
     return buf_obj;
 }
 


### PR DESCRIPTION
Signed-off-by: James Prestwood <james.prestwood@intel.com>