### PR TITLE
[sensor] Modularize sensor into separate submodules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,8 @@ analyze: $(JS)
 	@echo "% This is a generated file" > prj.mdef
 	@echo "# This is a generated file" > src/Makefile
 	@cat src/Makefile.base >> src/Makefile
+	@echo "# This is a generated file" > src/sensors/Makefile
+	@cat src/sensors/Makefile.base >> src/sensors/Makefile
 	@echo "# This is a generated file" > arc/src/Makefile
 	@cat arc/src/Makefile.base >> arc/src/Makefile
 	@if [ "$(TRACE)" = "on" ] || [ "$(TRACE)" = "full" ]; then \
@@ -213,7 +215,7 @@ analyze: $(JS)
 	@if [ "$(SNAPSHOT)" = "on" ]; then \
 		echo "ccflags-y += -DZJS_SNAPSHOT_BUILD" >> src/Makefile; \
 	fi
-	@echo "ccflags-y += $(shell ./scripts/analyze.sh $(BOARD) $(JS) $(CONFIG) $(ASHELL))" | tee -a src/Makefile arc/src/Makefile
+	@echo "ccflags-y += $(shell ./scripts/analyze.sh $(BOARD) $(JS) $(CONFIG) $(ASHELL))" | tee -a src/Makefile arc/src/Makefile src/sensors/Makefile
 	@if [ "$(OS)" = "Darwin" ]; then \
 		sed -i.bu '/This is a generated file/r./zjs.conf.tmp' src/Makefile; \
 	else \

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -468,14 +468,32 @@ if $buffer && [[ $MODULE != *"BUILD_MODULE_BUFFER"* ]]; then
     MODULES+=" -DBUILD_MODULE_BUFFER"
     echo "export ZJS_BUFFER=y" >> $CONFFILE
 fi
-sensor=$(grep -E Accelerometer\|Gyroscope\|AmbientLightSensor\|TemperatureSensor $SCRIPT)
-if [ $? -eq 0 ] || check_config_file ZJS_SENSOR; then
+if check_for_feature Accelerometer\|Gyroscope\|AmbientLightSensor\|TemperatureSensor || check_config_file ZJS_SENSOR; then
     >&2 echo Using module: Sensor
     MODULES+=" -DBUILD_MODULE_SENSOR"
     echo "export ZJS_SENSOR=y" >> $CONFFILE
+    if check_for_feature Accelerometer || check_config_file ZJS_SENSOR_ACCEL; then
+        >&2 echo Using module: Sensor Accelerometer
+        echo "export ZJS_SENSOR_ACCEL=y" >> $CONFFILE
+        MODULES+=" -DBUILD_MODULE_SENSOR_ACCEL"
+    fi
+    if check_for_feature Gyroscope || check_config_file ZJS_SENSOR_GYRO; then
+        >&2 echo Using module: Sensor Gyroscope
+        echo "export ZJS_SENSOR_GYRO=y" >> $CONFFILE
+        MODULES+=" -DBUILD_MODULE_SENSOR_GYRO"
+    fi
+    if check_for_feature AmbientLightSensor || check_config_file ZJS_SENSOR_LIGHT; then
+        >&2 echo Using module: Sensor Ambient Light
+        echo "export ZJS_SENSOR_LIGHT=y" >> $CONFFILE
+        MODULES+=" -DBUILD_MODULE_SENSOR_LIGHT"
+    fi
+    if check_for_feature TemperatureSensor || check_config_file ZJS_SENSOR_TEMP; then
+        >&2 echo Using module: Sensor Temperature
+        echo "export ZJS_SENSOR_TEMP=y" >> $CONFFILE
+        MODULES+=" -DBUILD_MODULE_SENSOR_TEMP"
+    fi
     if [[ $BOARD = "arduino_101" ]] || [[ $ASHELL = "y" ]]; then
-        bmi160=$(grep -E Accelerometer\|Gyroscope\|TemperatureSensor $SCRIPT)
-        if [[ $? -eq 0 ]] || [[ $ASHELL = "y" ]]; then
+        if check_for_feature Accelerometer\|Gyroscope\|TemperatureSensor || [[ $ASHELL = "y" ]]; then
             echo "CONFIG_SENSOR=y" >> $ARCPRJFILE
             echo "CONFIG_GPIO=y" >> $ARCPRJFILE
             echo "CONFIG_SPI=y" >> $ARCPRJFILE
@@ -490,8 +508,7 @@ if [ $? -eq 0 ] || check_config_file ZJS_SENSOR; then
             echo "CONFIG_BMI160_TRIGGER=y" >> $ARCPRJFILE
             echo "CONFIG_BMI160_TRIGGER_OWN_THREAD=y" >> $ARCPRJFILE
         fi
-        grovelight=$(grep -E AmbientLightSensor $SCRIPT)
-        if [[ $? -eq 0 ]] || [[ $ASHELL = "y" ]]; then
+        if check_for_feature AmbientLightSensor || [[ $ASHELL = "y" ]]; then
             MODULES+=" -DBUILD_MODULE_SENSOR_LIGHT"
             echo "CONFIG_ADC=y" >> $ARCPRJFILE
             # Workaround for the Zephyr issue ZEP-1882: ADC doesn't work with

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -468,32 +468,32 @@ if $buffer && [[ $MODULE != *"BUILD_MODULE_BUFFER"* ]]; then
     MODULES+=" -DBUILD_MODULE_BUFFER"
     echo "export ZJS_BUFFER=y" >> $CONFFILE
 fi
-if check_for_feature Accelerometer\|Gyroscope\|AmbientLightSensor\|TemperatureSensor || check_config_file ZJS_SENSOR; then
+if check_for_feature "Accelerometer\|Gyroscope\|AmbientLightSensor\|TemperatureSensor" || check_config_file ZJS_SENSOR; then
     >&2 echo Using module: Sensor
     MODULES+=" -DBUILD_MODULE_SENSOR"
     echo "export ZJS_SENSOR=y" >> $CONFFILE
-    if check_for_feature Accelerometer || check_config_file ZJS_SENSOR_ACCEL; then
+    if check_for_feature "Accelerometer" || check_config_file ZJS_SENSOR_ACCEL; then
         >&2 echo Using module: Sensor Accelerometer
         echo "export ZJS_SENSOR_ACCEL=y" >> $CONFFILE
         MODULES+=" -DBUILD_MODULE_SENSOR_ACCEL"
     fi
-    if check_for_feature Gyroscope || check_config_file ZJS_SENSOR_GYRO; then
+    if check_for_feature "Gyroscope" || check_config_file ZJS_SENSOR_GYRO; then
         >&2 echo Using module: Sensor Gyroscope
         echo "export ZJS_SENSOR_GYRO=y" >> $CONFFILE
         MODULES+=" -DBUILD_MODULE_SENSOR_GYRO"
     fi
-    if check_for_feature AmbientLightSensor || check_config_file ZJS_SENSOR_LIGHT; then
+    if check_for_feature "AmbientLightSensor" || check_config_file ZJS_SENSOR_LIGHT; then
         >&2 echo Using module: Sensor Ambient Light
         echo "export ZJS_SENSOR_LIGHT=y" >> $CONFFILE
         MODULES+=" -DBUILD_MODULE_SENSOR_LIGHT"
     fi
