### PR TITLE
[gpio] Remove BUILD_MODULE_GPIO ifdef around zjs_gpio.c file

### DIFF
--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -36,7 +36,7 @@ fi
 
 echo "# Modules found in $SCRIPT:" > $PRJFILE
 echo "# Modules found in $SCRIPT:" > $ARCPRJFILE
-tmpstr="# ZJS flags set by analyze.js"
+tmpstr="# ZJS flags set by analyze.sh"
 
 if [ -n "$CONFIG" ]; then
     tmpstr+=" and $CONFIG"

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -1,6 +1,5 @@
 // Copyright (c) 2016-2017, Intel Corporation.
 
-#ifdef BUILD_MODULE_GPIO
 // Zephyr includes
 #include <zephyr.h>
 #include <gpio.h>
@@ -455,5 +454,3 @@ void zjs_gpio_cleanup()
 {
     jerry_release_value(zjs_gpio_pin_prototype);
 }
-
-#endif // BUILD_MODULE_GPIO

--- a/zjs.conf
+++ b/zjs.conf
@@ -1,4 +1,7 @@
-# To force inclusion of a module remove the # in front of it
+# zjs.conf - force inclusion of modules into your build
+
+# To force inclusion of a module, remove the # in front of it.
+# Then pass CONFIG=zjs.conf to your make command.
 
 #ZJS_AIO=y
 #ZJS_ARDUINO101_PINS=y


### PR DESCRIPTION
I'm pretty sure this is no longer needed because building the module
is controlled by ZJS_GPIO but want to send out this canary before
changing all the modules. BUILD_MODULE_GPIO is still used in modules.c
and *pins.c to control a few sections though.

Also, fix a string in analyze and add a comment to the top of zjs.conf
describing how it is used, which I found along the way.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>