### PR TITLE
[ashell] Boot JavaScript file specified by boot.cfg

### DIFF
--- a/docs/ashell.md
+++ b/docs/ashell.md
@@ -86,6 +86,7 @@ Commands list:
      run [FILE] Runs the JavaScript program in the file
    parse [FILE] Check if the JS syntax is correct
     stop Stops current JavaScript execution
+ bootcfg [FILE] Set the file that should run at boot
       ls [FILE] List directory contents or file stat
      cat [FILE] Print the file contents of a file
       du [FILE] Estimate file space usage

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -97,4 +97,5 @@ ifeq ($(ASHELL), y)
 $(info Insecure Mode (development))
 export JERRY_INCLUDE = $(JERRY_BASE)/jerry-core/
 obj-y += ashell/
+ccflags-y += -DZJS_ASHELL
 endif

--- a/src/ashell/Makefile
+++ b/src/ashell/Makefile
@@ -30,4 +30,4 @@ obj-y += ../../deps/ihex/kk_ihex_read.o
 # Select extended ANSI C/POSIX function set in recent Newlib versions
 ccflags-y += -D_XOPEN_SOURCE=700
 
-ccflags-y += -Wall -Werror
+ccflags-y += -DZJS_ASHELL -Wall -Werror

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -522,8 +522,7 @@ void acm()
     k_fifo_init(&avail_queue);
 
     // Wait until the main loop is running before starting the javascript
-    if (k_sem_take(&mainloop_sem, K_FOREVER) == 0)
-    {
+    if (k_sem_take(&mainloop_sem, K_FOREVER) == 0) {
         ashell_run_boot_cfg();
     }
     else {

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -538,7 +538,7 @@ void acm()
             break;
         // Sleep is needed to allow the javascript in boot.cfg to run
         // while we wait for the connection.
-        k_sleep(2000);
+        k_sleep(1000);
     }
 
     /* 1000 msec = 1 sec */

--- a/src/ashell/file-utils.c
+++ b/src/ashell/file-utils.c
@@ -79,7 +79,7 @@ int fs_close_alloc(fs_file_t *fp)
     return res;
 }
 
