### PR TITLE
Adds CT_CC_GCC_STATIC_LIBSTDCXX=n to custom .config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ CT_INSTALL_DIR="${CT_PREFIX_DIR}"
 # Following options prevent link errors
 CT_WANTS_STATIC_LINK=n
 CT_CC_STATIC_LIBSTDCXX=n
+CT_CC_GCC_STATIC_LIBSTDCXX=n
 ...
 ```
 


### PR DESCRIPTION
Without this, `ct-ng build` will fail

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>