### PR TITLE
[ashell] Fix for calling eval after starting a new application

### DIFF
--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -326,8 +326,17 @@ void restore_zjs_api() {
 #ifdef BUILD_MODULE_SENSOR
     zjs_sensor_init();
 #endif
+    jerry_value_t global_obj = jerry_get_global_object();
+    jerry_value_t modules_obj = jerry_create_object();
+    jerry_value_t exports_obj = jerry_create_object();
+    zjs_set_property(modules_obj, "exports", exports_obj);
+    zjs_set_property(global_obj, "module", modules_obj);
     zjs_init_callbacks();
     zjs_modules_init();
+    zjs_error_init();
+    jerry_release_value(global_obj);
+    jerry_release_value(modules_obj);
+    jerry_release_value(exports_obj);
 }
 
 void javascript_stop()

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -148,9 +148,9 @@ static ZJS_DECL_FUNC(native_require_handler)
         if (!strcmp(mod->name, module)) {
             // We only want one instance of each module at a time
             if (mod->instance == 0) {
-                mod->instance = jerry_acquire_value(mod->init());
+                mod->instance = mod->init();
             }
-            return mod->instance;
+            return jerry_acquire_value(mod->instance);
         }
     }
     DBG_PRINT("Native module not found, searching for JavaScript module %s\n",


### PR DESCRIPTION
Currently jerry_eval will fail when ashell runs it after cleaning
the jerry engine.  This fixes it.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>