-bool fs_valid_filename_size(char *filename)
+bool fs_valid_filename(char *filename)
 {
     if (filename == NULL) {
         printf("No filename given\n");
@@ -92,33 +92,24 @@ bool fs_valid_filename_size(char *filename)
     ssize_t extlen;
     ssize_t size = strlen(filename);
 
-    if (fs_exist(filename)) {
-        ptr1 = strchr(ptr1, '.');
+    ptr1 = strchr(ptr1, '.');
 
+    if (ptr1 != NULL) {
+        // Check there aren't multiple periods
+        ptr2 = strchr(ptr1 + 1, '.');
 
-        if (ptr1 != NULL) {
-            // Check there aren't multiple periods
-            ptr2 = strchr(ptr1 + 1, '.');
-
-            if (ptr2 != NULL) {
-                printf("Invalid file extention format\n");
-                return false;
-            }
-
-            namelen = ptr1 - filename;
-            extlen = size - namelen - 1;
+        if (ptr2 != NULL) {
+            printf("Invalid file extension format\n");
+            return false;
         }
-        else
-        {
-            // Filename has no extension
-            namelen = strlen(filename);
-            extlen = 0;
-        }
+
+        namelen = ptr1 - filename;
+        extlen = size - namelen - 1;
     }
     else {
-        // Don't let the cfg be set to a file that doesn't exist
-        printf("File passed to cfg doesn't exist\n");
-        return false;
+        // Filename has no extension
+        namelen = strlen(filename);
+        extlen = 0;
     }
 
     if (namelen == 0) {
@@ -131,7 +122,7 @@ bool fs_valid_filename_size(char *filename)
     }
 
     if (extlen > 3) {
-        printf("File extention is longer than 3 characters\n");
+        printf("File extension is longer than 3 characters\n");
         return false;
     }
 

--- a/src/ashell/file-utils.c
+++ b/src/ashell/file-utils.c
@@ -108,7 +108,7 @@ bool fs_valid_filename(char *filename)
     }
     else {
         // Filename has no extension
-        namelen = strlen(filename);
+        namelen = size;
         extlen = 0;
     }
 
@@ -116,15 +116,9 @@ bool fs_valid_filename(char *filename)
         printf("Filename length is zero\n");
         return false;
     }
-    else if (namelen > 8) {
-        printf("Filename is longer than 8 characters\n");
+    else if (namelen > 8 || extlen > 3) {
+        printf("Filename must be 8.3 format\n");
         return false;
     }
-
-    if (extlen > 3) {
-        printf("File extension is longer than 3 characters\n");
-        return false;
-    }
-
     return true;
 }

--- a/src/ashell/file-utils.c
+++ b/src/ashell/file-utils.c
@@ -78,3 +78,62 @@ int fs_close_alloc(fs_file_t *fp)
     zjs_free(fp);
     return res;
 }
+
+bool fs_valid_filename_size(char *filename)
+{
+    if (filename == NULL) {
+        printf("No filename given\n");
+        return false;
+    }
+
+    char *ptr1 = filename;
+    char *ptr2 = NULL;
+    ssize_t namelen;
+    ssize_t extlen;
+    ssize_t size = strlen(filename);
+
+    if (fs_exist(filename)) {
+        ptr1 = strchr(ptr1, '.');
+
+
+        if (ptr1 != NULL) {
+            // Check there aren't multiple periods
+            ptr2 = strchr(ptr1 + 1, '.');
+
+            if (ptr2 != NULL) {
+                printf("Invalid file extention format\n");
+                return false;
+            }
+
+            namelen = ptr1 - filename;
+            extlen = size - namelen - 1;
+        }
+        else
+        {
+            // Filename has no extension
+            namelen = strlen(filename);
+            extlen = 0;
+        }
+    }
+    else {
+        // Don't let the cfg be set to a file that doesn't exist
+        printf("File passed to cfg doesn't exist\n");
+        return false;
+    }
+
+    if (namelen == 0) {
+        printf("Filename length is zero\n");
+        return false;
+    }
+    else if (namelen > 8) {
+        printf("Filename is longer than 8 characters\n");
+        return false;
+    }
+
+    if (extlen > 3) {
+        printf("File extention is longer than 3 characters\n");
+        return false;
+    }
+
+    return true;
+}

--- a/src/ashell/file-utils.h
+++ b/src/ashell/file-utils.h
@@ -14,5 +14,5 @@ fs_file_t *fs_open_alloc(const char *filename, const char *mode);
 int fs_close_alloc(fs_file_t *fp);
 int fs_exist(const char *path);
 ssize_t fs_size(fs_file_t *file);
-bool fs_valid_filename_size(char *filename);
+bool fs_valid_filename(char *filename);
 #endif // __file_wrapper_h__

--- a/src/ashell/file-utils.h
+++ b/src/ashell/file-utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __file_wrapper_h__
 #define __file_wrapper_h__
@@ -14,5 +14,5 @@ fs_file_t *fs_open_alloc(const char *filename, const char *mode);
 int fs_close_alloc(fs_file_t *fp);
 int fs_exist(const char *path);
 ssize_t fs_size(fs_file_t *file);
-
+bool fs_valid_filename_size(char *filename);
 #endif // __file_wrapper_h__

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -611,13 +611,13 @@ int32_t ashell_set_bootcfg(char *buf)
 static const struct ashell_cmd commands[] =
 {
     ASHELL_COMMAND("help",  "This help", ashell_help),
-    ASHELL_COMMAND("eval",  "Evaluate JavaScript in real time"                ,ashell_js_immediate_mode),
+    ASHELL_COMMAND("eval",  "Evaluate JavaScript in real time"               ,ashell_js_immediate_mode),
     ASHELL_COMMAND("clear", "Clear the terminal screen"                      ,ashell_clear),
     ASHELL_COMMAND("load",  "[FILE] Saves the input text into a file"        ,ashell_read_data),
     ASHELL_COMMAND("run",   "[FILE] Runs the JavaScript program in the file" ,ashell_run_javascript),
     ASHELL_COMMAND("parse", "[FILE] Check if the JS syntax is correct"       ,ashell_parse_javascript),
     ASHELL_COMMAND("stop",  "Stops current JavaScript execution"             ,ashell_stop_javascript),
-    ASHELL_COMMAND("cfg",   "[FILE] Set the file that should run at boot"    ,ashell_set_bootcfg),
+    ASHELL_COMMAND("bootcfg", "[FILE] Set the file that should run at boot"  ,ashell_set_bootcfg),
 
     ASHELL_COMMAND("ls",    "[FILE] List directory contents or file stat"    ,ashell_list_dir),
     ASHELL_COMMAND("cat",   "[FILE] Print the file contents of a file"       ,ashell_print_file),

--- a/src/ashell/shell-state.h
+++ b/src/ashell/shell-state.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __SHELL__STATE__H__
 #define __SHELL__STATE__H__
@@ -55,6 +55,11 @@ struct shell_state_config
  */
 int32_t ashell_main_state(char *buf, uint32_t len);
 
-int32_t ashell_help(char *buf);
+/**
+ * @brief Gets called when main loop starts and runs the JavaScript file found in
+ *  boot.cfg.  If no file exists, it simply exits and ashell starts normally.
+ */
+void ashell_run_boot_cfg();
 
+int32_t ashell_help(char *buf);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -146,6 +146,8 @@ int main(int argc, char *argv[])
     // the beginning of the program
     ZJS_PRINT("\n");
 
+    k_sem_init(&mainloop_sem, 0, 1);
+
 #ifdef ZJS_POOL_CONFIG
     zjs_init_mem_pools();
 #ifdef DUMP_MEM_STATS
@@ -249,6 +251,9 @@ int main(int argc, char *argv[])
 #ifdef ZJS_LINUX_BUILD
     uint8_t last_serviced = 1;
 #endif
+
+    // Inform other thread that the main loop has started.
+    k_sem_give(&mainloop_sem);
 
     while (1) {
         uint8_t serviced = 0;

--- a/src/main.c
+++ b/src/main.c
@@ -146,8 +146,9 @@ int main(int argc, char *argv[])
     // the beginning of the program
     ZJS_PRINT("\n");
 
+#ifdef ZJS_ASHELL
     k_sem_init(&mainloop_sem, 0, 1);
-
+#endif
 #ifdef ZJS_POOL_CONFIG
     zjs_init_mem_pools();
 #ifdef DUMP_MEM_STATS
@@ -251,10 +252,10 @@ int main(int argc, char *argv[])
 #ifdef ZJS_LINUX_BUILD
     uint8_t last_serviced = 1;
 #endif
-
+#ifdef ZJS_ASHELL
     // Inform other thread that the main loop has started.
     k_sem_give(&mainloop_sem);
-
+#endif
     while (1) {
         uint8_t serviced = 0;
 

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -11,7 +11,6 @@
 #include "zjs_error.h"
 
 #ifdef ZJS_ASHELL
-#include <kernel.h>
 struct k_sem mainloop_sem;
 #endif
 

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -6,7 +6,7 @@
 // The util code is only for the X86 side
 
 #include <stdlib.h>
-
+#include <kernel.h>
 #include "jerryscript.h"
 #include "zjs_common.h"
 #include "zjs_error.h"

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -11,6 +11,8 @@
 #include "zjs_common.h"
 #include "zjs_error.h"
 
+struct k_sem mainloop_sem;
+
 #define ZJS_UNDEFINED jerry_create_undefined()
 
 /**

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -6,12 +6,14 @@
 // The util code is only for the X86 side
 
 #include <stdlib.h>
-#include <kernel.h>
 #include "jerryscript.h"
 #include "zjs_common.h"
 #include "zjs_error.h"
 
+#ifdef ZJS_ASHELL
+#include <kernel.h>
 struct k_sem mainloop_sem;
+#endif
 
 #define ZJS_UNDEFINED jerry_create_undefined()
 


### PR DESCRIPTION
Now ashell will run whatever JavaScript file is specified
in boot.cfg. Users can set which file to run on boot using
'cfg' in the ashell menu. ashell operates as usual even if
it starts up a program.

Signed-off-by: Brian Jones <brian.j.jones@intel.com>