-    if check_for_feature TemperatureSensor || check_config_file ZJS_SENSOR_TEMP; then
+    if check_for_feature "TemperatureSensor" || check_config_file ZJS_SENSOR_TEMP; then
         >&2 echo Using module: Sensor Temperature
         echo "export ZJS_SENSOR_TEMP=y" >> $CONFFILE
         MODULES+=" -DBUILD_MODULE_SENSOR_TEMP"
     fi
     if [[ $BOARD = "arduino_101" ]] || [[ $ASHELL = "y" ]]; then
-        if check_for_feature Accelerometer\|Gyroscope\|TemperatureSensor || [[ $ASHELL = "y" ]]; then
+        if check_for_feature "Accelerometer\|Gyroscope\|TemperatureSensor" || [[ $ASHELL = "y" ]]; then
             echo "CONFIG_SENSOR=y" >> $ARCPRJFILE
             echo "CONFIG_GPIO=y" >> $ARCPRJFILE
             echo "CONFIG_SPI=y" >> $ARCPRJFILE
@@ -508,7 +508,7 @@ if check_for_feature Accelerometer\|Gyroscope\|AmbientLightSensor\|TemperatureSe
             echo "CONFIG_BMI160_TRIGGER=y" >> $ARCPRJFILE
             echo "CONFIG_BMI160_TRIGGER_OWN_THREAD=y" >> $ARCPRJFILE
         fi
-        if check_for_feature AmbientLightSensor || [[ $ASHELL = "y" ]]; then
+        if check_for_feature "AmbientLightSensor" || [[ $ASHELL = "y" ]]; then
             MODULES+=" -DBUILD_MODULE_SENSOR_LIGHT"
             echo "CONFIG_ADC=y" >> $ARCPRJFILE
             # Workaround for the Zephyr issue ZEP-1882: ADC doesn't work with

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -75,13 +75,16 @@ obj-$(ZJS_PROMISE) += zjs_promise.o
 obj-$(ZJS_NET_CONFIG) += zjs_net_config.o
 obj-$(ZJS_WS) += zjs_web_sockets.o
 
+ccflags-$(ZJS_SENSOR) += -I$(ZJS_BASE)/src/sensors
+obj-$(ZJS_SENSOR) += sensors/
+obj-$(ZJS_SENSOR) += zjs_sensor.o
+
 # skip for now for frdm_k64f
 ifeq ($(BOARD), arduino_101)
 	obj-$(ZJS_AIO) += zjs_aio.o
 	obj-$(ZJS_GROVE_LCD) += zjs_grove_lcd_ipm.o
 	obj-$(ZJS_I2C) += zjs_i2c.o \
                       zjs_i2c_ipm_handler.o
-	obj-$(ZJS_SENSOR) += zjs_sensor.o
 else
 	obj-$(ZJS_GROVE_LCD) += zjs_grove_lcd.o
 	obj-$(ZJS_I2C) += zjs_i2c.o \

--- a/src/sensors/Makefile.base
+++ b/src/sensors/Makefile.base
@@ -1,0 +1,16 @@
+# Copyright (c) 2017, Intel Corporation.
+
+JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
+
+ccflags-y += -Wall -Werror
+
+# Select extended ANSI C/POSIX function set in recent Newlib versions
+ccflags-y += -D_XOPEN_SOURCE=700
+
+ccflags-y += -I$(ZJS_BASE)/src
+ccflags-y += -I$(JERRY_BASE)/jerry-core
+
+obj-$(ZJS_SENSOR_ACCEL) += zjs_sensor_accel.o
+obj-$(ZJS_SENSOR_GYRO) += zjs_sensor_gyro.o
+obj-$(ZJS_SENSOR_LIGHT) += zjs_sensor_light.o
+obj-$(ZJS_SENSOR_TEMP) += zjs_sensor_temp.o

--- a/src/sensors/zjs_sensor_accel.c
+++ b/src/sensors/zjs_sensor_accel.c
@@ -1,7 +1,5 @@
 // Copyright (c) 2017, Intel Corporation.
 
-#ifdef BUILD_MODULE_SENSOR_ACCEL
-
 #include <string.h>
 #include "zjs_common.h"
 #include "zjs_util.h"
@@ -27,16 +25,6 @@ static void onchange(void *h, const void *argv)
     zjs_sensor_trigger_change(obj);
 }
 
-static void onstart(void *h, const void *argv)
-{
-    sensor_handle_t *handle = (sensor_handle_t *)h;
-    jerry_value_t obj = handle->sensor_obj;
-
-    if (jerry_value_has_error_flag(zjs_sensor_start_sensor(obj))) {
-        zjs_sensor_trigger_error(obj, "SensorError", "start failed");
-    }
-}
-
 static void onstop(void *h, const void *argv)
 {
     sensor_handle_t *handle = (sensor_handle_t *)h;
@@ -46,63 +34,28 @@ static void onstop(void *h, const void *argv)
     zjs_set_readonly_property(obj, "x", null_val);
     zjs_set_readonly_property(obj, "y", null_val);
     zjs_set_readonly_property(obj, "z", null_val);
-
-    if (jerry_value_has_error_flag(zjs_sensor_stop_sensor(obj))) {
-        zjs_sensor_trigger_error(obj, "SensorError", "stop failed");
-    }
 }
 
 static ZJS_DECL_FUNC(zjs_sensor_constructor)
 {
     ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_OBJECT);
 
-    double frequency = DEFAULT_SAMPLING_FREQUENCY;
-    size_t size = SENSOR_MAX_CONTROLLER_NAME_LEN;
-    sensor_controller_t controller;
+    jerry_value_t sensor_obj = ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create,
+                                                   g_instance,
+                                                   SENSOR_CHAN_ACCEL_XYZ,
+                                                   BMI160_DEVICE_NAME,
+                                                   0,
+                                                   800,
+                                                   onchange,
+                                                   NULL,
+                                                   onstop);
 
