### PR TITLE
[build] ROM=144 default makes more sense to minimize flash times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OS := $(shell uname)
 
 BOARD ?= arduino_101
 RAM ?= 55
-ROM ?= 256
+ROM ?= 144
 
 # Dump memory information: on = print allocs, full = print allocs + dump pools
 TRACE ?= off


### PR DESCRIPTION
If you don't like this, you can export ROM=256 or whatever you like in
your shell. But whenver you test small samples that can fit in the
default 144 it makes more sense to do that because it will flash
faster (and also wear out the flash on the device less quickly).

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>