### PR TITLE
[ble] Support multiple client connections (only up to 4 due to memory constraints)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,12 @@ analyze: $(JS)
 	else \
 		sed -i '/This is a generated file/r./zjs.conf.tmp' src/Makefile; \
 	fi
+	@# Add bluetooth debug configs if BLE is enabled
+	@if grep BUILD_MODULE_BLE src/Makefile; then \
+		if [ "$(VARIANT)" = "debug" ]; then \
+			echo "CONFIG_BLUETOOTH_DEBUG_LOG=y" >> prj.conf.tmp; \
+		fi \
+	fi
 	@# Add the include for the OCF Makefile only if the script is using OCF
 	@if grep BUILD_MODULE_OCF src/Makefile; then \
 		echo "CONFIG_BLUETOOTH_DEVICE_NAME=\"$(DEVICE_NAME)\"" >> prj.conf.tmp; \

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -291,6 +291,7 @@ if check_for_require ble || check_config_file ZJS_BLE; then
     echo "CONFIG_BLUETOOTH_SMP=y" >> $PRJFILE
     echo "CONFIG_BLUETOOTH_PERIPHERAL=y" >> $PRJFILE
     echo "CONFIG_BLUETOOTH_GATT_DYNAMIC_DB=y" >> $PRJFILE
+    echo "CONFIG_BLUETOOTH_MAX_CONN=4" >> $PRJFILE
     MODULES+=" -DBUILD_MODULE_EVENTS"
     echo "export ZJS_EVENTS=y" >> $CONFFILE
     echo "export ZJS_BLE=y" >> $CONFFILE

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -514,21 +514,21 @@ static void zjs_ble_blvl_ccc_cfg_changed(const struct bt_gatt_attr *attr, uint16
 
 static void zjs_ble_connected_c_callback(void *handle, const void *argv)
 {
-    ble_handle_t * h = (ble_handle_t *)handle;
+    ble_handle_t *h = (ble_handle_t *)handle;
     if (!h) {
         ERR_PRINT("handle not found\n");
         return;
     }
 
-    char *addr = (char *)argv;
-    ZVAL arg = jerry_create_string((jerry_char_t *)addr);
+    const char *addr = (const char *)argv;
+    ZVAL arg = jerry_create_string((const jerry_char_t *)addr);
     zjs_trigger_event(h->ble_obj, "accept", &arg, 1, NULL, NULL);
     DBG_PRINT("BLE event: connected, addr %s\n", addr);
 }
 
 static void zjs_ble_disconnected_c_callback(void *handle, const void *argv)
 {
-    ble_handle_t * h = (ble_handle_t *)handle;
+    ble_handle_t *h = (ble_handle_t *)handle;
     if (!h) {
         ERR_PRINT("handle not found\n");
         return;
@@ -549,7 +549,7 @@ static void zjs_ble_connected(struct bt_conn *conn, uint8_t err)
         DBG_PRINT("new connection\n");
         ble_connection_t *new_conn = zjs_ble_new_connection(&ble_handle->connections, conn);
         if (!new_conn) {
-            ERR_PRINT("failed to create new cilent connection\n");
+            ERR_PRINT("failed to create new client connection\n");
             return;
         }
 
@@ -599,7 +599,7 @@ static struct bt_conn_auth_cb zjs_ble_auth_cb_display = {
 
 static void zjs_ble_ready_c_callback(void *handle, const void *argv)
 {
-    ble_handle_t * h = (ble_handle_t *)handle;
+    ble_handle_t *h = (ble_handle_t *)handle;
     if (!h) {
         ERR_PRINT("handle not found\n");
         return;

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -427,12 +427,16 @@ static ZJS_DECL_FUNC(zjs_ble_update_value_callback_function)
         ble_characteristic_t *chrc = (ble_characteristic_t *)ptr;
         if (chrc->chrc_attr) {
             zjs_buffer_t *buf = zjs_buffer_find(argv[0]);
-            // loop through all the connections
-            ble_connection_t *conn = ble_handle->connections;
-            while (conn) {
-                bt_gatt_notify(conn->bt_conn, chrc->chrc_attr,
-                               buf->buffer, buf->bufsize);
-                conn = conn->next;
+            if (buf) {
+                // loop through all the connections
+                ble_connection_t *conn = ble_handle->connections;
+                while (conn) {
+                    bt_gatt_notify(conn->bt_conn, chrc->chrc_attr,
+                                   buf->buffer, buf->bufsize);
+                    conn = conn->next;
+                }
+            } else {
+                return zjs_error("buffer not found");
             }
         }
     }


### PR DESCRIPTION
Refactored BLE module to handle multiple connections,
Zephyr default to only 1 client connection, so added a config
to overwrite it to support up to 4 clients.

Also enabled CONFIG_BLUETOOTH_DEBUG_LOG in debug mode to get more
more useful output.

Fixes #984, #334

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>