-    if (argc >= 1) {
-        jerry_value_t options = argv[0];
-        ZVAL controller_val = zjs_get_property(options, "controller");
-
-        if (jerry_value_is_string(controller_val)) {
-            zjs_copy_jstring(controller_val, controller.name, &size);
-        } else {
-            snprintf(controller.name, size, BMI160_DEVICE_NAME);
-            DBG_PRINT("controller not set, default to %s\n", controller.name);
-        }
-
-        double option_freq;
-        if (zjs_obj_get_double(options, "frequency", &option_freq)) {
-            // limit frequency to 800
-            if (option_freq < 1 || option_freq > 800) {
-                ERR_PRINT("unsupported frequency, default to %dHz\n",
-                          DEFAULT_SAMPLING_FREQUENCY);
-            } else {
-                frequency = option_freq;
-            }
-        } else {
-            DBG_PRINT("frequency not found, default to %dHz\n",
-                      DEFAULT_SAMPLING_FREQUENCY);
-        }
+    if (!jerry_value_has_error_flag(sensor_obj)) {
+        ZVAL null_val = jerry_create_null();
+        zjs_set_readonly_property(sensor_obj, "x", null_val);
+        zjs_set_readonly_property(sensor_obj, "y", null_val);
+        zjs_set_readonly_property(sensor_obj, "z", null_val);
     }
-
-    jerry_value_t sensor_obj = zjs_sensor_create(g_instance,
-                                                 SENSOR_CHAN_ACCEL_XYZ,
-                                                 &controller,
-                                                 frequency,
-                                                 onchange,
-                                                 onstart,
-                                                 onstop);
-
-    if (jerry_value_has_error_flag(sensor_obj)) {
-        return sensor_obj;
-    }
-
-    // initialize readings to null
-    ZVAL null_val = jerry_create_null();
-    zjs_set_readonly_property(sensor_obj, "x", null_val);
-    zjs_set_readonly_property(sensor_obj, "y", null_val);
-    zjs_set_readonly_property(sensor_obj, "z", null_val);
 
     return sensor_obj;
 }
@@ -112,14 +65,8 @@ sensor_instance_t *zjs_sensor_accel_init()
     if (g_instance)
         return g_instance;
 
-    ZVAL global_obj = jerry_get_global_object();
-    zjs_obj_add_function(global_obj, zjs_sensor_constructor, "Accelerometer");
-    g_instance = zjs_malloc(sizeof(sensor_instance_t));
-    if (!g_instance) {
-        ERR_PRINT("failed to allocate sensor_instance_t\n");
-        return NULL;
-    }
-    memset(g_instance, 0, sizeof(sensor_instance_t));
+    g_instance = zjs_sensor_create_instance("Accelerometer",
+                                            zjs_sensor_constructor);
     return g_instance;
 }
 
@@ -130,5 +77,3 @@ void zjs_sensor_accel_cleanup()
         g_instance = NULL;
     }
 }
-
-#endif // BUILD_MODULE_SENSOR_ACCEL

--- a/src/sensors/zjs_sensor_accel.c
+++ b/src/sensors/zjs_sensor_accel.c
@@ -1,0 +1,134 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifdef BUILD_MODULE_SENSOR_ACCEL
+
+#include <string.h>
+#include "zjs_common.h"
+#include "zjs_util.h"
+#include "zjs_sensor.h"
+#include "zjs_sensor_accel.h"
+
+static sensor_instance_t *g_instance = NULL;
+
+static void onchange(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    double x, y, z;
+
+    // reading is a ptr to an array of 3 double values
+    x = ((double *)argv)[0];
+    y = ((double *)argv)[1];
+    z = ((double *)argv)[2];
+    zjs_obj_add_readonly_number(obj, x, "x");
+    zjs_obj_add_readonly_number(obj, y, "y");
+    zjs_obj_add_readonly_number(obj, z, "z");
+    zjs_sensor_trigger_change(obj);
+}
+
+static void onstart(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    if (jerry_value_has_error_flag(zjs_sensor_start_sensor(obj))) {
+        zjs_sensor_trigger_error(obj, "SensorError", "start failed");
+    }
+}
+
+static void onstop(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    jerry_value_t null_val = jerry_create_null();
+    zjs_set_readonly_property(obj, "x", null_val);
+    zjs_set_readonly_property(obj, "y", null_val);
+    zjs_set_readonly_property(obj, "z", null_val);
+
+    if (jerry_value_has_error_flag(zjs_sensor_stop_sensor(obj))) {
+        zjs_sensor_trigger_error(obj, "SensorError", "stop failed");
+    }
+}
+
+static ZJS_DECL_FUNC(zjs_sensor_constructor)
+{
+    ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_OBJECT);
+
+    double frequency = DEFAULT_SAMPLING_FREQUENCY;
+    size_t size = SENSOR_MAX_CONTROLLER_NAME_LEN;
+    sensor_controller_t controller;
+
+    if (argc >= 1) {
+        jerry_value_t options = argv[0];
+        ZVAL controller_val = zjs_get_property(options, "controller");
+
+        if (jerry_value_is_string(controller_val)) {
+            zjs_copy_jstring(controller_val, controller.name, &size);
+        } else {
+            snprintf(controller.name, size, BMI160_DEVICE_NAME);
+            DBG_PRINT("controller not set, default to %s\n", controller.name);
+        }
+
+        double option_freq;
+        if (zjs_obj_get_double(options, "frequency", &option_freq)) {
+            // limit frequency to 800
+            if (option_freq < 1 || option_freq > 800) {
+                ERR_PRINT("unsupported frequency, default to %dHz\n",
+                          DEFAULT_SAMPLING_FREQUENCY);
+            } else {
+                frequency = option_freq;
+            }
+        } else {
+            DBG_PRINT("frequency not found, default to %dHz\n",
+                      DEFAULT_SAMPLING_FREQUENCY);
+        }
+    }
+
+    jerry_value_t sensor_obj = zjs_sensor_create(g_instance,
+                                                 SENSOR_CHAN_ACCEL_XYZ,
+                                                 &controller,
+                                                 frequency,
+                                                 onchange,
+                                                 onstart,
+                                                 onstop);
+
+    if (jerry_value_has_error_flag(sensor_obj)) {
+        return sensor_obj;
+    }
+
+    // initialize readings to null
+    ZVAL null_val = jerry_create_null();
+    zjs_set_readonly_property(sensor_obj, "x", null_val);
+    zjs_set_readonly_property(sensor_obj, "y", null_val);
+    zjs_set_readonly_property(sensor_obj, "z", null_val);
+
+    return sensor_obj;
+}
+
+sensor_instance_t *zjs_sensor_accel_init()
+{
+    if (g_instance)
+        return g_instance;
+
+    ZVAL global_obj = jerry_get_global_object();
+    zjs_obj_add_function(global_obj, zjs_sensor_constructor, "Accelerometer");
+    g_instance = zjs_malloc(sizeof(sensor_instance_t));
+    if (!g_instance) {
+        ERR_PRINT("failed to allocate sensor_instance_t\n");
+        return NULL;
+    }
+    memset(g_instance, 0, sizeof(sensor_instance_t));
+    return g_instance;
+}
+
+void zjs_sensor_accel_cleanup()
+{
+    if (g_instance) {
+        zjs_free(g_instance);
+        g_instance = NULL;
+    }
+}
+
+#endif // BUILD_MODULE_SENSOR_ACCEL

--- a/src/sensors/zjs_sensor_accel.h
+++ b/src/sensors/zjs_sensor_accel.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifndef __zjs_sensor_accel_h__
+#define __zjs_sensor_accel_h__
+
+/**
+ *  Initialize accelerometer sensor module
+ *
+ *  @return Accelerometer object
+ */
+sensor_instance_t *zjs_sensor_accel_init();
+
+/**
+ * Clean up module
+ */
+void zjs_sensor_accel_cleanup();
+
+#endif  // __zjs_sensor_accel_h__

