### PR TITLE
[headers] Warn if libc6-dev-i386 package not installed

### DIFF
--- a/scripts/checkheaders
+++ b/scripts/checkheaders
@@ -63,6 +63,15 @@ fi
 echo RESULTS: $PASSCOUNT/$TOTAL passed
 
 if [ $PASSCOUNT -ne $TOTAL ]; then
+    # on Ubuntu ensure libc6-dev-i386
+    if which dpkg > /dev/null; then
+        if ! dpkg -l lib6-dev-i386 > /dev/null 2>&1; then
+            echo
+            echo WARNING: package libc6-dev-i386 not found
+            echo You may need to run: sudo apt install libc6-dev-i386
+        fi
+    fi
+
     exit 1
 fi
 


### PR DESCRIPTION
This package prevents some non-helpful errors from appearing like:
   fatal error: sys/cdefs/h: no such file

Which might be hard to figure out, otherwise.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>