### PR TITLE
[build] Fix makefile bug that EXT_JERRY_FLAGS are ignored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,6 @@ ROM ?= 256
 # Dump memory information: on = print allocs, full = print allocs + dump pools
 TRACE ?= off
 
-# Generate and run snapshot as byte code instead of running JS directly
-ifneq (,$(filter $(MAKECMDGOALS),ide ashell linux))
-SNAPSHOT=off
-# if the user passes in SNAPSHOT=on for ide, ashell, or linux give an error
-ifeq ($(SNAPSHOT), on)
-$(error ide, ashell, and linux do not support SNAPSHOT=$(SNAPSHOT))
-endif
-else
-# snapshot is enabled by default
-SNAPSHOT ?= on
-ifeq ($(SNAPSHOT), on)
-EXT_JERRY_FLAGS += -DFEATURE_JS_PARSER=OFF
-endif
-endif
-
 ifneq (,$(DEV))
 $(error DEV= is no longer supported, please use make ide or make ashell)
 endif
@@ -67,9 +52,24 @@ BLE_ADDR ?= "none"
 # JerryScript options
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 EXT_JERRY_FLAGS ?=	-DENABLE_ALL_IN_ONE=ON \
-					-DFEATURE_PROFILE=$(ZJS_BASE)/jerry_feature.profile \
-					-DFEATURE_ERROR_MESSAGES=OFF \
-					-DJERRY_LIBM=OFF
+			-DFEATURE_PROFILE=$(ZJS_BASE)/jerry_feature.profile \
+			-DFEATURE_ERROR_MESSAGES=OFF \
+			-DJERRY_LIBM=OFF
+
+# Generate and run snapshot as byte code instead of running JS directly
+ifneq (,$(filter $(MAKECMDGOALS),ide ashell linux))
+SNAPSHOT=off
+# if the user passes in SNAPSHOT=on for ide, ashell, or linux give an error
+ifeq ($(SNAPSHOT), on)
+$(error ide, ashell, and linux do not support SNAPSHOT=$(SNAPSHOT))
+endif
+else
+# snapshot is enabled by default
+SNAPSHOT ?= on
+ifeq ($(SNAPSHOT), on)
+EXT_JERRY_FLAGS += -DFEATURE_JS_PARSER=OFF
+endif
+endif
 
 # Settings for ashell builds
 ifneq (,$(filter $(MAKECMDGOALS),ide ashell))


### PR DESCRIPTION
One of the previous patch broke the Makefile so that
jerryscript flags are not appended to EXT_JERRY_FLAGS,
which caused final ROM size to go up significantly.

Fixes #901

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>