--- a/src/sensors/zjs_sensor_gyro.c
+++ b/src/sensors/zjs_sensor_gyro.c
@@ -1,0 +1,134 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifdef BUILD_MODULE_SENSOR_GYRO
+
+#include <string.h>
+#include "zjs_common.h"
+#include "zjs_util.h"
+#include "zjs_sensor.h"
+#include "zjs_sensor_gyro.h"
+
+static sensor_instance_t *g_instance = NULL;
+
+static void onchange(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    double x, y, z;
+
+    // reading is a ptr to an array of 3 double values
+    x = ((double *)argv)[0];
+    y = ((double *)argv)[1];
+    z = ((double *)argv)[2];
+    zjs_obj_add_readonly_number(obj, x, "x");
+    zjs_obj_add_readonly_number(obj, y, "y");
+    zjs_obj_add_readonly_number(obj, z, "z");
+    zjs_sensor_trigger_change(obj);
+}
+
+static void onstart(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    if (jerry_value_has_error_flag(zjs_sensor_start_sensor(obj))) {
+        zjs_sensor_trigger_error(obj, "SensorError", "start failed");
+    }
+}
+
+static void onstop(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    jerry_value_t null_val = jerry_create_null();
+    zjs_set_readonly_property(obj, "x", null_val);
+    zjs_set_readonly_property(obj, "y", null_val);
+    zjs_set_readonly_property(obj, "z", null_val);
+
+    if (jerry_value_has_error_flag(zjs_sensor_stop_sensor(obj))) {
+        zjs_sensor_trigger_error(obj, "SensorError", "stop failed");
+    }
+}
+
+static ZJS_DECL_FUNC(zjs_sensor_constructor)
+{
+    ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_OBJECT);
+
+    double frequency = DEFAULT_SAMPLING_FREQUENCY;
+    size_t size = SENSOR_MAX_CONTROLLER_NAME_LEN;
+    sensor_controller_t controller;
+
+    if (argc >= 1) {
+        jerry_value_t options = argv[0];
+        ZVAL controller_val = zjs_get_property(options, "controller");
+
+        if (jerry_value_is_string(controller_val)) {
+            zjs_copy_jstring(controller_val, controller.name, &size);
+        } else {
+            snprintf(controller.name, size, BMI160_DEVICE_NAME);
+            DBG_PRINT("controller not set, default to %s\n", controller.name);
+        }
+
+        double option_freq;
+        if (zjs_obj_get_double(options, "frequency", &option_freq)) {
+            // limit frequency to 800
+            if (option_freq < 1 || option_freq > 800) {
+                ERR_PRINT("unsupported frequency, default to %dHz\n",
+                          DEFAULT_SAMPLING_FREQUENCY);
+            } else {
+                frequency = option_freq;
+            }
+        } else {
+            DBG_PRINT("frequency not found, default to %dHz\n",
+                      DEFAULT_SAMPLING_FREQUENCY);
+        }
+    }
+
+    jerry_value_t sensor_obj = zjs_sensor_create(g_instance,
+                                                 SENSOR_CHAN_GYRO_XYZ,
+                                                 &controller,
+                                                 frequency,
+                                                 onchange,
+                                                 onstart,
+                                                 onstop);
+
+    if (jerry_value_has_error_flag(sensor_obj)) {
+        return sensor_obj;
+    }
+
+    // initialize readings to null
+    ZVAL null_val = jerry_create_null();
+    zjs_set_readonly_property(sensor_obj, "x", null_val);
+    zjs_set_readonly_property(sensor_obj, "y", null_val);
+    zjs_set_readonly_property(sensor_obj, "z", null_val);
+
+    return sensor_obj;
+}
+
+sensor_instance_t *zjs_sensor_gyro_init()
+{
+    if (g_instance)
+        return g_instance;
+
+    ZVAL global_obj = jerry_get_global_object();
+    zjs_obj_add_function(global_obj, zjs_sensor_constructor, "Gyroscope");
+    g_instance = zjs_malloc(sizeof(sensor_instance_t));
+    if (!g_instance) {
+        ERR_PRINT("failed to allocate sensor_instance_t\n");
+        return NULL;
+    }
+    memset(g_instance, 0, sizeof(sensor_instance_t));
+    return g_instance;
+}
+
+void zjs_sensor_gyro_cleanup()
+{
+    if (g_instance) {
+        zjs_free(g_instance);
+        g_instance = NULL;
+    }
+}
+
+#endif // BUILD_MODULE_SENSOR_GYRO

--- a/src/sensors/zjs_sensor_gyro.c
+++ b/src/sensors/zjs_sensor_gyro.c
@@ -1,7 +1,5 @@
 // Copyright (c) 2017, Intel Corporation.
 
-#ifdef BUILD_MODULE_SENSOR_GYRO
-
 #include <string.h>
 #include "zjs_common.h"
 #include "zjs_util.h"
@@ -27,16 +25,6 @@ static void onchange(void *h, const void *argv)
     zjs_sensor_trigger_change(obj);
 }
 
-static void onstart(void *h, const void *argv)
-{
-    sensor_handle_t *handle = (sensor_handle_t *)h;
-    jerry_value_t obj = handle->sensor_obj;
-
-    if (jerry_value_has_error_flag(zjs_sensor_start_sensor(obj))) {
-        zjs_sensor_trigger_error(obj, "SensorError", "start failed");
-    }
-}
-
 static void onstop(void *h, const void *argv)
 {
     sensor_handle_t *handle = (sensor_handle_t *)h;
@@ -46,63 +34,28 @@ static void onstop(void *h, const void *argv)
     zjs_set_readonly_property(obj, "x", null_val);
     zjs_set_readonly_property(obj, "y", null_val);
     zjs_set_readonly_property(obj, "z", null_val);
-
-    if (jerry_value_has_error_flag(zjs_sensor_stop_sensor(obj))) {
-        zjs_sensor_trigger_error(obj, "SensorError", "stop failed");
-    }
 }
 
 static ZJS_DECL_FUNC(zjs_sensor_constructor)
 {
     ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_OBJECT);
 
-    double frequency = DEFAULT_SAMPLING_FREQUENCY;
-    size_t size = SENSOR_MAX_CONTROLLER_NAME_LEN;
-    sensor_controller_t controller;
+    jerry_value_t sensor_obj = ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create,
+                                                   g_instance,
+                                                   SENSOR_CHAN_GYRO_XYZ,
+                                                   BMI160_DEVICE_NAME,
+                                                   0,
+                                                   800,
+                                                   onchange,
+                                                   NULL,
+                                                   onstop);
 
