### PR TITLE
[utils] Add ZJS_DECL_FUNC and related macros

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -49,19 +49,13 @@ const char script_jscode[] = {
 #endif
 
 // native eval handler
-static jerry_value_t native_eval_handler(const jerry_value_t function_obj,
-                                         const jerry_value_t this,
-                                         const jerry_value_t argv[],
-                                         const jerry_length_t argc)
+static ZJS_DECL_FUNC(native_eval_handler)
 {
     return zjs_error("eval not supported");
 }
 
 // native print handler
-static jerry_value_t native_print_handler(const jerry_value_t function_obj,
-                                          const jerry_value_t this,
-                                          const jerry_value_t argv[],
-                                          const jerry_length_t argc)
+static ZJS_DECL_FUNC(native_print_handler)
 {
     if (argc < 1 || !jerry_value_is_string(argv[0]))
         return zjs_error("print: missing string argument");
@@ -76,10 +70,7 @@ static jerry_value_t native_print_handler(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t stop_js_handler(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc)
+static ZJS_DECL_FUNC(stop_js_handler)
 {
     #ifdef CONFIG_BOARD_ARDUINO_101
     zjs_ipm_free_callbacks();

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -158,10 +158,7 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
     }
 }
 
-static jerry_value_t zjs_aio_pin_read(const jerry_value_t function_obj,
-                                      const jerry_value_t this,
-                                      const jerry_value_t argv[],
-                                      const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_aio_pin_read)
 {
     uint32_t pin;
     zjs_obj_get_uint32(this, "pin", &pin);
@@ -180,10 +177,7 @@ static jerry_value_t zjs_aio_pin_read(const jerry_value_t function_obj,
     return result;
 }
 
-static jerry_value_t zjs_aio_pin_close(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_aio_pin_close)
 {
     uint32_t pin;
     zjs_obj_get_uint32(this, "pin", &pin);
@@ -200,10 +194,7 @@ static jerry_value_t zjs_aio_pin_close(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_aio_pin_on)
 {
     // args: event name, callback
     ZJS_VALIDATE_ARGS(Z_STRING, Z_FUNCTION Z_NULL);
@@ -245,10 +236,7 @@ static jerry_value_t zjs_aio_pin_on(const jerry_value_t function_obj,
 }
 
 // Asynchronous Operations
-static jerry_value_t zjs_aio_pin_read_async(const jerry_value_t function_obj,
-                                            const jerry_value_t this,
-                                            const jerry_value_t argv[],
-                                            const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_aio_pin_read_async)
 {
     // args: callback
     ZJS_VALIDATE_ARGS(Z_FUNCTION);
@@ -270,10 +258,7 @@ static jerry_value_t zjs_aio_pin_read_async(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_aio_open(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_aio_open)
 {
     // args: initialization object
     ZJS_VALIDATE_ARGS(Z_OBJECT);

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -171,10 +171,7 @@ static void zjs_ble_free_services(ble_service_t *service)
     }
 }
 
-static jerry_value_t zjs_ble_read_callback_function(const jerry_value_t function_obj,
-                                                    const jerry_value_t this,
-                                                    const jerry_value_t argv[],
-                                                    const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_read_callback_function)
 {
     // TODO: couldn't use ZJS_VALIDATE_ARGS here because it needs to give the
     //   semaphore on error case
@@ -276,10 +273,7 @@ static ssize_t zjs_ble_read_attr_callback(struct bt_conn *conn,
     return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 }
 
-static jerry_value_t zjs_ble_write_callback_function(const jerry_value_t function_obj,
-                                                     const jerry_value_t this,
-                                                     const jerry_value_t argv[],
-                                                     const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_write_callback_function)
 {
     // TODO: couldn't use ZJS_VALIDATE_ARGS here because it needs to give the
     //   semaphore on error case
@@ -376,10 +370,7 @@ static ssize_t zjs_ble_write_attr_callback(struct bt_conn *conn,
     return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 }
 
-static jerry_value_t zjs_ble_update_value_callback_function(const jerry_value_t function_obj,
-                                                            const jerry_value_t this,
-                                                            const jerry_value_t argv[],
-                                                            const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_update_value_callback_function)
 {
     // args: buffer
     ZJS_VALIDATE_ARGS(Z_OBJECT);
@@ -560,10 +551,7 @@ void zjs_ble_enable() {
     bt_conn_auth_cb_register(&zjs_ble_auth_cb_display);
 }
 
-static jerry_value_t zjs_ble_disconnect(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_disconnect)
 {
     if (ble_conn.default_conn) {
         int error = bt_conn_disconnect(ble_conn.default_conn,
@@ -652,10 +640,7 @@ static int zjs_encode_url_frame(jerry_value_t url, uint8_t **frame, int *size)
     return ZJS_SUCCESS;
 }
 
-static jerry_value_t zjs_ble_start_advertising(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_start_advertising)
 {
     // arg 0 should be the device name to advertise, e.g. "Arduino101"
     // arg 1 should be an array of UUIDs (short, 4 hex chars)
@@ -759,10 +744,7 @@ static jerry_value_t zjs_ble_start_advertising(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_ble_stop_advertising(const jerry_value_t function_obj,
-                                              const jerry_value_t this,
-                                              const jerry_value_t argv[],
-                                              const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_stop_advertising)
 {
     DBG_PRINT("stopAdvertising has been called\n");
     return ZJS_UNDEFINED;
@@ -1099,10 +1081,7 @@ static bool zjs_ble_register_service(ble_service_t *service)
     return true;
 }
 
-static jerry_value_t zjs_ble_set_services(const jerry_value_t function_obj,
-                                          const jerry_value_t this,
-                                          const jerry_value_t argv[],
-                                          const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_set_services)
 {
     // arg 0 should be an array of services
     // arg 1 is optionally an callback function
@@ -1179,10 +1158,7 @@ static jerry_value_t zjs_ble_set_services(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_ble_update_rssi(const jerry_value_t function_obj,
-                                         const jerry_value_t this,
-                                         const jerry_value_t argv[],
-                                         const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_update_rssi)
 {
     // TODO: get actual RSSI value from Zephyr Bluetooth driver
     ZVAL arg = jerry_create_number(-50);
@@ -1191,10 +1167,7 @@ static jerry_value_t zjs_ble_update_rssi(const jerry_value_t function_obj,
 }
 
 // Constructor
-static jerry_value_t zjs_ble_primary_service(const jerry_value_t function_obj,
-                                             const jerry_value_t this,
-                                             const jerry_value_t argv[],
-                                             const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_primary_service)
 {
     // args: initialization object
     ZJS_VALIDATE_ARGS(Z_OBJECT);
@@ -1203,10 +1176,7 @@ static jerry_value_t zjs_ble_primary_service(const jerry_value_t function_obj,
 }
 
 // Constructor
-static jerry_value_t zjs_ble_characteristic(const jerry_value_t function_obj,
-                                            const jerry_value_t this,
-                                            const jerry_value_t argv[],
-                                            const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_characteristic)
 {
     // args: initialization object
     ZJS_VALIDATE_ARGS(Z_OBJECT);
@@ -1247,10 +1217,7 @@ static jerry_value_t zjs_ble_characteristic(const jerry_value_t function_obj,
 }
 
 // Constructor
-static jerry_value_t zjs_ble_descriptor(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_ble_descriptor)
 {
     // args: initialization object
     ZJS_VALIDATE_ARGS(Z_OBJECT);

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -117,82 +117,52 @@ static jerry_value_t zjs_buffer_write_bytes(const jerry_value_t this,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_buffer_read_uint8(const jerry_value_t function_obj,
-                                           const jerry_value_t this,
-                                           const jerry_value_t argv[],
-                                           const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_read_uint8)
 {
     return zjs_buffer_read_bytes(this, argv, argc, 1, true);
 }
 
-static jerry_value_t zjs_buffer_read_uint16_be(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_read_uint16_be)
 {
     return zjs_buffer_read_bytes(this, argv, argc, 2, true);
 }
 
-static jerry_value_t zjs_buffer_read_uint16_le(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_read_uint16_le)
 {
     return zjs_buffer_read_bytes(this, argv, argc, 2, false);
 }
 
-static jerry_value_t zjs_buffer_read_uint32_be(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_read_uint32_be)
 {
     return zjs_buffer_read_bytes(this, argv, argc, 4, true);
 }
 
-static jerry_value_t zjs_buffer_read_uint32_le(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_read_uint32_le)
 {
     return zjs_buffer_read_bytes(this, argv, argc, 4, false);
 }
 
-static jerry_value_t zjs_buffer_write_uint8(const jerry_value_t function_obj,
-                                           const jerry_value_t this,
-                                           const jerry_value_t argv[],
-                                           const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_write_uint8)
 {
     return zjs_buffer_write_bytes(this, argv, argc, 1, true);
 }
 
-static jerry_value_t zjs_buffer_write_uint16_be(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_write_uint16_be)
 {
     return zjs_buffer_write_bytes(this, argv, argc, 2, true);
 }
 
-static jerry_value_t zjs_buffer_write_uint16_le(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_write_uint16_le)
 {
     return zjs_buffer_write_bytes(this, argv, argc, 2, false);
 }
 
-static jerry_value_t zjs_buffer_write_uint32_be(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_write_uint32_be)
 {
     return zjs_buffer_write_bytes(this, argv, argc, 4, true);
 }
 
-static jerry_value_t zjs_buffer_write_uint32_le(const jerry_value_t function_obj,
-                                               const jerry_value_t this,
-                                               const jerry_value_t argv[],
-                                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_write_uint32_le)
 {
     return zjs_buffer_write_bytes(this, argv, argc, 4, false);
 }
@@ -205,10 +175,7 @@ char zjs_int_to_hex(int value) {
     return 'a' + value - 10;
 }
 
-static jerry_value_t zjs_buffer_to_string(const jerry_value_t function_obj,
-                                          const jerry_value_t this,
-                                          const jerry_value_t argv[],
-                                          const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_to_string)
 {
     // requires: this must be a JS buffer object, if an argument is present it
     //             must be the string 'ascii' or 'hex', as those are the only
@@ -263,10 +230,7 @@ static void zjs_buffer_callback_free(uintptr_t handle)
     zjs_free(item);
 }
 
-static jerry_value_t zjs_buffer_write_string(const jerry_value_t function_obj,
-                                             const jerry_value_t this,
-                                             const jerry_value_t argv[],
-                                             const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer_write_string)
 {
     // requires: string - what will be written to buf
     //           offset - where to start writing (Default: 0)
@@ -385,10 +349,7 @@ jerry_value_t zjs_buffer_create(uint32_t size, zjs_buffer_t **ret_buf)
 }
 
 // Buffer constructor
-static jerry_value_t zjs_buffer(const jerry_value_t function_obj,
-                                const jerry_value_t this,
-                                const jerry_value_t argv[],
-                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_buffer)
 {
     // requires: single argument can be a numeric size in bytes, an array of
     //             uint8s, or a string

--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -138,11 +138,7 @@ static void print_value(const jerry_value_t value, FILE *out, bool deep,
     }
 }
 
-static jerry_value_t do_print(const jerry_value_t function_obj,
-                              const jerry_value_t this,
-                              const jerry_value_t argv[],
-                              const jerry_length_t argc,
-                              FILE *out)
+static ZJS_DECL_FUNC_ARGS(do_print, FILE *out)
 {
     for (int i = 0; i < argc; i++) {
         if (i) {
@@ -155,26 +151,17 @@ static jerry_value_t do_print(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t console_log(const jerry_value_t function_obj,
-                                 const jerry_value_t this,
-                                 const jerry_value_t argv[],
-                                 const jerry_length_t argc)
+static ZJS_DECL_FUNC(console_log)
 {
-    return do_print(function_obj, this, argv, argc, stdout);
+    return ZJS_CHAIN_FUNC_ARGS(do_print, stdout);
 }
 
-static jerry_value_t console_error(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(console_error)
 {
-    return do_print(function_obj, this, argv, argc, stderr);
+    return ZJS_CHAIN_FUNC_ARGS(do_print, stderr);
 }
 
-static jerry_value_t console_time(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(console_time)
 {
     // args: label
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -186,10 +173,7 @@ static jerry_value_t console_time(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t console_time_end(const jerry_value_t function_obj,
-                                      const jerry_value_t this,
-                                      const jerry_value_t argv[],
-                                      const jerry_length_t argc)
+static ZJS_DECL_FUNC(console_time_end)
 {
     // args: label
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -216,10 +200,7 @@ static jerry_value_t console_time_end(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t console_assert(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc)
+static ZJS_DECL_FUNC(console_assert)
 {
     // args: validity[, output]
     ZJS_VALIDATE_ARGS(Z_BOOL, Z_OPTIONAL Z_ANY);

--- a/src/zjs_dgram.c
+++ b/src/zjs_dgram.c
@@ -149,10 +149,7 @@ static void udp_received(struct net_context *context,
     zjs_signal_callback(handle->message_cb_id, args, sizeof(args));
 }
 
-static jerry_value_t zjs_dgram_createSocket(const jerry_value_t function_obj,
-                                            const jerry_value_t this,
-                                            const jerry_value_t argv[],
-                                            const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_dgram_createSocket)
 {
     // args: address family
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -191,10 +188,7 @@ static jerry_value_t zjs_dgram_createSocket(const jerry_value_t function_obj,
     return sockobj;
 }
 
-static jerry_value_t zjs_dgram_sock_on(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_dgram_sock_on)
 {
     // args: event name, callback
     ZJS_VALIDATE_ARGS(Z_STRING, Z_FUNCTION Z_NULL);
@@ -243,10 +237,7 @@ static void udp_sent(struct net_context *context, int status, void *token,
     }
 }
 
-static jerry_value_t zjs_dgram_sock_send(const jerry_value_t function_obj,
-                                         const jerry_value_t this,
-                                         const jerry_value_t argv[],
-                                         const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_dgram_sock_send)
 {
     // NOTE: really argv[1] and argv[2] (offset and length) are supposed to be
     //   optional, which would require improvements to ZJS_VALIDATE_ARGS,
@@ -295,10 +286,7 @@ static jerry_value_t zjs_dgram_sock_send(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_dgram_sock_bind(const jerry_value_t function_obj,
-                                         const jerry_value_t this,
-                                         const jerry_value_t argv[],
-                                         const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_dgram_sock_bind)
 {
     // NOTE: really argv[0] and argv[1] are supposed to be optional, but
     //   leaving them as they were here for now
@@ -324,10 +312,7 @@ static jerry_value_t zjs_dgram_sock_bind(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_dgram_sock_close(const jerry_value_t function_obj,
-                                          const jerry_value_t this,
-                                          const jerry_value_t argv[],
-                                          const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_dgram_sock_close)
 {
     GET_HANDLE(dgram_handle_t, handle);
     zjs_dgram_free_cb((uintptr_t)handle);

--- a/src/zjs_error.c
+++ b/src/zjs_error.c
@@ -21,10 +21,7 @@ static zjs_error_t error_types[] = {
     { "TypeError" },
 };
 
-static jerry_value_t error_handler(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(error_handler)
 {
     // args: message
     ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_STRING);

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -109,10 +109,7 @@ void zjs_add_event_listener(jerry_value_t obj, const char *event,
     zjs_obj_add_number(event_emitter, ++num_events, "numEvents");
 }
 
-static jerry_value_t add_listener(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(add_listener)
 {
     // args: event name, callback
     ZJS_VALIDATE_ARGS(Z_STRING, Z_FUNCTION);
@@ -127,10 +124,7 @@ static jerry_value_t add_listener(const jerry_value_t function_obj,
     return jerry_acquire_value(this);
 }
 
-static jerry_value_t emit_event(const jerry_value_t function_obj,
-                                const jerry_value_t this,
-                                const jerry_value_t *argv,
-                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(emit_event)
 {
     // args: event name[, additional pass-through args]
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -148,10 +142,7 @@ static jerry_value_t emit_event(const jerry_value_t function_obj,
                                                   argc - 1, NULL, NULL));
 }
 
-static jerry_value_t remove_listener(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc)
+static ZJS_DECL_FUNC(remove_listener)
 {
     // args: event name, callback
     ZJS_VALIDATE_ARGS(Z_STRING, Z_FUNCTION);
@@ -184,10 +175,7 @@ static jerry_value_t remove_listener(const jerry_value_t function_obj,
     return jerry_acquire_value(this);
 }
 
-static jerry_value_t remove_all_listeners(const jerry_value_t function_obj,
-                                          const jerry_value_t this,
-                                          const jerry_value_t argv[],
-                                          const jerry_length_t argc)
+static ZJS_DECL_FUNC(remove_all_listeners)
 {
     // args: event name
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -237,10 +225,7 @@ bool foreach_event_name(const jerry_value_t prop_name,
     return true;
 }
 
-static jerry_value_t get_event_names(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc)
+static ZJS_DECL_FUNC(get_event_names)
 {
     event_names_t names;
 
@@ -256,20 +241,14 @@ static jerry_value_t get_event_names(const jerry_value_t function_obj,
     return names.name_array;
 }
 
-static jerry_value_t get_max_listeners(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc)
+static ZJS_DECL_FUNC(get_max_listeners)
 {
     ZVAL event_emitter = zjs_get_property(this, HIDDEN_PROP("event"));
     uint32_t max_listeners = get_max_event_listeners(event_emitter);
     return jerry_create_number(max_listeners);
 }
 
-static jerry_value_t set_max_listeners(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc)
+static ZJS_DECL_FUNC(set_max_listeners)
 {
     // args: max count
     ZJS_VALIDATE_ARGS(Z_NUMBER);
@@ -285,10 +264,7 @@ static jerry_value_t set_max_listeners(const jerry_value_t function_obj,
     return jerry_acquire_value(this);
 }
 
-static jerry_value_t get_listener_count(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(get_listener_count)
 {
     // args: event name
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -320,10 +296,7 @@ static jerry_value_t get_listener_count(const jerry_value_t function_obj,
     return jerry_create_number(count);
 }
 
-static jerry_value_t get_listeners(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(get_listeners)
 {
     // args: event name
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -459,10 +432,7 @@ void zjs_make_event(jerry_value_t obj, jerry_value_t prototype)
     zjs_obj_add_object(obj, event_obj, HIDDEN_PROP("event"));
 }
 
-static jerry_value_t event_constructor(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc)
+static ZJS_DECL_FUNC(event_constructor)
 {
     jerry_value_t new_emitter = jerry_create_object();
     zjs_make_event(new_emitter, ZJS_UNDEFINED);

--- a/src/zjs_fs.c
+++ b/src/zjs_fs.c
@@ -139,10 +139,7 @@ static uint16_t get_mode(char *str)
     return mode;
 }
 
-static jerry_value_t is_file(const jerry_value_t function_obj,
-                             const jerry_value_t this,
-                             const jerry_value_t argv[],
-                             const jerry_length_t argc)
+static ZJS_DECL_FUNC(is_file)
 {
     struct fs_dirent *entry;
 
@@ -156,10 +153,7 @@ static jerry_value_t is_file(const jerry_value_t function_obj,
     }
 }
 
-static jerry_value_t is_directory(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(is_directory)
 {
     struct fs_dirent *entry;
 
@@ -200,11 +194,7 @@ static jerry_value_t create_stats_obj(struct fs_dirent *entry)
     return stats_obj;
 }
 
-static jerry_value_t zjs_open(const jerry_value_t function_obj,
-                              const jerry_value_t this,
-                              const jerry_value_t argv[],
-                              const jerry_length_t argc,
-                              uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_open, uint8_t async)
 {
     // NOTE: what we call mode below is actually 'flags' in Node docs, argv[1];
     //   we don't support mode (optional argv[2])
@@ -274,27 +264,17 @@ static jerry_value_t zjs_open(const jerry_value_t function_obj,
     return jerry_create_number(handle->fd);
 }
 
-static jerry_value_t zjs_open_sync(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc) {
-    return zjs_open(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_open_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_open, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_open_async(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc) {
-    return zjs_open(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_open_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_open, 1);
 }
 #endif
 
-static jerry_value_t zjs_close(const jerry_value_t function_obj,
-                               const jerry_value_t this,
-                               const jerry_value_t argv[],
-                               const jerry_length_t argc,
-                               uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_close, uint8_t async)
 {
     // args: file descriptor
     ZJS_VALIDATE_ARGS(Z_NUMBER);
@@ -330,27 +310,17 @@ static jerry_value_t zjs_close(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_close_sync(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc) {
-    return zjs_close(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_close_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_close, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_close_async(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc) {
-    return zjs_close(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_close_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_close, 1);
 }
 #endif
 
-static jerry_value_t zjs_unlink(const jerry_value_t function_obj,
-                                const jerry_value_t this,
-                                const jerry_value_t argv[],
-                                const jerry_length_t argc,
-                                uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_unlink, uint8_t async)
 {
     // args: filename
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -388,27 +358,17 @@ static jerry_value_t zjs_unlink(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_unlink_sync(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc) {
-    return zjs_unlink(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_unlink_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_unlink, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_unlink_async(const jerry_value_t function_obj,
-                                      const jerry_value_t this,
-                                      const jerry_value_t argv[],
-                                      const jerry_length_t argc) {
-    return zjs_unlink(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_unlink_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_unlink, 1);
 }
 #endif
 
-static jerry_value_t zjs_read(const jerry_value_t function_obj,
-                              const jerry_value_t this,
-                              const jerry_value_t argv[],
-                              const jerry_length_t argc,
-                              uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_read, uint8_t async)
 {
     // args: file descriptor, buffer, offset, length, position
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_OBJECT, Z_NUMBER, Z_NUMBER, Z_NUMBER Z_NULL);
@@ -492,27 +452,17 @@ static jerry_value_t zjs_read(const jerry_value_t function_obj,
     return jerry_create_number(ret);
 }
 
-static jerry_value_t zjs_read_sync(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc) {
-    return zjs_read(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_read_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_read, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_read_async(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc) {
-    return zjs_read(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_read_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_read, 1);
 }
 #endif
 
-static jerry_value_t zjs_write(const jerry_value_t function_obj,
-                               const jerry_value_t this,
-                               const jerry_value_t argv[],
-                               const jerry_length_t argc,
-                               uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_write, uint8_t async)
 {
     // args: file descriptor, buffer[, offset[, length[, position]]]
     ZJS_VALIDATE_ARGS_OPTCOUNT(optcount, Z_NUMBER, Z_OBJECT,
@@ -605,27 +555,17 @@ static jerry_value_t zjs_write(const jerry_value_t function_obj,
     return jerry_create_number(written);
 }
 
-static jerry_value_t zjs_write_sync(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc) {
-    return zjs_write(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_write_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_write, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_write_async(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc) {
-    return zjs_write(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_write_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_write, 1);
 }
 #endif
 
-static jerry_value_t zjs_truncate(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc,
-                                  uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_truncate, uint8_t async)
 {
     // args: file descriptor or string path, length
     ZJS_VALIDATE_ARGS(Z_OBJECT Z_STRING, Z_NUMBER);
@@ -678,27 +618,17 @@ static jerry_value_t zjs_truncate(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_truncate_sync(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc) {
-    return zjs_truncate(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_truncate_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_truncate, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_truncate_async(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc) {
-    return zjs_truncate(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_truncate_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_truncate, 1);
 }
 #endif
 
-static jerry_value_t zjs_mkdir(const jerry_value_t function_obj,
-                               const jerry_value_t this,
-                               const jerry_value_t argv[],
-                               const jerry_length_t argc,
-                               uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_mkdir, uint8_t async)
 {
     // args: dirpath
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -733,27 +663,17 @@ static jerry_value_t zjs_mkdir(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_mkdir_sync(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc) {
-    return zjs_mkdir(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_mkdir_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_mkdir, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_mkdir_async(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc) {
-    return zjs_mkdir(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_mkdir_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_mkdir, 1);
 }
 #endif
 
-static jerry_value_t zjs_readdir(const jerry_value_t function_obj,
-                                 const jerry_value_t this,
-                                 const jerry_value_t argv[],
-                                 const jerry_length_t argc,
-                                 uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_readdir, uint8_t async)
 {
     // args: dirpath
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -842,27 +762,17 @@ static jerry_value_t zjs_readdir(const jerry_value_t function_obj,
     return array;
 }
 
-static jerry_value_t zjs_readdir_sync(const jerry_value_t function_obj,
-                                      const jerry_value_t this,
-                                      const jerry_value_t argv[],
-                                      const jerry_length_t argc) {
-    return zjs_readdir(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_readdir_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_readdir, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_readdir_async(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc) {
-    return zjs_readdir(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_readdir_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_readdir, 1);
 }
 #endif
 
-static jerry_value_t zjs_stat(const jerry_value_t function_obj,
-                              const jerry_value_t this,
-                              const jerry_value_t argv[],
-                              const jerry_length_t argc,
-                              uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_stat, uint8_t async)
 {
     // args: filepath
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -904,27 +814,17 @@ static jerry_value_t zjs_stat(const jerry_value_t function_obj,
     return create_stats_obj(&entry);
 }
 
-static jerry_value_t zjs_stat_sync(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc) {
-    return zjs_stat(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_stat_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_stat, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_stat_async(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc) {
-    return zjs_stat(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_stat_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_stat, 1);
 }
 #endif
 
-static jerry_value_t zjs_write_file(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc,
-                                    uint8_t async)
+static ZJS_DECL_FUNC_ARGS(zjs_write_file, uint8_t async)
 {
     // args: filepath, data
     ZJS_VALIDATE_ARGS(Z_STRING, Z_OBJECT Z_STRING);
@@ -998,19 +898,13 @@ Finished:
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_write_file_sync(const jerry_value_t function_obj,
-                                         const jerry_value_t this,
-                                         const jerry_value_t argv[],
-                                         const jerry_length_t argc) {
-    return zjs_write_file(function_obj, this, argv, argc, 0);
+static ZJS_DECL_FUNC(zjs_write_file_sync) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_write_file, 0);
 }
 
 #ifdef ZJS_FS_ASYNC_APIS
-static jerry_value_t zjs_write_file_async(const jerry_value_t function_obj,
-                                          const jerry_value_t this,
-                                          const jerry_value_t argv[],
-                                          const jerry_length_t argc) {
-    return zjs_write_file(function_obj, this, argv, argc, 1);
+static ZJS_DECL_FUNC(zjs_write_file_async) {
+    return ZJS_CHAIN_FUNC_ARGS(zjs_write_file, 1);
 }
 #endif
 

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -149,10 +149,7 @@ static void zjs_gpio_zephyr_callback(struct device *port,
     }
 }
 
-static jerry_value_t zjs_gpio_pin_read(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_gpio_pin_read)
 {
     // requires: this is a GPIOPin object from zjs_gpio_open, takes no args
     //  effects: reads a logical value from the pin and returns it in ret_val_p
@@ -187,10 +184,7 @@ static jerry_value_t zjs_gpio_pin_read(const jerry_value_t function_obj,
     return jerry_create_boolean(logical);
 }
 
-static jerry_value_t zjs_gpio_pin_write(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_gpio_pin_write)
 {
     // requires: this is a GPIOPin object from zjs_gpio_open, takes one arg,
     //             the logical boolean value to set to the pin (true = active)
@@ -237,10 +231,7 @@ static void zjs_gpio_close(gpio_handle_t *handle)
         handle->closed = true;
 }
 
-static jerry_value_t zjs_gpio_pin_close(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_gpio_pin_close)
 {
     uintptr_t ptr;
     if (jerry_get_object_native_handle(this, &ptr)) {
@@ -275,11 +266,7 @@ static void post_open_promise(void *h)
     }
 }
 
-static jerry_value_t zjs_gpio_open(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc,
-                                   bool async)
+static ZJS_DECL_FUNC_ARGS(zjs_gpio_open, bool async)
 {
     // requires: arg 0 is an object with these members: pin (int), direction
     //             (defaults to "out"), activeLow (defaults to false),
@@ -424,20 +411,14 @@ static jerry_value_t zjs_gpio_open(const jerry_value_t function_obj,
     return jerry_acquire_value(pinobj);
 }
 
-static jerry_value_t zjs_gpio_open_sync(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_gpio_open_sync)
 {
-    return zjs_gpio_open(function_obj, this, argv, argc, false);
+    return ZJS_CHAIN_FUNC_ARGS(zjs_gpio_open, false);
 }
 
-static jerry_value_t zjs_gpio_open_async(const jerry_value_t function_obj,
-                                         const jerry_value_t this,
-                                         const jerry_value_t argv[],
-                                         const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_gpio_open_async)
 {
-    return zjs_gpio_open(function_obj, this, argv, argc, true);
+    return ZJS_CHAIN_FUNC_ARGS(zjs_gpio_open, true);
 }
 
 jerry_value_t zjs_gpio_init()

--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -21,10 +21,7 @@ static struct device *glcd = NULL;
 
 static jerry_value_t zjs_glcd_prototype;
 
-static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_print)
 {
     // args: text
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -46,10 +43,7 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_clear(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_clear)
 {
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -60,10 +54,7 @@ static jerry_value_t zjs_glcd_clear(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj,
-                                             const jerry_value_t this,
-                                             const jerry_value_t argv[],
-                                             const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_set_cursor_pos)
 {
     // args: column, row
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER);
@@ -79,10 +70,7 @@ static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj,
-                                           const jerry_value_t this,
-                                           const jerry_value_t argv[],
-                                           const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_select_color)
 {
     // args: predefined color index
     ZJS_VALIDATE_ARGS(Z_NUMBER);
@@ -97,10 +85,7 @@ static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_set_color)
 {
     // args: red, green, blue
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER, Z_NUMBER);
@@ -117,10 +102,7 @@ static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj,
-                                           const jerry_value_t this,
-                                           const jerry_value_t argv[],
-                                           const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_set_function)
 {
     // args: predefined function number
     ZJS_VALIDATE_ARGS(Z_NUMBER);
@@ -135,10 +117,7 @@ static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_get_function(const jerry_value_t function_obj,
-                                           const jerry_value_t this,
-                                           const jerry_value_t argv[],
-                                           const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_get_function)
 {
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -149,10 +128,7 @@ static jerry_value_t zjs_glcd_get_function(const jerry_value_t function_obj,
     return jerry_create_number(value);
 }
 
-static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj,
-                                                const jerry_value_t this,
-                                                const jerry_value_t argv[],
-                                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_set_display_state)
 {
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -164,10 +140,7 @@ static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_glcd_get_display_state(const jerry_value_t function_obj,
-                                                const jerry_value_t this,
-                                                const jerry_value_t argv[],
-                                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_get_display_state)
 {
     if (!glcd) {
         return zjs_error("Grove LCD device not found");
@@ -178,10 +151,7 @@ static jerry_value_t zjs_glcd_get_display_state(const jerry_value_t function_obj
     return jerry_create_number(value);
 }
 
-static jerry_value_t zjs_glcd_init(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_init)
 {
     if (!glcd) {
         /* Initialize the Grove LCD */

--- a/src/zjs_grove_lcd_ipm.c
+++ b/src/zjs_grove_lcd_ipm.c
@@ -100,10 +100,7 @@ static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *
     }
 }
 
-static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_print)
 {
     // args: text
     ZJS_VALIDATE_ARGS(Z_STRING);
@@ -124,10 +121,7 @@ static jerry_value_t zjs_glcd_print(const jerry_value_t function_obj,
     return result;
 }
 
-static jerry_value_t zjs_glcd_clear(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_clear)
 {
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -136,10 +130,7 @@ static jerry_value_t zjs_glcd_clear(const jerry_value_t function_obj,
     return zjs_glcd_call_remote_function(&send);
 }
 
-static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj,
-                                             const jerry_value_t this,
-                                             const jerry_value_t argv[],
-                                             const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_set_cursor_pos)
 {
     // args: column, row
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER);
@@ -153,10 +144,7 @@ static jerry_value_t zjs_glcd_set_cursor_pos(const jerry_value_t function_obj,
     return zjs_glcd_call_remote_ignore(&send);
 }
 
-static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj,
-                                           const jerry_value_t this,
-                                           const jerry_value_t argv[],
-                                           const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_select_color)
 {
     // args: predefined color index
     ZJS_VALIDATE_ARGS(Z_NUMBER);
@@ -169,10 +157,7 @@ static jerry_value_t zjs_glcd_select_color(const jerry_value_t function_obj,
     return zjs_glcd_call_remote_ignore(&send);
 }
 
-static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_set_color)
 {
     // args: red, green, blue
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER, Z_NUMBER);
@@ -187,10 +172,7 @@ static jerry_value_t zjs_glcd_set_color(const jerry_value_t function_obj,
     return zjs_glcd_call_remote_ignore(&send);
 }
 
-static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj,
-                                           const jerry_value_t this,
-                                           const jerry_value_t argv[],
-                                           const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_set_function)
 {
     // args: predefined function number
     ZJS_VALIDATE_ARGS(Z_NUMBER);
@@ -203,10 +185,7 @@ static jerry_value_t zjs_glcd_set_function(const jerry_value_t function_obj,
     return zjs_glcd_call_remote_ignore(&send);
 }
 
-static jerry_value_t zjs_glcd_get_function(const jerry_value_t function_obj,
-                                           const jerry_value_t this,
-                                           const jerry_value_t argv[],
-                                           const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_get_function)
 {
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -216,10 +195,7 @@ static jerry_value_t zjs_glcd_get_function(const jerry_value_t function_obj,
     return zjs_glcd_call_remote_function(&send);
 }
 
-static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj,
-                                                const jerry_value_t this,
-                                                const jerry_value_t argv[],
-                                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_set_display_state)
 {
     // args: predefined numeric constants
     ZJS_VALIDATE_ARGS(Z_NUMBER);
@@ -232,10 +208,7 @@ static jerry_value_t zjs_glcd_set_display_state(const jerry_value_t function_obj
     return zjs_glcd_call_remote_ignore(&send);
 }
 
-static jerry_value_t zjs_glcd_get_display_state(const jerry_value_t function_obj,
-                                                const jerry_value_t this,
-                                                const jerry_value_t argv[],
-                                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_get_display_state)
 {
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
@@ -245,10 +218,7 @@ static jerry_value_t zjs_glcd_get_display_state(const jerry_value_t function_obj
     return zjs_glcd_call_remote_function(&send);
 }
 
-static jerry_value_t zjs_glcd_init(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_glcd_init)
 {
     // send IPM message to the ARC side
     zjs_ipm_message_t send;

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -83,10 +83,7 @@ static jerry_value_t zjs_i2c_read_base(const jerry_value_t this,
     return buf_obj;
 }
 
-static jerry_value_t zjs_i2c_read(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_i2c_read)
 {
     // requires: Requires two arguments and has an optional third.
     //           arg[0] - Address of the I2C device you wish to read from.
@@ -100,10 +97,7 @@ static jerry_value_t zjs_i2c_read(const jerry_value_t function_obj,
     return zjs_i2c_read_base(this, argv, argc, false);
 }
 
-static jerry_value_t zjs_i2c_burst_read(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_i2c_burst_read)
 {
     // requires: Requires two arguments and has an optional third.
     //           arg[0] - Address of the I2C device you wish to read from.
@@ -118,10 +112,7 @@ static jerry_value_t zjs_i2c_burst_read(const jerry_value_t function_obj,
     return zjs_i2c_read_base(this, argv, argc, true);
 }
 
-static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_i2c_write)
 {
     // requires: Requires two arguments and has an optional third.
     //           arg[0] - Address of the I2C device you wish to write to.
@@ -165,28 +156,19 @@ static jerry_value_t zjs_i2c_write(const jerry_value_t function_obj,
     return jerry_create_number(error_msg);
 }
 
-static jerry_value_t zjs_i2c_abort(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_i2c_abort)
 {
     // Not implemented yet
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_i2c_close(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_i2c_close)
 {
     // Not implemented yet
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_i2c_open(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_i2c_open)
 {
     // requires: Requires two arguments
     //           arg[0] - I2C bus number you want to open a connection to.

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -125,10 +125,7 @@ struct routine_map {
 static uint8_t num_routines = 0;
 struct routine_map svc_routine_map[NUM_SERVICE_ROUTINES];
 
-static jerry_value_t native_require_handler(const jerry_value_t function_obj,
-                                            const jerry_value_t this,
-                                            const jerry_value_t argv[],
-                                            const jerry_length_t argc)
+static ZJS_DECL_FUNC(native_require_handler)
 {
     // args: module name
     ZJS_VALIDATE_ARGS(Z_STRING);

--- a/src/zjs_performance.c
+++ b/src/zjs_performance.c
@@ -8,10 +8,7 @@
 #include <sys/time.h>
 #endif
 
-static jerry_value_t zjs_performance_now(const jerry_value_t function_obj,
-                                         const jerry_value_t this,
-                                         const jerry_value_t argv[],
-                                         const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_performance_now)
 {
     if (argc != 0)
         return zjs_error("performance.now: no args expected");

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -33,11 +33,7 @@ static void post_promise(void *h)
     }
 }
 
-static jerry_value_t promise_resolve(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc,
-                                     uint8_t fulfill)
+static ZJS_DECL_FUNC_ARGS(promise_resolve, uint8_t fulfill)
 {
     // args: callback
     ZJS_VALIDATE_ARGS(Z_FUNCTION);
@@ -60,20 +56,14 @@ static jerry_value_t promise_resolve(const jerry_value_t function_obj,
     return jerry_acquire_value(this);
 }
 
-static jerry_value_t promise_then(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(promise_then)
 {
-    return promise_resolve(function_obj, this, argv, argc, 1);
+    return ZJS_CHAIN_FUNC_ARGS(promise_resolve, 1);
 }
 
-static jerry_value_t promise_catch(const jerry_value_t function_obj,
-                                   const jerry_value_t this,
-                                   const jerry_value_t argv[],
-                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(promise_catch)
 {
-    return promise_resolve(function_obj, this, argv, argc, 0);
+    return ZJS_CHAIN_FUNC_ARGS(promise_resolve, 0);
 }
 
 void zjs_make_promise(jerry_value_t obj, zjs_post_promise_func post,

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -72,10 +72,7 @@ static void zjs_pwm_set_ms(jerry_value_t obj, double period, double pulseWidth)
                      (uint32_t)(pulseWidth * 1000));
 }
 
-static jerry_value_t zjs_pwm_pin_set_cycles(const jerry_value_t function_obj,
-                                            const jerry_value_t this,
-                                            const jerry_value_t argv[],
-                                            const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_pwm_pin_set_cycles)
 {
     // requires: this is a PWMPin object from zjs_pwm_open, takes two arguments:
     //             the period in hardware cycles, dependent on the underlying
@@ -106,10 +103,7 @@ static jerry_value_t zjs_pwm_pin_set_cycles(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_pwm_pin_set_ms(const jerry_value_t function_obj,
-                                        const jerry_value_t this,
-                                        const jerry_value_t argv[],
-                                        const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_pwm_pin_set_ms)
 {
     // requires: this is a PWMPin object from zjs_pwm_open, takes two arguments:
     //             the period in milliseconds (float), and the pulse width in
@@ -139,10 +133,7 @@ static jerry_value_t zjs_pwm_pin_set_ms(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_pwm_open(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_pwm_open)
 {
     // requires: arg 0 is an object with these members: channel (int), period in
     //             hardware cycles (defaults to 255), pulse width in hardware

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -469,10 +469,7 @@ static void zjs_sensor_onstop_c_callback(void *h, const void *argv)
     }
 }
 
-static jerry_value_t zjs_sensor_start(const jerry_value_t function_obj,
-                                      const jerry_value_t this,
-                                      const jerry_value_t argv[],
-                                      const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_sensor_start)
 {
     // requires: this is a Sensor object from takes no args
     //  effects: activates the sensor and start monitoring changes
@@ -491,10 +488,7 @@ static jerry_value_t zjs_sensor_start(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_sensor_stop(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_sensor_stop)
 {
     // requires: this is a Sensor object from takes no args
     //  effects: de-activates the sensor and stop monitoring changes
@@ -515,11 +509,7 @@ static jerry_value_t zjs_sensor_stop(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
-                                       const jerry_value_t this,
-                                       const jerry_value_t argv[],
-                                       const jerry_length_t argc,
-                                       enum sensor_channel channel)
+static ZJS_DECL_FUNC_ARGS(zjs_sensor_create, enum sensor_channel channel)
 {
     // args: [initialization object]
     char *expect = Z_OPTIONAL Z_OBJECT;
@@ -646,65 +636,37 @@ static jerry_value_t zjs_sensor_create(const jerry_value_t function_obj,
     return sensor_obj;
 }
 
-static jerry_value_t zjs_accel_create(const jerry_value_t function_obj,
-                                      const jerry_value_t this,
-                                      const jerry_value_t argv[],
-                                      const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_accel_create)
 {
     // requires: arg 0 is an object containing sensor options:
     //             frequency (double) - sampling frequency
     //             includeGravity (bool) - whether you want gravity included
     //  effects: Creates a Accelerometer object to the local sensor
-    return zjs_sensor_create(function_obj,
-                             this,
-                             argv,
-                             argc,
-                             SENSOR_CHAN_ACCEL_XYZ);
+    return ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create, SENSOR_CHAN_ACCEL_XYZ);
 }
 
-static jerry_value_t zjs_gyro_create(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_gyro_create)
 {
     // requires: arg 0 is an object containing sensor options:
     //             frequency (double) - sampling frequency
     //  effects: Creates a Gyroscope object to the local sensor
-    return zjs_sensor_create(function_obj,
-                             this,
-                             argv,
-                             argc,
-                             SENSOR_CHAN_GYRO_XYZ);
+    return ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create, SENSOR_CHAN_GYRO_XYZ);
 }
 
-static jerry_value_t zjs_light_create(const jerry_value_t function_obj,
-                                      const jerry_value_t this,
-                                      const jerry_value_t argv[],
-                                      const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_light_create)
 {
     // requires: arg 0 is an object containing sensor options:
     //             frequency (double) - sampling frequency
     //  effects: Creates a AmbientLightSensor object to the local sensor
-    return zjs_sensor_create(function_obj,
-                             this,
-                             argv,
-                             argc,
-                             SENSOR_CHAN_LIGHT);
+    return ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create, SENSOR_CHAN_LIGHT);
 }
 
-static jerry_value_t zjs_temp_create(const jerry_value_t function_obj,
-                                     const jerry_value_t this,
-                                     const jerry_value_t argv[],
-                                     const jerry_length_t argc)
+static ZJS_DECL_FUNC(zjs_temp_create)
 {
     // requires: arg 0 is an object containing sensor options:
     //             frequency (double) - sampling frequency
     //  effects: Creates a TemperatureSensor object to the local sensor
-    return zjs_sensor_create(function_obj,
-                             this,
-                             argv,
-                             argc,
-                             SENSOR_CHAN_TEMP);
+    return ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create, SENSOR_CHAN_TEMP);
 }
 
 void zjs_sensor_init()

--- a/src/zjs_test_promise.c
+++ b/src/zjs_test_promise.c
@@ -24,10 +24,7 @@ static void post_promise(void *handle)
     }
 }
 
-static jerry_value_t create_promise(const jerry_value_t function_obj,
-                                    const jerry_value_t this,
-                                    const jerry_value_t argv[],
-                                    const jerry_length_t argc)
+static ZJS_DECL_FUNC(create_promise)
 {
     dummy_handle_t *handle = zjs_malloc(sizeof(dummy_handle_t));
     handle->value = TEST_VAL;
@@ -40,10 +37,7 @@ static jerry_value_t create_promise(const jerry_value_t function_obj,
     return promise;
 }
 
-static jerry_value_t test_fulfill(const jerry_value_t function_obj,
-                                  const jerry_value_t this,
-                                  const jerry_value_t argv[],
-                                  const jerry_length_t argc)
+static ZJS_DECL_FUNC(test_fulfill)
 {
     // args: promise object
     ZJS_VALIDATE_ARGS(Z_OBJECT);
@@ -52,10 +46,7 @@ static jerry_value_t test_fulfill(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t test_reject(const jerry_value_t function_obj,
-                                 const jerry_value_t this,
-                                 const jerry_value_t argv[],
-                                 const jerry_length_t argc)
+static ZJS_DECL_FUNC(test_reject)
 {
     // args: promise object
     ZJS_VALIDATE_ARGS(Z_OBJECT);

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -127,11 +127,7 @@ static bool delete_timer(int32_t id)
     return false;
 }
 
-static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
-                                      const jerry_value_t this,
-                                      const jerry_length_t argc,
-                                      const jerry_value_t argv[],
-                                      bool repeat)
+static ZJS_DECL_FUNC_ARGS(add_timer_helper, bool repeat)
 {
     // args: callback, time in milliseconds[, pass-through args]
     ZJS_VALIDATE_ARGS(Z_FUNCTION, Z_NUMBER);
@@ -150,36 +146,19 @@ static jerry_value_t add_timer_helper(const jerry_value_t function_obj,
 }
 
 // native setInterval handler
-static jerry_value_t native_set_interval_handler(const jerry_value_t function_obj,
-                                                 const jerry_value_t this,
-                                                 const jerry_value_t argv[],
-                                                 const jerry_length_t argc)
+static ZJS_DECL_FUNC(native_set_interval_handler)
 {
-    return add_timer_helper(function_obj,
-                            this,
-                            argc,
-                            argv,
-                            true);
+    return ZJS_CHAIN_FUNC_ARGS(add_timer_helper, true);
 }
 
 // native setInterval handler
-static jerry_value_t native_set_timeout_handler(const jerry_value_t function_obj,
-                                                const jerry_value_t this,
-                                                const jerry_value_t argv[],
-                                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(native_set_timeout_handler)
 {
-    return add_timer_helper(function_obj,
-                            this,
-                            argc,
-                            argv,
-                            false);
+    return ZJS_CHAIN_FUNC_ARGS(add_timer_helper, false);
 }
 
 // native clearInterval handler
-static jerry_value_t native_clear_interval_handler(const jerry_value_t function_obj,
-                                                   const jerry_value_t this,
-                                                   const jerry_value_t argv[],
-                                                   const jerry_length_t argc)
+static ZJS_DECL_FUNC(native_clear_interval_handler)
 {
     // args: timer object
     // FIXME: timers should be ints, not objects!

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -154,10 +154,7 @@ static int write_data(struct device *dev, const char *buf, int len)
     return bytes;
 }
 
-static jerry_value_t uart_write(const jerry_value_t function_obj,
-                                const jerry_value_t this,
-                                const jerry_value_t argv[],
-                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(uart_write)
 {
     // args: buffer
     ZJS_VALIDATE_ARGS(Z_OBJECT);
@@ -183,10 +180,7 @@ static jerry_value_t uart_write(const jerry_value_t function_obj,
     return promise;
 }
 
-static jerry_value_t uart_set_read_range(const jerry_value_t function_obj,
-                                         const jerry_value_t this,
-                                         const jerry_value_t argv[],
-                                         const jerry_length_t argc)
+static ZJS_DECL_FUNC(uart_set_read_range)
 {
     // args: min, max
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER);
@@ -215,10 +209,7 @@ static jerry_value_t uart_set_read_range(const jerry_value_t function_obj,
     return ZJS_UNDEFINED;
 }
 
-static jerry_value_t uart_init(const jerry_value_t function_obj,
-                               const jerry_value_t this,
-                               const jerry_value_t argv[],
-                               const jerry_length_t argc)
+static ZJS_DECL_FUNC(uart_init)
 {
     // args: initialization object
     ZJS_VALIDATE_ARGS(Z_OBJECT);

--- a/src/zjs_unit_tests.c
+++ b/src/zjs_unit_tests.c
@@ -89,10 +89,7 @@ static void test_compress_32()
 
 // Test test_validate_args function
 
-static jerry_value_t dummy_func(const jerry_value_t function_obj,
-                                const jerry_value_t this,
-                                const jerry_value_t argv[],
-                                const jerry_length_t argc)
+static ZJS_DECL_FUNC(dummy_func)
 {
     return ZJS_UNDEFINED;
 }

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -115,6 +115,59 @@ uint32_t zjs_uncompress_16_to_32(uint16_t num);
 void zjs_print_error_message(jerry_value_t error);
 
 /**
+ * Macro to declare a standard JerryScript external function in a shorter form
+ *
+ * @param name  The name of the function to declare
+ *
+ * Note: This hides the fact that you have function_obj, this, argv, and argc
+ *   variables available in the function.
+ *
+ * Example:
+ * static ZJS_DECL_FUNC(zjs_my_api)
+ * {
+ *     // do something useful; often using those hidden args
+ *     return ZJS_UNDEFINED;
+ * };
+ */
+#define ZJS_DECL_FUNC(name)                               \
+    jerry_value_t name(const jerry_value_t function_obj,  \
+                       const jerry_value_t this,          \
+                       const jerry_value_t argv[],        \
+                       const jerry_length_t argc)
+
+/**
+ * Macro to declare a function that takes the JerryScript args plus more
+ *
+ * @param name  The name of the function to declare
+ * @param ...   List of other arguments to declare after the standard ones
+ *
+ * Example:
+ * static ZJS_DECL_FUNC_ARGS(zjs_my_api_with_args, int mode)
+ * {
+ *     // do something useful, using mode and often the hidden args
+ *     return ZJS_UNDEFINED;
+ * };
+ */
+#define ZJS_DECL_FUNC_ARGS(name, ...)                     \
+    jerry_value_t name(const jerry_value_t function_obj,  \
+                       const jerry_value_t this,          \
+                       const jerry_value_t argv[],        \
+                       const jerry_length_t argc,         \
+                       __VA_ARGS__)
+
+/**
+ * Macro to call a function declared with ZJS_DECL_FUNC_ARGS from another API
+ *
+ * @param name  The name of the function to call
+ * @param ...   List of other arguments to pass
+ *
+ * Example:
+ * jerry_value_t rval = ZJS_CHAIN_FUNC_ARGS(zjs_my_api_with_args, 1);
+ */
+#define ZJS_CHAIN_FUNC_ARGS(name, ...)                 \
+    name(function_obj, this, argv, argc, __VA_ARGS__)
+
+/**
  * Release a jerry_value_t passed by reference
  */
 void zjs_free_value(const jerry_value_t *value);


### PR DESCRIPTION
These simplify the boilerplate of declaring JavaScript to C binding
functions. The one downside is this hides the variable names that
are declared, so you're expected to know what those are.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>