### PR TITLE
[buffer] Check for NULL return buffer pointers in create func

### DIFF
--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -378,7 +378,9 @@ jerry_value_t zjs_buffer_create(uint32_t size, zjs_buffer_t **ret_buf)
     // watch for the object getting garbage collected, and clean up
     jerry_set_object_native_handle(buf_obj, (uintptr_t)buf_item,
                                    zjs_buffer_callback_free);
-    *ret_buf = buf_item;
+    if (ret_buf) {
+        *ret_buf = buf_item;
+    }
     return buf_obj;
 }
 


### PR DESCRIPTION
Fixes #970 and #988.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>