-    if (argc >= 1) {
-        jerry_value_t options = argv[0];
-        ZVAL controller_val = zjs_get_property(options, "controller");
-
-        if (jerry_value_is_string(controller_val)) {
-            zjs_copy_jstring(controller_val, controller.name, &size);
-        } else {
-            snprintf(controller.name, size, BMI160_DEVICE_NAME);
-            DBG_PRINT("controller not set, default to %s\n", controller.name);
-        }
-
-        double option_freq;
-        if (zjs_obj_get_double(options, "frequency", &option_freq)) {
-            // limit frequency to 800
-            if (option_freq < 1 || option_freq > 800) {
-                ERR_PRINT("unsupported frequency, default to %dHz\n",
-                          DEFAULT_SAMPLING_FREQUENCY);
-            } else {
-                frequency = option_freq;
-            }
-        } else {
-            DBG_PRINT("frequency not found, default to %dHz\n",
-                      DEFAULT_SAMPLING_FREQUENCY);
-        }
+    if (!jerry_value_has_error_flag(sensor_obj)) {
+        ZVAL null_val = jerry_create_null();
+        zjs_set_readonly_property(sensor_obj, "x", null_val);
+        zjs_set_readonly_property(sensor_obj, "y", null_val);
+        zjs_set_readonly_property(sensor_obj, "z", null_val);
     }
-
-    jerry_value_t sensor_obj = zjs_sensor_create(g_instance,
-                                                 SENSOR_CHAN_GYRO_XYZ,
-                                                 &controller,
-                                                 frequency,
-                                                 onchange,
-                                                 onstart,
-                                                 onstop);
-
-    if (jerry_value_has_error_flag(sensor_obj)) {
-        return sensor_obj;
-    }
-
-    // initialize readings to null
-    ZVAL null_val = jerry_create_null();
-    zjs_set_readonly_property(sensor_obj, "x", null_val);
-    zjs_set_readonly_property(sensor_obj, "y", null_val);
-    zjs_set_readonly_property(sensor_obj, "z", null_val);
 
     return sensor_obj;
 }
@@ -112,14 +65,8 @@ sensor_instance_t *zjs_sensor_gyro_init()
     if (g_instance)
         return g_instance;
 
-    ZVAL global_obj = jerry_get_global_object();
-    zjs_obj_add_function(global_obj, zjs_sensor_constructor, "Gyroscope");
-    g_instance = zjs_malloc(sizeof(sensor_instance_t));
-    if (!g_instance) {
-        ERR_PRINT("failed to allocate sensor_instance_t\n");
-        return NULL;
-    }
-    memset(g_instance, 0, sizeof(sensor_instance_t));
+    g_instance = zjs_sensor_create_instance("Gyroscope",
+                                            zjs_sensor_constructor);
     return g_instance;
 }
 
@@ -130,5 +77,3 @@ void zjs_sensor_gyro_cleanup()
         g_instance = NULL;
     }
 }
-
-#endif // BUILD_MODULE_SENSOR_GYRO

--- a/src/sensors/zjs_sensor_gyro.h
+++ b/src/sensors/zjs_sensor_gyro.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifndef __zjs_sensor_gyro_h__
+#define __zjs_sensor_gyro_h__
+
+/**
+ *  Initialize gyroscope sensor module
+ *
+ *  @return Gyroscope object
+ */
+sensor_instance_t *zjs_sensor_gyro_init();
+
+/**
+ * Clean up module
+ */
+void zjs_sensor_gyro_cleanup();
+
+#endif  // __zjs_sensor_gyro_h__

--- a/src/sensors/zjs_sensor_light.c
+++ b/src/sensors/zjs_sensor_light.c
@@ -1,0 +1,133 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifdef BUILD_MODULE_SENSOR_LIGHT
+
+#include <string.h>
+#include "zjs_common.h"
+#include "zjs_util.h"
+#include "zjs_sensor.h"
+#include "zjs_sensor_light.h"
+
+static sensor_instance_t *g_instance = NULL;
+
+static void onchange(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    double d;
+
+    // reading is a ptr to double
+    d = *((double *)argv);
+    zjs_obj_add_readonly_number(obj, d, "illuminance");
+    zjs_sensor_trigger_change(obj);
+}
+
+static void onstart(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    if (jerry_value_has_error_flag(zjs_sensor_start_sensor(obj))) {
+        zjs_sensor_trigger_error(obj, "SensorError", "start failed");
+    }
+}
+
+static void onstop(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    jerry_value_t null_val = jerry_create_null();
+    zjs_set_readonly_property(obj, "illuminance", null_val);
+
+    if (jerry_value_has_error_flag(zjs_sensor_stop_sensor(obj))) {
+        zjs_sensor_trigger_error(obj, "SensorError", "stop failed");
+    }
+}
+
+static ZJS_DECL_FUNC(zjs_sensor_constructor)
+{
+    ZJS_VALIDATE_ARGS(Z_OBJECT);
+
+    double frequency = DEFAULT_SAMPLING_FREQUENCY;
+    size_t size = SENSOR_MAX_CONTROLLER_NAME_LEN;
+    sensor_controller_t controller;
+    jerry_value_t options = argv[0];
+
+    // AmbientLight expectes a obj with pin number
+    uint32_t pin;
+    if (zjs_obj_get_uint32(options, "pin", &pin)) {
+        controller.pin = pin;
+    } else {
+        ERR_PRINT("pin not found\n");
+        return jerry_create_null();
+    }
+
+    ZVAL controller_val = zjs_get_property(options, "controller");
+
+    if (jerry_value_is_string(controller_val)) {
+        zjs_copy_jstring(controller_val, controller.name, &size);
+    } else {
+        snprintf(controller.name, size, ADC_DEVICE_NAME);
+        DBG_PRINT("controller not set, default to %s\n", controller.name);
+    }
+
+    double option_freq;
+    if (zjs_obj_get_double(options, "frequency", &option_freq)) {
+        // limit frequency to 100
+        if (option_freq < 1 || option_freq > 100) {
+            ERR_PRINT("unsupported frequency, default to %dHz\n",
+                      DEFAULT_SAMPLING_FREQUENCY);
+        } else {
+            frequency = option_freq;
+        }
+    } else {
+        DBG_PRINT("frequency not found, default to %dHz\n",
+                  DEFAULT_SAMPLING_FREQUENCY);
+    }
+
+    jerry_value_t sensor_obj = zjs_sensor_create(g_instance,
+                                                 SENSOR_CHAN_LIGHT,
+                                                 &controller,
+                                                 frequency,
+                                                 onchange,
+                                                 onstart,
+                                                 onstop);
+
+    if (jerry_value_has_error_flag(sensor_obj)) {
+        return sensor_obj;
+    }
+
+    // initialize readings to null
+    ZVAL null_val = jerry_create_null();
+    zjs_set_readonly_property(sensor_obj, "illuminance", null_val);
+
+    return sensor_obj;
+}
+
+sensor_instance_t *zjs_sensor_light_init()
+{
+    if (g_instance)
+        return g_instance;
+
+    ZVAL global_obj = jerry_get_global_object();
+    zjs_obj_add_function(global_obj, zjs_sensor_constructor, "AmbientLightSensor");
+    g_instance = zjs_malloc(sizeof(sensor_instance_t));
+    if (!g_instance) {
+        ERR_PRINT("failed to allocate sensor_instance_t\n");
+        return NULL;
+    }
+    memset(g_instance, 0, sizeof(sensor_instance_t));
+    return g_instance;
+}
+
+void zjs_sensor_light_cleanup()
+{
+    if (g_instance) {
+        zjs_free(g_instance);
+        g_instance = NULL;
+    }
+}
+
+#endif // BUILD_MODULE_SENSOR_LIGHT

