### PR TITLE
[trlite] Run more tests on Linux to catch buffer issues, etc.

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -390,7 +390,7 @@ if [ "$RUN" == "all" -o "$RUN" == "3" ]; then
 
     # linux runtime tests
     # TODO: Add buffer, it fails in Linux ATM
-    for i in error event promise; do
+    for i in buffer buffer-rw eval error event promise timers; do
         ./outdir/linux/release/jslinux tests/test-$i.js > /tmp/output
         cat /tmp/output
         try_command "t-$i" test ! $(grep "FAIL" /tmp/output)


### PR DESCRIPTION
Running these buffer tests would have prevented two buffer issues from
slipping past us last week I think.

Also added several other tests that work on Linux.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>