### PR TITLE
[ashell] Remove boot.cfg if this is a newly flashed board

### DIFF
--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -646,7 +646,6 @@ int32_t ashell_help(char *buf)
         comms_printf("%8s %s\r\n", commands[t].cmd_name, commands[t].syntax);
     }
     //comms_println("TODO: Read help file per command!");
-    ashell_run_boot_cfg();
     return RET_OK;
 }
 


### PR DESCRIPTION
If the board __TIMESTAMP__ is newer than the one in boot.cfg,
remove it.  This allows users to get their ashell build out of a
bad state should the javascript function they specified in boot.cfg
wedges the board on boot.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>