--- a/src/sensors/zjs_sensor_light.c
+++ b/src/sensors/zjs_sensor_light.c
@@ -1,7 +1,5 @@
 // Copyright (c) 2017, Intel Corporation.
 
-#ifdef BUILD_MODULE_SENSOR_LIGHT
-
 #include <string.h>
 #include "zjs_common.h"
 #include "zjs_util.h"
@@ -23,16 +21,6 @@ static void onchange(void *h, const void *argv)
     zjs_sensor_trigger_change(obj);
 }
 
-static void onstart(void *h, const void *argv)
-{
-    sensor_handle_t *handle = (sensor_handle_t *)h;
-    jerry_value_t obj = handle->sensor_obj;
-
-    if (jerry_value_has_error_flag(zjs_sensor_start_sensor(obj))) {
-        zjs_sensor_trigger_error(obj, "SensorError", "start failed");
-    }
-}
-
 static void onstop(void *h, const void *argv)
 {
     sensor_handle_t *handle = (sensor_handle_t *)h;
@@ -40,68 +28,26 @@ static void onstop(void *h, const void *argv)
 
     jerry_value_t null_val = jerry_create_null();
     zjs_set_readonly_property(obj, "illuminance", null_val);
-
-    if (jerry_value_has_error_flag(zjs_sensor_stop_sensor(obj))) {
-        zjs_sensor_trigger_error(obj, "SensorError", "stop failed");
-    }
 }
 
 static ZJS_DECL_FUNC(zjs_sensor_constructor)
 {
     ZJS_VALIDATE_ARGS(Z_OBJECT);
 
-    double frequency = DEFAULT_SAMPLING_FREQUENCY;
-    size_t size = SENSOR_MAX_CONTROLLER_NAME_LEN;
-    sensor_controller_t controller;
-    jerry_value_t options = argv[0];
+    jerry_value_t sensor_obj = ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create,
+                                                   g_instance,
+                                                   SENSOR_CHAN_LIGHT,
+                                                   ADC_DEVICE_NAME,
+                                                   -1,
+                                                   100,
+                                                   onchange,
+                                                   NULL,
+                                                   onstop);
 
-    // AmbientLight expectes a obj with pin number
-    uint32_t pin;
-    if (zjs_obj_get_uint32(options, "pin", &pin)) {
-        controller.pin = pin;
-    } else {
-        ERR_PRINT("pin not found\n");
-        return jerry_create_null();
-    }
-
-    ZVAL controller_val = zjs_get_property(options, "controller");
-
-    if (jerry_value_is_string(controller_val)) {
-        zjs_copy_jstring(controller_val, controller.name, &size);
-    } else {
-        snprintf(controller.name, size, ADC_DEVICE_NAME);
-        DBG_PRINT("controller not set, default to %s\n", controller.name);
-    }
-
-    double option_freq;
-    if (zjs_obj_get_double(options, "frequency", &option_freq)) {
-        // limit frequency to 100
-        if (option_freq < 1 || option_freq > 100) {
-            ERR_PRINT("unsupported frequency, default to %dHz\n",
-                      DEFAULT_SAMPLING_FREQUENCY);
-        } else {
-            frequency = option_freq;
-        }
-    } else {
-        DBG_PRINT("frequency not found, default to %dHz\n",
-                  DEFAULT_SAMPLING_FREQUENCY);
-    }
-
-    jerry_value_t sensor_obj = zjs_sensor_create(g_instance,
-                                                 SENSOR_CHAN_LIGHT,
-                                                 &controller,
-                                                 frequency,
-                                                 onchange,
-                                                 onstart,
-                                                 onstop);
-
-    if (jerry_value_has_error_flag(sensor_obj)) {
-        return sensor_obj;
-    }
-
-    // initialize readings to null
+    if (!jerry_value_has_error_flag(sensor_obj)) {
     ZVAL null_val = jerry_create_null();
     zjs_set_readonly_property(sensor_obj, "illuminance", null_val);
+    }
 
     return sensor_obj;
 }
@@ -111,14 +57,8 @@ sensor_instance_t *zjs_sensor_light_init()
     if (g_instance)
         return g_instance;
 
-    ZVAL global_obj = jerry_get_global_object();
-    zjs_obj_add_function(global_obj, zjs_sensor_constructor, "AmbientLightSensor");
-    g_instance = zjs_malloc(sizeof(sensor_instance_t));
-    if (!g_instance) {
-        ERR_PRINT("failed to allocate sensor_instance_t\n");
-        return NULL;
-    }
-    memset(g_instance, 0, sizeof(sensor_instance_t));
+    g_instance = zjs_sensor_create_instance("AmbientLightSensor",
+                                            zjs_sensor_constructor);
     return g_instance;
 }
 
@@ -129,5 +69,3 @@ void zjs_sensor_light_cleanup()
         g_instance = NULL;
     }
 }
-
-#endif // BUILD_MODULE_SENSOR_LIGHT

--- a/src/sensors/zjs_sensor_light.h
+++ b/src/sensors/zjs_sensor_light.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifndef __zjs_sensor_light_h__
+#define __zjs_sensor_light_h__
+
+/**
+ *  Initialize ambient light sensor module
+ *
+ *  @return AmbientLightSensor object
+ */
+sensor_instance_t *zjs_sensor_light_init();
+
+/**
+ * Clean up module
+ */
+void zjs_sensor_light_cleanup();
+
+#endif  // __zjs_sensor_light_h__

