### PR TITLE
[sensor] Remove gravity option in Accelerometer

### DIFF
--- a/docs/sensors.md
+++ b/docs/sensors.md
@@ -62,7 +62,6 @@ callback ErrorCallback = void(SensorErrorEvent error);
 ```javascript
 [Constructor(optional AccelerometerOptions accelerometerOptions)]
 interface Accelerometer : Sensor {
-    attribute boolean includesGravity;
     readonly attribute double x;
     readonly attribute double y;
     readonly attribute double z;
@@ -70,7 +69,6 @@ interface Accelerometer : Sensor {
 
 dictionary AccelerometerOptions : SensorOptions  {
     string controller;       // controller name, default to "bmi160"
-    boolean includeGravity;  // not supported currently
 };
 ```
 ####GyroscopeSensor Interface

--- a/samples/BMI160Accelerometer.js
+++ b/samples/BMI160Accelerometer.js
@@ -8,7 +8,6 @@ console.log("BMI160 accelerometer test...");
 var updateFrequency = 20; // maximum is 100Hz, but in ashell maximum is 20Hz
 
 var sensor = new Accelerometer({
-    includeGravity: false, // true is not supported, will throw error
     frequency: updateFrequency
 });
 

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -568,17 +568,7 @@ static ZJS_DECL_FUNC_ARGS(zjs_sensor_create, enum sensor_channel channel)
                       DEFAULT_SAMPLING_FREQUENCY);
         }
 
-        if (channel == SENSOR_CHAN_ACCEL_XYZ) {
-            bool option_gravity;
-            if (zjs_obj_get_boolean(options, "includeGravity",
-                                    &option_gravity) && option_gravity) {
-                if (option_gravity) {
-                    ERR_PRINT("includeGravity is not supported\n");
-                }
-                zjs_obj_add_readonly_boolean(sensor_obj, option_gravity,
-                                             "includeGravity");
-            }
-        } else if (channel == SENSOR_CHAN_LIGHT) {
+        if (channel == SENSOR_CHAN_LIGHT) {
             if (zjs_obj_get_uint32(options, "pin", &pin)) {
                 zjs_obj_add_readonly_number(sensor_obj, pin, "pin");
             }
@@ -640,7 +630,6 @@ static ZJS_DECL_FUNC(zjs_accel_create)
 {
     // requires: arg 0 is an object containing sensor options:
     //             frequency (double) - sampling frequency
-    //             includeGravity (bool) - whether you want gravity included
     //  effects: Creates a Accelerometer object to the local sensor
     return ZJS_CHAIN_FUNC_ARGS(zjs_sensor_create, SENSOR_CHAN_ACCEL_XYZ);
 }

--- a/tests/test-bmi160accelerometer.js
+++ b/tests/test-bmi160accelerometer.js
@@ -6,7 +6,6 @@ console.log("Testing bmi160 accelerometer APIs");
 var genericSensor = require("GenericSensor.js");
 
 var sensor = new Accelerometer({
-    includeGravity: false,
     frequency: 50
 });
 


### PR DESCRIPTION
The includeGravity flag doesn't exists in the W3C spec as
the Accelerometer is split into LinearAccelerationSensor and
GravitySensor.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>