### PR TITLE
[snapshot] Fix possible cause of parser disabled in ashell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,6 @@ cleanlocal:
 	@rm -f prj.mdef
 	@rm -f zjs.conf.tmp
 	@rm -f js.tmp
-	@rm -f .snapshot.last_build
 
 # Explicit clean
 .PHONY: clean


### PR DESCRIPTION
We should not delete the .snapshot.last_build file since make clean
do not rebuild snapshot tool.

Fixes #936

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>