--- a/src/sensors/zjs_sensor_temp.c
+++ b/src/sensors/zjs_sensor_temp.c
@@ -1,0 +1,126 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifdef BUILD_MODULE_SENSOR_TEMP
+
+#include <string.h>
+#include "zjs_common.h"
+#include "zjs_util.h"
+#include "zjs_sensor.h"
+#include "zjs_sensor_temp.h"
+
+static sensor_instance_t *g_instance = NULL;
+
+static void onchange(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    double d;
+
+    // reading is a ptr to double
+    d = *((double *)argv);
+    zjs_obj_add_readonly_number(obj, d, "celsius");
+    zjs_sensor_trigger_change(obj);
+}
+
+static void onstart(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    if (jerry_value_has_error_flag(zjs_sensor_start_sensor(obj))) {
+        zjs_sensor_trigger_error(obj, "SensorError", "start failed");
+    }
+}
+
+static void onstop(void *h, const void *argv)
+{
+    sensor_handle_t *handle = (sensor_handle_t *)h;
+    jerry_value_t obj = handle->sensor_obj;
+
+    jerry_value_t null_val = jerry_create_null();
+    zjs_set_readonly_property(obj, "illuminance", null_val);
+
+    if (jerry_value_has_error_flag(zjs_sensor_stop_sensor(obj))) {
+        zjs_sensor_trigger_error(obj, "SensorError", "stop failed");
+    }
+}
+
+static ZJS_DECL_FUNC(zjs_sensor_constructor)
+{
+    ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_OBJECT);
+
+    double frequency = DEFAULT_SAMPLING_FREQUENCY;
+    size_t size = SENSOR_MAX_CONTROLLER_NAME_LEN;
+    sensor_controller_t controller;
+
+    if (argc >= 1) {
+        jerry_value_t options = argv[0];
+        ZVAL controller_val = zjs_get_property(options, "controller");
+
+        if (jerry_value_is_string(controller_val)) {
+            zjs_copy_jstring(controller_val, controller.name, &size);
+        } else {
+            snprintf(controller.name, size, BMI160_DEVICE_NAME);
+            DBG_PRINT("controller not set, default to %s\n", controller.name);
+        }
+
+        double option_freq;
+        if (zjs_obj_get_double(options, "frequency", &option_freq)) {
+            // limit frequency to 800
+            if (option_freq < 1 || option_freq > 800) {
+                ERR_PRINT("unsupported frequency, default to %dHz\n",
+                          DEFAULT_SAMPLING_FREQUENCY);
+            } else {
+                frequency = option_freq;
+            }
+        } else {
+            DBG_PRINT("frequency not found, default to %dHz\n",
+                      DEFAULT_SAMPLING_FREQUENCY);
+        }
+    }
+
+    jerry_value_t sensor_obj = zjs_sensor_create(g_instance,
+                                                 SENSOR_CHAN_TEMP,
+                                                 &controller,
+                                                 frequency,
+                                                 onchange,
+                                                 onstart,
+                                                 onstop);
+
+    if (jerry_value_has_error_flag(sensor_obj)) {
+        return sensor_obj;
+    }
+
+    // initialize readings to null
+    ZVAL null_val = jerry_create_null();
+    zjs_set_readonly_property(sensor_obj, "celsius", null_val);
+
+    return sensor_obj;
+}
+
+sensor_instance_t *zjs_sensor_temp_init()
+{
+    if (g_instance)
+        return g_instance;
+
+    ZVAL global_obj = jerry_get_global_object();
+    zjs_obj_add_function(global_obj, zjs_sensor_constructor, "TemperatureSensor");
+    g_instance = zjs_malloc(sizeof(sensor_instance_t));
+    if (!g_instance) {
+        ERR_PRINT("failed to allocate sensor_instance_t\n");
+        return NULL;
+    }
+    memset(g_instance, 0, sizeof(sensor_instance_t));
+    return g_instance;
+}
+
+void zjs_sensor_temp_cleanup()
+{
+    if (g_instance) {
+        zjs_free(g_instance);
+        g_instance = NULL;
+    }
+}
+
+#endif // BUILD_MODULE_SENSOR_TEMP

--- a/src/sensors/zjs_sensor_temp.c
+++ b/src/sensors/zjs_sensor_temp.c
@@ -1,7 +1,5 @@
 // Copyright (c) 2017, Intel Corporation.
 
-#ifdef BUILD_MODULE_SENSOR_TEMP
-
 #include <string.h>
 #include "zjs_common.h"
 #include "zjs_util.h"
@@ -23,16 +21,6 @@ static void onchange(void *h, const void *argv)
     zjs_sensor_trigger_change(obj);
 }
 
-static void onstart(void *h, const void *argv)
-{
-    sensor_handle_t *handle = (sensor_handle_t *)h;
-    jerry_value_t obj = handle->sensor_obj;
-
-    if (jerry_value_has_error_flag(zjs_sensor_start_sensor(obj))) {
-        zjs_sensor_trigger_error(obj, "SensorError", "start failed");
-    }
-}
-
 static void onstop(void *h, const void *argv)
 {
     sensor_handle_t *handle = (sensor_handle_t *)h;
@@ -40,61 +28,27 @@ static void onstop(void *h, const void *argv)
 
     jerry_value_t null_val = jerry_create_null();
     zjs_set_readonly_property(obj, "illuminance", null_val);
-
-    if (jerry_value_has_error_flag(zjs_sensor_stop_sensor(obj))) {
-        zjs_sensor_trigger_error(obj, "SensorError", "stop failed");
-    }
 }
 
 static ZJS_DECL_FUNC(zjs_sensor_constructor)
 {
     ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_OBJECT);
 
-    double frequency = DEFAULT_SAMPLING_FREQUENCY;
-    size_t size = SENSOR_MAX_CONTROLLER_NAME_LEN;
-    sensor_controller_t controller;
+    jerry_value_t sensor_obj = ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create,
+                                                   g_instance,
+                                                   SENSOR_CHAN_TEMP,
+                                                   BMI160_DEVICE_NAME,
+                                                   0,
+                                                   800,
+                                                   onchange,
+                                                   NULL,
+                                                   onstop);
 
-    if (argc >= 1) {
-        jerry_value_t options = argv[0];
-        ZVAL controller_val = zjs_get_property(options, "controller");
-
-        if (jerry_value_is_string(controller_val)) {
-            zjs_copy_jstring(controller_val, controller.name, &size);
-        } else {
-            snprintf(controller.name, size, BMI160_DEVICE_NAME);
-            DBG_PRINT("controller not set, default to %s\n", controller.name);
-        }
-
-        double option_freq;
-        if (zjs_obj_get_double(options, "frequency", &option_freq)) {
-            // limit frequency to 800
-            if (option_freq < 1 || option_freq > 800) {
-                ERR_PRINT("unsupported frequency, default to %dHz\n",
-                          DEFAULT_SAMPLING_FREQUENCY);
-            } else {
-                frequency = option_freq;
-            }
-        } else {
-            DBG_PRINT("frequency not found, default to %dHz\n",
-                      DEFAULT_SAMPLING_FREQUENCY);
-        }
-    }
-
-    jerry_value_t sensor_obj = zjs_sensor_create(g_instance,
-                                                 SENSOR_CHAN_TEMP,
-                                                 &controller,
-                                                 frequency,
-                                                 onchange,
-                                                 onstart,
-                                                 onstop);
-
-    if (jerry_value_has_error_flag(sensor_obj)) {
-        return sensor_obj;
-    }
-
-    // initialize readings to null
+    if (!jerry_value_has_error_flag(sensor_obj)) {
     ZVAL null_val = jerry_create_null();
     zjs_set_readonly_property(sensor_obj, "celsius", null_val);
+
+    }
 
     return sensor_obj;
 }
@@ -104,14 +58,8 @@ sensor_instance_t *zjs_sensor_temp_init()
     if (g_instance)
         return g_instance;
 
-    ZVAL global_obj = jerry_get_global_object();
-    zjs_obj_add_function(global_obj, zjs_sensor_constructor, "TemperatureSensor");
-    g_instance = zjs_malloc(sizeof(sensor_instance_t));
-    if (!g_instance) {
-        ERR_PRINT("failed to allocate sensor_instance_t\n");
-        return NULL;
-    }
-    memset(g_instance, 0, sizeof(sensor_instance_t));
+    g_instance = zjs_sensor_create_instance("TemperatureSensor",
+                                            zjs_sensor_constructor);
     return g_instance;
 }
 
@@ -122,5 +70,3 @@ void zjs_sensor_temp_cleanup()
         g_instance = NULL;
     }
 }
