### PR TITLE
[ashell] Fixing using native modules with long names in ashell

### DIFF
--- a/src/ashell/file-utils.c
+++ b/src/ashell/file-utils.c
@@ -49,8 +49,7 @@ fs_file_t *fs_open_alloc(const char *filename, const char *mode)
     }
     else {
         /* Return NULL if trying to read from a nonexistent file */
-        if (!fs_exist(filename))
-        {
+        if (!fs_exist(filename)) {
             printf("[ERR] %s not found\n", filename);
             return NULL;
         }

--- a/src/ashell/file-utils.c
+++ b/src/ashell/file-utils.c
@@ -50,7 +50,10 @@ fs_file_t *fs_open_alloc(const char *filename, const char *mode)
     else {
         /* Return NULL if trying to read from a nonexistent file */
         if (!fs_exist(filename))
+        {
+            printf("[ERR] %s not found\n", filename);
             return NULL;
+        }
     }
 
     fs_file_t *file = (fs_file_t *)zjs_malloc(sizeof(fs_file_t));

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -202,7 +202,6 @@ static bool add_requires(requires_list_t **list, char *filebuf)
     char *ptr2 = NULL;
     char *filestr = NULL;
     char *ext_check = NULL;
-    bool valid = true;
 
     while (ptr1 != NULL) {
         // Find next instance of "require"
@@ -212,7 +211,7 @@ static bool add_requires(requires_list_t **list, char *filebuf)
             ptr1 = strchr(ptr1, '"') + 1;
             ptr2 = strchr(ptr1, '"');
             size_t len = ptr2 - ptr1;
-            if (len < (ssize_t)MAX_MODULE_LEN) {
+            if (len < (ssize_t)MAX_MODULE_STRLEN) {
                 // Allocate the memory for the string
                 filestr = (char *)zjs_malloc(len + 1);
                 strncpy(filestr, ptr1, len);
@@ -226,8 +225,8 @@ static bool add_requires(requires_list_t **list, char *filebuf)
                         add_to_list(list, filestr);
                     }
                     else {
-                        valid = false;
-                        break;
+                        zjs_free(filestr);
+                        return false;
                     }
                 }
                 zjs_free(filestr);
@@ -237,14 +236,12 @@ static bool add_requires(requires_list_t **list, char *filebuf)
                 filestr = (char *)zjs_malloc(10);
                 strncpy(filestr, ptr1, 10);
                 comms_printf("[ERR] requires(\"%s...\") string is too long\n", filestr);
-                valid = false;
-                break;
+                zjs_free(filestr);
+                return false;
             }
         }
     }
-    if (filestr != NULL)
-        zjs_free(filestr);
-    return valid;
+    return true;
 }
 
 static bool load_require_modules(char *file_buffer)

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -211,7 +211,7 @@ static bool add_requires(requires_list_t **list, char *filebuf)
             ptr1 = strchr(ptr1, '"') + 1;
             ptr2 = strchr(ptr1, '"');
             size_t len = ptr2 - ptr1;
-            if (len < (ssize_t)MAX_MODULE_STRLEN) {
+            if (len < (ssize_t)MAX_MODULE_STR_LEN) {
                 // Allocate the memory for the string
                 filestr = (char *)zjs_malloc(len + 1);
                 strncpy(filestr, ptr1, len);

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -134,7 +134,6 @@ static ZJS_DECL_FUNC(native_require_handler)
     // args: module name
     ZJS_VALIDATE_ARGS(Z_STRING);
 
-    const int MAX_MODULE_LEN = 32;
     jerry_size_t size = MAX_MODULE_LEN;
     char module[size];
     zjs_copy_jstring(argv[0], module, &size);

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -134,7 +134,7 @@ static ZJS_DECL_FUNC(native_require_handler)
     // args: module name
     ZJS_VALIDATE_ARGS(Z_STRING);
 
-    jerry_size_t size = MAX_MODULE_LEN;
+    jerry_size_t size = MAX_MODULE_STRLEN;
     char module[size];
     zjs_copy_jstring(argv[0], module, &size);
     if (!size) {

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -134,7 +134,7 @@ static ZJS_DECL_FUNC(native_require_handler)
     // args: module name
     ZJS_VALIDATE_ARGS(Z_STRING);
 
-    jerry_size_t size = MAX_MODULE_STRLEN;
+    jerry_size_t size = MAX_MODULE_STR_LEN;
     char module[size];
     zjs_copy_jstring(argv[0], module, &size);
     if (!size) {

--- a/src/zjs_modules.h
+++ b/src/zjs_modules.h
@@ -10,6 +10,7 @@
 #include "jerryscript.h"
 
 #define NUM_SERVICE_ROUTINES 3
+#define MAX_MODULE_LEN 32
 
 /**
  * Service routine function type

--- a/src/zjs_modules.h
+++ b/src/zjs_modules.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_modules_h__
 #define __zjs_modules_h__
@@ -10,7 +10,7 @@
 #include "jerryscript.h"
 
 #define NUM_SERVICE_ROUTINES 3
-#define MAX_MODULE_LEN 32
+#define MAX_MODULE_STRLEN 32
 
 /**
  * Service routine function type

--- a/src/zjs_modules.h
+++ b/src/zjs_modules.h
@@ -10,7 +10,7 @@
 #include "jerryscript.h"
 
 #define NUM_SERVICE_ROUTINES 3
-#define MAX_MODULE_STRLEN 32
+#define MAX_MODULE_STR_LEN 32
 
 /**
  * Service routine function type


### PR DESCRIPTION
I was checking the length of the filename against the maximum
JS file length. Native modules can be longer and were failing
because of this.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>