### PR TITLE
[ashell] Removing sensor from ashell default configuration

### DIFF
--- a/fragments/zjs.conf.dev
+++ b/fragments/zjs.conf.dev
@@ -12,7 +12,8 @@ ZJS_I2C=y
 #ZJS_OCF=y
 ZJS_PERFORMANCE=y
 ZJS_PWM=y
-ZJS_SENSOR=y
+# Note: enabling sensor will disable GPIO input on all pins.
+#ZJS_SENSOR=y
 ZJS_TIMERS=y
 ZJS_UART=y
 ZJS_FS=y


### PR DESCRIPTION
If sensor is enabled, it will cause GPIO input to be disabled for
all pins.  Because GPIO is used more often than sensor, sensor is
being taken out of the default ashell configuration.  You can
enable sensor again simply by uncommenting it in the file.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>