-
-#endif // BUILD_MODULE_SENSOR_TEMP

--- a/src/sensors/zjs_sensor_temp.h
+++ b/src/sensors/zjs_sensor_temp.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifndef __zjs_sensor_temp_h__
+#define __zjs_sensor_temp_h__
+
+/**
+ *  Initialize temperature sensor module
+ *
+ *  @return TemperatureSensor object
+ */
+sensor_instance_t *zjs_sensor_temp_init();
+
+/**
+ * Clean up module
+ */
+void zjs_sensor_temp_cleanup();
+
+#endif  // __zjs_sensor_temp_h__

--- a/src/zjs_sensor.h
+++ b/src/zjs_sensor.h
@@ -1,9 +1,117 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __zjs_sensor_h__
 #define __zjs_sensor_h__
 
+#include <sensor.h>
 #include "jerryscript.h"
+#include "zjs_callbacks.h"
+
+#define DEFAULT_SAMPLING_FREQUENCY      20
+#define SENSOR_MAX_CONTROLLER_NAME_LEN  16
+
+typedef enum sensor_state {
+    SENSOR_STATE_UNCONNECTED,
+    SENSOR_STATE_IDLE,
+    SENSOR_STATE_ACTIVATING,
+    SENSOR_STATE_ACTIVATED,
+    SENSOR_STATE_ERRORED,
+} sensor_state_t;
+
+typedef struct sensor_controller {
+    char name[SENSOR_MAX_CONTROLLER_NAME_LEN+1];
+    uint32_t pin;
+} sensor_controller_t;
+
+typedef struct sensor_handle {
+    sensor_state_t state;
+    enum sensor_channel channel;
+    sensor_controller_t *controller;
+    int frequency;
+    jerry_value_t sensor_obj;
+    zjs_callback_id onchange_cb_id;
+    zjs_callback_id onstart_cb_id;
+    zjs_callback_id onstop_cb_id;
+    struct sensor_handle *next;
+} sensor_handle_t;
+
+typedef struct sensor_instance {
+    void *handles;
+} sensor_instance_t;
+
+/*
+ * Creates a Generic W3C Sensor object using the controller information and initialize it
+ *
+ * @param instance      instance object that is created by each sensor module's init function
+ * @param channel       the type of sensor object, maps to the supported Zephyr sensor channels
+ * @param controller    the hardware controller sensor, contains info like controller name and pin number
+ * @param frequency     the desired polling frequency
+ * @param onchange      the function to be called when sensor reports data has changed
+ * @param onstart       the function to be called when sensor.start() has been called
+ * @param onstart       the function to be called when sensor.stop() has been called
+ *
+ * @return              a new Sensor object or Error object if creation failed
+ */
+jerry_value_t zjs_sensor_create(sensor_instance_t *instance,
+                                enum sensor_channel channel,
+                                sensor_controller_t *controller,
+                                uint32_t frequency,
+                                zjs_c_callback_func onchange,
+                                zjs_c_callback_func onstart,
+                                zjs_c_callback_func onstop);
+
+/*
+ * Starts the sensor, usually in trigger mode or polling mode depending on the controller,
+ * this should be called after onstart has been called, any new readings will then be notified
+ * in the onchange callback
+ *
+ * @param obj           the sensor object that was created from zjs_sensor_create
+ */
+jerry_value_t zjs_sensor_start_sensor(jerry_value_t obj);
+
+/*
+ * Stops the sensor, usually in trigger mode or polling mode depending on the controller,
+ * this should be called after onstop has been called, you will then stop receive any
+ * new readings
+ *
+ * @param obj           the sensor object that was created from zjs_sensor_create
+ */
+jerry_value_t zjs_sensor_stop_sensor(jerry_value_t obj);
+
+/*
+ * Get the current state of the sensor
+ *
+ * @param obj           the sensor object that was created from zjs_sensor_create
+ *
+ * @return              the state from enum sensor_state.
+ */
+sensor_state_t zjs_sensor_get_state(jerry_value_t obj);
+
+/*
+ * Set the current state of the sensor
+ *
+ * @param obj           the sensor object that was created from zjs_sensor_create
+ * @param state         the state from enum sensor_state.
+ */
+void zjs_sensor_set_state(jerry_value_t obj, sensor_state_t state);
+
+/*
+ * Trigger a change event so the sensor.onchange callback will be called
+ *
+ * @param obj           the sensor object that was created from zjs_sensor_create
+ */
+void zjs_sensor_trigger_change(jerry_value_t obj);
+
+/*
+ * Trigger a error event so the sensor.onerror callback will be called
+ *
+ * @param obj           the sensor object that was created from zjs_sensor_create
+ * @param error_name    the custom error name
+ * @param error_message the error message detail
+ */
+void zjs_sensor_trigger_error(jerry_value_t obj,
+                              const char *error_name,
+                              const char *error_message);
 
 /** Initialize the sensor module, or reinitialize after cleanup */
 void zjs_sensor_init();

--- a/src/zjs_sensor.h
+++ b/src/zjs_sensor.h
@@ -40,22 +40,38 @@ typedef struct sensor_instance {
 } sensor_instance_t;
 
 /*
+ * Create a new sensor instance struct that stores all the created objects
+ *
+ * @param name          name of the Sensor subclass that will exist in global
+ * @param func          constructor of the Sensor subclass
+ *
+ * @return              pointer to the sensor instance struct
+ */
+sensor_instance_t *zjs_sensor_create_instance(const char *name, void *func);
+
+/*
  * Creates a Generic W3C Sensor object using the controller information and initialize it
  *
  * @param instance      instance object that is created by each sensor module's init function
  * @param channel       the type of sensor object, maps to the supported Zephyr sensor channels
- * @param controller    the hardware controller sensor, contains info like controller name and pin number
- * @param frequency     the desired polling frequency
+ * @param c_name        the default hardware controller name if not set
+ * @param pin           the default pin if not set
+ * @param max_frequency the max supported polling frequency
  * @param onchange      the function to be called when sensor reports data has changed
  * @param onstart       the function to be called when sensor.start() has been called
  * @param onstart       the function to be called when sensor.stop() has been called
  *
  * @return              a new Sensor object or Error object if creation failed
  */
-jerry_value_t zjs_sensor_create(sensor_instance_t *instance,
+jerry_value_t zjs_sensor_create(const jerry_value_t func_obj,
+                                const jerry_value_t this,
+                                const jerry_value_t argv[],
+                                const jerry_length_t argc,
+                                sensor_instance_t *instance,
                                 enum sensor_channel channel,
-                                sensor_controller_t *controller,
-                                uint32_t frequency,
+                                const char *c_name,
+                                uint32_t pin,
+                                uint32_t max_frequency,
                                 zjs_c_callback_func onchange,
                                 zjs_c_callback_func onstart,
                                 zjs_c_callback_func onstop);


### PR DESCRIPTION
Instead of having all the different Sensor implementations
all exists in a single file, it's cleaner to break it out
into separate sub modules, which then can be loaded separately.

The sensor.c just implements the core sensor logic and will
have the individual sensors handle the data through callbacks.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>