### PR TITLE
Mock gpio module to run tests on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 # Copyright (c) 2016-2017, Intel Corporation.
 
+# a place to add temporary defines to ZJS builds such as -DZJS_GPIO_MOCK
+ZJS_FLAGS :=
+
 OS := $(shell uname)
 
 BOARD ?= arduino_101
@@ -137,6 +140,7 @@ ram_report: zephyr
 					CB_STATS=$(CB_STATS) \
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT) \
+					ZJS_FLAGS=$(ZJS_FLAGS) \
 					ram_report
 
 .PHONY: rom_report
@@ -146,6 +150,7 @@ rom_report: zephyr
 					CB_STATS=$(CB_STATS) \
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT) \
+					ZJS_FLAGS=$(ZJS_FLAGS) \
 					rom_report
 
 # choose name of jerryscript library based on snapshot feature
@@ -158,14 +163,16 @@ endif
 # Build for zephyr, default target
 .PHONY: zephyr
 zephyr: analyze generate $(JERRYLIB) $(ARC)
-	@make -f Makefile.zephyr	BOARD=$(BOARD) \
+	@make -f Makefile.zephyr \
+					BOARD=$(BOARD) \
 					VARIANT=$(VARIANT) \
 					CB_STATS=$(CB_STATS) \
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT) \
 					BLE_ADDR=$(BLE_ADDR) \
 					ASHELL=$(ASHELL) \
-					NETWORK_BUILD=$(NET_BUILD)
+					NETWORK_BUILD=$(NET_BUILD) \
+					ZJS_FLAGS=$(ZJS_FLAGS)
 ifeq ($(BOARD), arduino_101)
 	@echo
 	@echo -n Creating dfu images...
@@ -362,7 +369,8 @@ qemu: zephyr
 	make -f Makefile.zephyr qemu \
 		CB_STATS=$(CB_STATS) \
 		SNAPSHOT=$(SNAPSHOT) \
-		NETWORK_BUILD=$(NET_BUILD)
+		NETWORK_BUILD=$(NET_BUILD) \
+		ZJS_FLAGS=$(ZJS_FLAGS)
 
 # Builds ARC binary
 .PHONY: arc

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -17,6 +17,7 @@ CORE_SRC +=	src/zjs_a101_pins.c \
 		src/zjs_error.c \
 		src/zjs_event.c \
 		src/zjs_gpio.c \
+		src/zjs_gpio_mock.c \
 		src/zjs_linux_ring_buffer.c \
 		src/zjs_linux_time.c \
 		src/main.c \
@@ -56,7 +57,8 @@ LINUX_DEFINES +=	-DZJS_LINUX_BUILD \
 			-DBUILD_MODULE_PROMISE \
 			-DBUILD_MODULE_TEST_CALLBACKS \
 			-DBUILD_MODULE_A101 \
-			-DBUILD_MODULE_GPIO
+			-DBUILD_MODULE_GPIO \
+			-DZJS_GPIO_MOCK
 
 LINUX_FLAGS += 	-fno-asynchronous-unwind-tables \
 		-fno-omit-frame-pointer \

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -9,12 +9,14 @@ OCF_ROOT ?= deps/iotivity-constrained
 
 BUILD_DIR = $(ZJS_BASE)/outdir/linux/$(VARIANT)
 
-CORE_SRC +=	src/zjs_buffer.c \
+CORE_SRC +=	src/zjs_a101_pins.c \
+		src/zjs_buffer.c \
 		src/zjs_callbacks.c \
 		src/zjs_common.c \
 		src/zjs_console.c \
 		src/zjs_error.c \
 		src/zjs_event.c \
+		src/zjs_gpio.c \
 		src/zjs_linux_ring_buffer.c \
 		src/zjs_linux_time.c \
 		src/main.c \
@@ -52,7 +54,9 @@ LINUX_DEFINES +=	-DZJS_LINUX_BUILD \
 			-DBUILD_MODULE_BUFFER \
 			-DBUILD_MODULE_TEST_PROMISE \
 			-DBUILD_MODULE_PROMISE \
-			-DBUILD_MODULE_TEST_CALLBACKS
+			-DBUILD_MODULE_TEST_CALLBACKS \
+			-DBUILD_MODULE_A101 \
+			-DBUILD_MODULE_GPIO
 
 LINUX_FLAGS += 	-fno-asynchronous-unwind-tables \
 		-fno-omit-frame-pointer \

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -392,10 +392,10 @@ if [ "$RUN" == "all" -o "$RUN" == "3" ]; then
 
     # linux runtime tests
     # TODO: Add buffer, it fails in Linux ATM
-    for i in buffer buffer-rw callbacks eval error event promise timers; do
+    for i in buffer buffer-rw callbacks eval error event gpio promise timers; do
         ./outdir/linux/release/jslinux tests/test-$i.js > /tmp/output
-        cat /tmp/output
         try_command "t-$i" test ! $(grep "FAIL" /tmp/output)
+        cat /tmp/output
     done
 fi
 

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -3,7 +3,7 @@
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 OCF_ROOT ?= deps/iotivity-constrained
 
-ccflags-y += -Wall -Werror
+ccflags-y += -Wall -Werror $(ZJS_FLAGS)
 
 # TODO: iotivity-constrained gives some warnings and until we figure out how to
 #       disable them just for iotivity-constrained, we need to turn them back
@@ -62,6 +62,9 @@ obj-$(ZJS_NET) += zjs_net.o
 obj-$(ZJS_EVENTS) += zjs_event.o
 obj-$(ZJS_FS) += zjs_fs.o
 obj-$(ZJS_GPIO) += zjs_gpio.o
+ifeq ($(filter $(ZJS_FLAGS),-DZJS_GPIO_MOCK),-DZJS_GPIO_MOCK)
+obj-y += zjs_gpio_mock.o
+endif
 obj-$(ZJS_BLE) += zjs_ble.o
 obj-$(ZJS_PWM) += zjs_pwm.o
 obj-$(ZJS_PERFORMANCE) += zjs_performance.o

--- a/src/zjs_a101_pins.c
+++ b/src/zjs_a101_pins.c
@@ -1,9 +1,5 @@
 // Copyright (c) 2016-2017, Intel Corporation.
 
-#ifdef BUILD_MODULE_A101
-// Zephyr includes
-#include <zephyr.h>
-
 // ZJS includes
 #include <zjs_gpio.h>
 #include <zjs_pwm.h>
@@ -117,4 +113,3 @@ jerry_value_t zjs_a101_init()
 
     return obj;
 }
-#endif // BUILD_MODULE_A101

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -291,7 +291,7 @@ static ZJS_DECL_FUNC(zjs_gpio_open)
     bool both = false;
     if (zjs_obj_get_string(data, "edge", buffer, BUFLEN)) {
         if (!strcmp(buffer, ZJS_EDGE_BOTH)) {
-            flags |= GPIO_INT | GPIO_INT_DOUBLE_EDGE;
+            flags |= GPIO_INT | GPIO_INT_EDGE | GPIO_INT_DOUBLE_EDGE;
             edge = ZJS_EDGE_BOTH;
             both = true;
         }

--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -14,72 +14,14 @@
 #include "zjs_util.h"
 #include "zjs_callbacks.h"
 
-#if defined(ZJS_LINUX_BUILD) || defined(QEMU_BUILD)
-#ifndef ZJS_GPIO_MOCK
-#define ZJS_GPIO_MOCK
-#endif
-#endif
-
-#ifndef ZJS_GPIO_MOCK
-#define DEVICE struct device *
+#ifdef ZJS_GPIO_MOCK
+#include "zjs_gpio_mock.h"
 #else
-#define DEVICE jerry_value_t
-
-struct mock_gpio_callback;
-typedef void (*mock_gpio_callback_handler_t)(DEVICE port,
-                                             struct mock_gpio_callback *cb,
-                                             uint32_t pins);
-struct mock_gpio_callback {
-    mock_gpio_callback_handler_t handler;
-    uint32_t pin_mask;
-};
-
-#define gpio_callback mock_gpio_callback
-#define gpio_callback_handler_t mock_gpio_callback_handler_t
-
-#define device_get_binding mock_device_get_binding
-#define gpio_pin_read mock_gpio_pin_read
-#define gpio_pin_write mock_gpio_pin_write
-#define gpio_pin_configure mock_gpio_pin_configure
-#define gpio_init_callback mock_gpio_init_callback
-#define gpio_add_callback mock_gpio_add_callback
-#define gpio_remove_callback mock_gpio_remove_callback
-#define gpio_pin_enable_callback mock_gpio_pin_enable_callback
-
-static DEVICE mock_device_get_binding(const char *name);
-static int mock_gpio_pin_read(DEVICE port, uint32_t pin, uint32_t *value);
-static int mock_gpio_pin_write(DEVICE port, uint32_t pin, uint32_t value);
-static int mock_gpio_pin_configure(DEVICE port, uint8_t pin, int flags);
-static void mock_gpio_init_callback(struct gpio_callback *callback,
-                                    gpio_callback_handler_t handler,
-                                    uint32_t pin_mask);
-static int mock_gpio_add_callback(DEVICE port, struct gpio_callback *callback);
-static int mock_gpio_remove_callback(DEVICE port,
-                                     struct gpio_callback *callback);
-static int mock_gpio_pin_enable_callback(DEVICE port, uint32_t pin);
-
-static jerry_value_t mock_root_obj = 0;
-
-#ifdef ZJS_LINUX_BUILD
-// provide Zephyr dependencies
-#define GPIO_DIR_IN           (0 << 0)
-#define GPIO_DIR_OUT          (1 << 0)
-#define GPIO_INT              (1 << 1)
-#define GPIO_INT_ACTIVE_LOW   (0 << 2)
-#define GPIO_INT_ACTIVE_HIGH  (1 << 2)
-#define GPIO_INT_EDGE         (1 << 5)
-#define GPIO_INT_DOUBLE_EDGE  (1 << 6)
-#define GPIO_POL_NORMAL       (0 << 7)
-#define GPIO_POL_INV          (1 << 7)
-#define GPIO_PUD_NORMAL       (0 << 8)
-#define GPIO_PUD_PULL_UP      (1 << 8)
-#define GPIO_PUD_PULL_DOWN    (2 << 8)
-
-#define BIT(n)  (1UL << (n))
-#define CONTAINER_OF(ptr, type, field) \
-	((type *)(((char *)(ptr)) - offsetof(type, field)))
-#endif  // ZJS_LINUX_BUILD
-#endif  // ZJS_GPIO_MOCK
+#define DEVICE struct device *
+#define zjs_gpio_mock_pre_init()
+#define zjs_gpio_mock_post_init(gpio_obj)
+#define zjs_gpio_mock_cleanup()
+#endif
 
 static const char *ZJS_DIR_IN = "in";
 static const char *ZJS_DIR_OUT = "out";
@@ -120,8 +62,9 @@ typedef struct gpio_handle {
     bool closed;
 } gpio_handle_t;
 
-static jerry_value_t lookup_pin(const jerry_value_t pin_obj, DEVICE *port,
-                                int *pin)
+// non-static so that mock can access it, meant to be private though
+jerry_value_t gpio_internal_lookup_pin(const jerry_value_t pin_obj,
+                                       DEVICE *port, int *pin)
 {
     char pin_id[32];
     int newpin;
@@ -229,7 +172,7 @@ static ZJS_DECL_FUNC(zjs_gpio_pin_read)
 
     int newpin;
     DEVICE gpiodev;
-    ZVAL status = lookup_pin(this, &gpiodev, &newpin);
+    ZVAL status = gpio_internal_lookup_pin(this, &gpiodev, &newpin);
     if (!jerry_value_is_undefined(status))
         return status;
 
@@ -271,7 +214,7 @@ static ZJS_DECL_FUNC(zjs_gpio_pin_write)
 
     int newpin;
     DEVICE gpiodev;
-    ZVAL status = lookup_pin(this, &gpiodev, &newpin);
+    ZVAL status = gpio_internal_lookup_pin(this, &gpiodev, &newpin);
     if (!jerry_value_is_undefined(status))
         return status;
 
@@ -336,7 +279,7 @@ static ZJS_DECL_FUNC(zjs_gpio_open)
     DEVICE gpiodev;
     int newpin;
 
-    ZVAL status = lookup_pin(data, &gpiodev, &newpin);
+    ZVAL status = gpio_internal_lookup_pin(data, &gpiodev, &newpin);
     if (!jerry_value_is_undefined(status))
         return status;
 
@@ -445,378 +388,11 @@ static ZJS_DECL_FUNC(zjs_gpio_open)
     return jerry_acquire_value(pinobj);
 }
 
-#ifdef ZJS_GPIO_MOCK
-// Sample structure of mock root object:
-// var obj = {
-//     "GPIO_0": {
-//         "pin1": {
-//             "state": <boolean>,
-//             "flags": <uint32>,
-//             "wired": <array>  // pins this pin is wired to
-//         },
-//         "pin2": <object>
-//     },
-//     "GPIO_1": <object>,
-//     "GPIO_2": <object>,
-// }
-
-// mock helpers
-static jerry_value_t get_pin(jerry_value_t port, unsigned int pin)
-{
-    char name[15];
-    sprintf(name, "pin%u\n", pin);
-    return zjs_get_property(port, name);
-}
-
-static jerry_value_t ensure_pin(jerry_value_t port, unsigned int pin)
-{
-    char name[15];
-    sprintf(name, "pin%u\n", pin);
-    jerry_value_t pin_obj = zjs_get_property(port, name);
-    if (!jerry_value_is_object(pin_obj)) {
-        pin_obj = jerry_create_object();
-        zjs_set_property(port, name, pin_obj);
-    }
-    return pin_obj;
-}
-
-struct value_match_data {
-    jerry_value_t name;
-    jerry_value_t value;
-};
-
-static bool value_match(const jerry_value_t name, const jerry_value_t value,
-                        void *user_data)
-{
-    struct value_match_data *data = (struct value_match_data *)user_data;
-    if (value == data->value) {
-        // found match, stop processing and return name
-        data->name = name;
-        return false;
-    }
-    return true;
-}
-
-static jerry_value_t find_property_with_value(jerry_value_t obj,
-                                              jerry_value_t value)
-{
-    // effects: returns name of first property in obj that is set to value, or
-    //            else a 0 value
-    struct value_match_data match;
-    match.name = 0;
-    match.value = value;
-    jerry_foreach_object_property(obj, value_match, &match);
-    return match.name;
-}
-
-// donated by jprestwo from his pending websockets patch, should move to util
-static jerry_value_t push_array(jerry_value_t array, jerry_value_t val)
-{
-    jerry_value_t new;
-    if (!jerry_value_is_array(array)) {
-        new = jerry_create_array(1);
-        jerry_set_property_by_index(new, 0, val);
-    } else {
-        uint32_t size = jerry_get_array_length(array);
-        new = jerry_create_array(size + 1);
-        for (int i = 0; i < size; i++) {
-            ZVAL v = jerry_get_property_by_index(array, i);
-            jerry_set_property_by_index(new, i, v);
-        }
-        jerry_set_property_by_index(new, size, val);
-    }
-    return new;
-}
-
-// mock control functions
-
-/**
- * @name mock
- */
-
-/**
- * Simulate a wire connecting the two given pins
- *
- * @name wire
- * @param {GPIOPin} pin1
- * @param {GPIOPin} pin2
- */
-static ZJS_DECL_FUNC(zjs_gpio_mock_wire)
-{
-    ZJS_VALIDATE_ARGS(Z_OBJECT, Z_OBJECT);
-
-    DEVICE port1;
-    DEVICE port2;
-    int pin1, pin2;
-    lookup_pin(argv[0], &port1, &pin1);
-    lookup_pin(argv[1], &port2, &pin2);
-
-    jerry_value_t name1 = find_property_with_value(mock_root_obj, port1);
-    jerry_value_t name2 = find_property_with_value(mock_root_obj, port2);
-    if (!name1 || !name2) {
-        return zjs_error("invalid port object");
-    }
-
-    ZVAL pin1_obj = get_pin(port1, pin1);
-    ZVAL pin2_obj = get_pin(port2, pin2);
-    if (!jerry_value_is_object(pin1_obj) ||
-        !jerry_value_is_object(pin2_obj)) {
-        return zjs_error("invalid pin object");
-    }
-
-    ZVAL pin1_wired = zjs_get_property(pin1_obj, "wired");
-    ZVAL new1_wired = push_array(pin1_wired, pin2_obj);
-    zjs_set_property(pin1_obj, "wired", new1_wired);
-
-    ZVAL pin2_wired = zjs_get_property(pin2_obj, "wired");
-    ZVAL new2_wired = push_array(pin2_wired, pin1_obj);
-    zjs_set_property(pin2_obj, "wired", new2_wired);
-
-    return ZJS_UNDEFINED;
-}
-
-// mocked apis
-static DEVICE mock_device_get_binding(const char *name)
-{
-    ZVAL obj = zjs_get_property(mock_root_obj, name);
-    jerry_value_t rval = obj;
-    if (!jerry_value_is_object(obj)) {
-        ZVAL new_obj = jerry_create_object();
-        zjs_set_property(mock_root_obj, name, new_obj);
-        rval = new_obj;
-    }
-
-    // DEVICE is jerry_value_t in mock mode
-    return rval;
-}
-
-static int mock_gpio_pin_read(DEVICE port, uint32_t pin, uint32_t *value)
-{
-    if (!find_property_with_value(mock_root_obj, port)) {
-        ERR_PRINT("invalid port object\n");
-        return -1;
-    }
-
-    ZVAL pin_obj = get_pin(port, pin);
-    if (!jerry_value_is_object(pin_obj)) {
-        ERR_PRINT("invalid pin object\n");
-        return -1;
-    }
-
-    // reading from a GPIO output seems to be allowed, so don't check direction
-
-    // check for a 'state'
-    bool flag;
-    if (zjs_obj_get_boolean(pin_obj, "state", &flag)) {
-        *value = flag ? 1 : 0;
-        return 0;
-    }
-
-    // check for a pin this is wired to
-    ZVAL wired = zjs_get_property(pin_obj, "wired");
-    if (jerry_value_is_array(wired)) {
-        uint32_t len = jerry_get_array_length(wired);
-        for (uint32_t i = 0; i < len; ++i) {
-            ZVAL pin = jerry_get_property_by_index(wired, i);
-            if (zjs_obj_get_boolean(pin, "state", &flag)) {
-                *value = flag ? 1 : 0;
-                return 0;
-            }
-        }
-    }
-
-    // TODO: for advanced tests, might check against a timing pattern
-
-    ERR_PRINT("no mock value\n");
-    return -1;
-}
-
-// TODO: write generic list code
-typedef struct mock_cb_item {
-    struct mock_cb_item *next;
-    struct gpio_callback *callback;
-    gpio_callback_handler_t handler;
-    uint32_t pin_mask;
-    uint32_t enabled_mask;
-    jerry_value_t port;
-} mock_cb_item_t;
-
-mock_cb_item_t *mock_cb_list = NULL;
-
-static int mock_gpio_pin_write(DEVICE port, uint32_t pin, uint32_t value)
-{
-    if (!find_property_with_value(mock_root_obj, port)) {
-        ERR_PRINT("invalid port object\n");
-        return -1;
-    }
-
-    ZVAL pin_obj = get_pin(port, pin);
-    if (!jerry_value_is_object(pin_obj)) {
-        ERR_PRINT("invalid pin object\n");
-        return -1;
-    }
-
-    uint32_t flags;
-    if (!zjs_obj_get_uint32(pin_obj, "flags", &flags) ||
-        !(flags & GPIO_DIR_OUT)) {
-        // attempted write to an input; just do nothing
-        return 0;
-    }
-
-    // set 'state'
-    bool level = false;
-    bool found = zjs_obj_get_boolean(pin_obj, "state", &level);
-    bool new_level = value ? true : false;
-    zjs_obj_add_boolean(pin_obj, new_level, "state");
-
-    if (found && level != new_level) {
-        // check for pins this is wired to
-        ZVAL wired = zjs_get_property(pin_obj, "wired");
-        if (jerry_value_is_array(wired)) {
-            // trigger edges on change
-            uint32_t len = jerry_get_array_length(wired);
-            for (uint32_t i = 0; i < len; ++i) {
-                ZVAL connection = jerry_get_property_by_index(wired, i);
-                uint32_t conn_pin = 0;
-                zjs_obj_get_uint32(connection, "pin", &conn_pin);
-
-                if (zjs_obj_get_uint32(connection, "flags", &flags)) {
-                    // make sure it has interrupt and edge-triggering enabled
-                    uint32_t expect = GPIO_INT | GPIO_INT_EDGE;
-                    if ((flags & expect) != expect) {
-                        continue;
-                    }
-
-                    if ((flags & GPIO_INT_DOUBLE_EDGE) ||
-                        ((flags & GPIO_INT_ACTIVE_HIGH) == GPIO_INT_ACTIVE_HIGH
-                         && new_level) ||
-                        ((flags & GPIO_INT_ACTIVE_LOW) == GPIO_INT_ACTIVE_LOW
-                         && !new_level)) {
-
-                        // simulate onchange interrupt
-                        uintptr_t ptr;
-                        if (jerry_get_object_native_handle(connection, &ptr)) {
-                            mock_cb_item_t *item = (mock_cb_item_t *)ptr;
-                            if (BIT(conn_pin) & item->enabled_mask) {
-                                item->handler(port, item->callback,
-                                              item->enabled_mask);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    return 0;
-}
-
-static int mock_gpio_pin_configure(DEVICE port, uint8_t pin, int flags)
-{
-    if (!find_property_with_value(mock_root_obj, port)) {
-        ERR_PRINT("invalid port object\n");
-        return -1;
-    }
-
-    // create or update pin object
-    ZVAL pin_obj = ensure_pin(port, pin);
-    zjs_set_property(pin_obj, "flags", jerry_create_number(flags));
-    zjs_set_property(pin_obj, "pin", jerry_create_number(pin));
-
-    return 0;
-}
-
-static void mock_gpio_init_callback(struct gpio_callback *callback,
-                                    gpio_callback_handler_t handler,
-                                    uint32_t pin_mask)
-{
-    mock_cb_item_t *item = (mock_cb_item_t *)malloc(sizeof(mock_cb_item_t));
-    item->next = mock_cb_list;
-    item->callback = callback;
-    item->handler = handler;
-    item->pin_mask = pin_mask;
-    item->enabled_mask = 0;
-    item->port = 0;
-    mock_cb_list = item;
-}
-
-static int mock_gpio_add_callback(DEVICE port, struct gpio_callback *callback)
-{
-    if (!find_property_with_value(mock_root_obj, port)) {
-        ERR_PRINT("invalid port object\n");
-        return -1;
-    }
-
-    mock_cb_item_t *item = mock_cb_list;
-    while (item) {
-        if (item->callback == callback) {
-            item->port = port;
-            break;
-        }
-        item = item->next;
-    }
-    return 0;
-}
-
-static int mock_gpio_remove_callback(DEVICE port,
-                                     struct gpio_callback *callback)
-{
-    // disable the callback for this port
-    if (!find_property_with_value(mock_root_obj, port)) {
-        ERR_PRINT("invalid port object\n");
-        return -1;
-    }
-
-    mock_cb_item_t *item = mock_cb_list;
-    while (item) {
-        if (item->callback == callback && item->port == port) {
-            item->enabled_mask = 0;
-            item = item->next;
-            break;
-        }
-        item = item->next;
-    }
-
-    return 0;
-}
-
-static int mock_gpio_pin_enable_callback(DEVICE port, uint32_t pin)
-{
-    if (!find_property_with_value(mock_root_obj, port)) {
-        ERR_PRINT("invalid port object\n");
-        return -1;
-    }
-
-    ZVAL pin_obj = get_pin(port, pin);
-    if (!jerry_value_is_object(pin_obj)) {
-        ERR_PRINT("invalid pin object\n");
-        return -1;
-    }
-
-    mock_cb_item_t *item = mock_cb_list;
-    while (item) {
-        if (item->port == port) {
-            uint32_t bit = BIT(pin);
-            if (bit & item->pin_mask) {
-                item->enabled_mask |= bit;
-                jerry_set_object_native_handle(pin_obj, (uintptr_t)item, NULL);
-                // FIXME: maybe need to clean up on re-open w/o close
-                break;
-           }
-        }
-        item = item->next;
-    }
-    return 0;
-}
-#endif  // ZJS_GPIO_MOCK
-
 jerry_value_t zjs_gpio_init()
 {
     // effects: finds the GPIO driver and returns the GPIO JS object
 
-#ifdef ZJS_GPIO_MOCK
-    mock_root_obj = jerry_create_object();
-#endif
+    zjs_gpio_mock_pre_init();
 
     char devname[10];
     for (int i = 0; i < GPIO_DEV_COUNT; i++) {
@@ -841,11 +417,7 @@ jerry_value_t zjs_gpio_init()
     jerry_value_t gpio_obj = jerry_create_object();
     zjs_obj_add_function(gpio_obj, zjs_gpio_open, "open");
 
-#ifdef ZJS_GPIO_MOCK
-    // use the mock property to check for mock APIs
-    zjs_obj_add_boolean(gpio_obj, true, "mock");
-    zjs_obj_add_function(gpio_obj, zjs_gpio_mock_wire, "wire");
-#endif
+    zjs_gpio_mock_post_init(gpio_obj);
 
     return gpio_obj;
 }
@@ -854,14 +426,5 @@ void zjs_gpio_cleanup()
 {
     jerry_release_value(zjs_gpio_pin_prototype);
 
-#ifdef ZJS_GPIO_MOCK
-    jerry_release_value(mock_root_obj);
-
-    mock_cb_item_t *item = mock_cb_list;
-    while (item) {
-        mock_cb_item_t *next = item->next;
-        zjs_free(item);
-        item = next;
-    }
-#endif
+    zjs_gpio_mock_cleanup();
 }

--- a/src/zjs_gpio_mock.c
+++ b/src/zjs_gpio_mock.c
@@ -1,0 +1,404 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifndef ZJS_LINUX_BUILD
+#include "gpio.h"
+#endif
+
+#include "zjs_gpio.h"
+#include "zjs_util.h"
+
+// mock headers should be included last
+#include "zjs_gpio_mock.h"
+
+// specially declare this internal gpio function
+jerry_value_t gpio_internal_lookup_pin(const jerry_value_t pin_obj,
+                                       DEVICE *port, int *pin);
+
+// Sample structure of mock root object:
+// var obj = {
+//     "GPIO_0": {
+//         "pin1": {
+//             "state": <boolean>,
+//             "flags": <uint32>,
+//             "wired": <array>  // pins this pin is wired to
+//         },
+//         "pin2": <object>
+//     },
+//     "GPIO_1": <object>,
+//     "GPIO_2": <object>,
+// }
+static jerry_value_t mock_root_obj = 0;
+
+// mock helpers
+static jerry_value_t get_pin(jerry_value_t port, unsigned int pin)
+{
+    char name[15];
+    sprintf(name, "pin%u\n", pin);
+    return zjs_get_property(port, name);
+}
+
+static jerry_value_t ensure_pin(jerry_value_t port, unsigned int pin)
+{
+    char name[15];
+    sprintf(name, "pin%u\n", pin);
+    jerry_value_t pin_obj = zjs_get_property(port, name);
+    if (!jerry_value_is_object(pin_obj)) {
+        pin_obj = jerry_create_object();
+        zjs_set_property(port, name, pin_obj);
+    }
+    return pin_obj;
+}
+
+struct value_match_data {
+    jerry_value_t name;
+    jerry_value_t value;
+};
+
+static bool value_match(const jerry_value_t name, const jerry_value_t value,
+                        void *user_data)
+{
+    struct value_match_data *data = (struct value_match_data *)user_data;
+    if (value == data->value) {
+        // found match, stop processing and return name
+        data->name = name;
+        return false;
+    }
+    return true;
+}
+
+static jerry_value_t find_property_with_value(jerry_value_t obj,
+                                              jerry_value_t value)
+{
+    // effects: returns name of first property in obj that is set to value, or
+    //            else a 0 value
+    struct value_match_data match;
+    match.name = 0;
+    match.value = value;
+    jerry_foreach_object_property(obj, value_match, &match);
+    return match.name;
+}
+
+// donated by jprestwo from his pending websockets patch, should move to util
+static jerry_value_t push_array(jerry_value_t array, jerry_value_t val)
+{
+    jerry_value_t new;
+    if (!jerry_value_is_array(array)) {
+        new = jerry_create_array(1);
+        jerry_set_property_by_index(new, 0, val);
+    } else {
+        uint32_t size = jerry_get_array_length(array);
+        new = jerry_create_array(size + 1);
+        for (int i = 0; i < size; i++) {
+            ZVAL v = jerry_get_property_by_index(array, i);
+            jerry_set_property_by_index(new, i, v);
+        }
+        jerry_set_property_by_index(new, size, val);
+    }
+    return new;
+}
+
+// mock control functions
+
+/**
+ * @name mock
+ */
+
+/**
+ * Simulate a wire connecting the two given pins
+ *
+ * @name wire
+ * @param {GPIOPin} pin1
+ * @param {GPIOPin} pin2
+ */
+static ZJS_DECL_FUNC(zjs_gpio_mock_wire)
+{
+    ZJS_VALIDATE_ARGS(Z_OBJECT, Z_OBJECT);
+
+    DEVICE port1;
+    DEVICE port2;
+    int pin1, pin2;
+    gpio_internal_lookup_pin(argv[0], &port1, &pin1);
+    gpio_internal_lookup_pin(argv[1], &port2, &pin2);
+
+    jerry_value_t name1 = find_property_with_value(mock_root_obj, port1);
+    jerry_value_t name2 = find_property_with_value(mock_root_obj, port2);
+    if (!name1 || !name2) {
+        return zjs_error("invalid port object");
+    }
+
+    ZVAL pin1_obj = get_pin(port1, pin1);
+    ZVAL pin2_obj = get_pin(port2, pin2);
+    if (!jerry_value_is_object(pin1_obj) ||
+        !jerry_value_is_object(pin2_obj)) {
+        return zjs_error("invalid pin object");
+    }
+
+    ZVAL pin1_wired = zjs_get_property(pin1_obj, "wired");
+    ZVAL new1_wired = push_array(pin1_wired, pin2_obj);
+    zjs_set_property(pin1_obj, "wired", new1_wired);
+
+    ZVAL pin2_wired = zjs_get_property(pin2_obj, "wired");
+    ZVAL new2_wired = push_array(pin2_wired, pin1_obj);
+    zjs_set_property(pin2_obj, "wired", new2_wired);
+
+    return ZJS_UNDEFINED;
+}
+
+// mocked apis
+DEVICE mock_gpio_device_get_binding(const char *name)
+{
+    ZVAL obj = zjs_get_property(mock_root_obj, name);
+    jerry_value_t rval = obj;
+    if (!jerry_value_is_object(obj)) {
+        ZVAL new_obj = jerry_create_object();
+        zjs_set_property(mock_root_obj, name, new_obj);
+        rval = new_obj;
+    }
+
+    // DEVICE is jerry_value_t in mock mode
+    return rval;
+}
+
+int mock_gpio_pin_read(DEVICE port, uint32_t pin, uint32_t *value)
+{
+    if (!find_property_with_value(mock_root_obj, port)) {
+        ERR_PRINT("invalid port object\n");
+        return -1;
+    }
+
+    ZVAL pin_obj = get_pin(port, pin);
+    if (!jerry_value_is_object(pin_obj)) {
+        ERR_PRINT("invalid pin object\n");
+        return -1;
+    }
+
+    // reading from a GPIO output seems to be allowed, so don't check direction
+
+    // check for a 'state'
+    bool flag;
+    if (zjs_obj_get_boolean(pin_obj, "state", &flag)) {
+        *value = flag ? 1 : 0;
+        return 0;
+    }
+
+    // check for a pin this is wired to
+    ZVAL wired = zjs_get_property(pin_obj, "wired");
+    if (jerry_value_is_array(wired)) {
+        uint32_t len = jerry_get_array_length(wired);
+        for (uint32_t i = 0; i < len; ++i) {
+            ZVAL pin = jerry_get_property_by_index(wired, i);
+            if (zjs_obj_get_boolean(pin, "state", &flag)) {
+                *value = flag ? 1 : 0;
+                return 0;
+            }
+        }
+    }
+
+    // TODO: for advanced tests, might check against a timing pattern
+
+    ERR_PRINT("no mock value\n");
+    return -1;
+}
+
+// TODO: write generic list code
+typedef struct mock_cb_item {
+    struct mock_cb_item *next;
+    struct gpio_callback *callback;
+    gpio_callback_handler_t handler;
+    uint32_t pin_mask;
+    uint32_t enabled_mask;
+    jerry_value_t port;
+} mock_cb_item_t;
+
+mock_cb_item_t *mock_cb_list = NULL;
+
+int mock_gpio_pin_write(DEVICE port, uint32_t pin, uint32_t value)
+{
+    if (!find_property_with_value(mock_root_obj, port)) {
+        ERR_PRINT("invalid port object\n");
+        return -1;
+    }
+
+    ZVAL pin_obj = get_pin(port, pin);
+    if (!jerry_value_is_object(pin_obj)) {
+        ERR_PRINT("invalid pin object\n");
+        return -1;
+    }
+
+    uint32_t flags;
+    if (!zjs_obj_get_uint32(pin_obj, "flags", &flags) ||
+        !(flags & GPIO_DIR_OUT)) {
+        // attempted write to an input; just do nothing
+        return 0;
+    }
+
+    // set 'state'
+    bool level = false;
+    bool found = zjs_obj_get_boolean(pin_obj, "state", &level);
+    bool new_level = value ? true : false;
+    zjs_obj_add_boolean(pin_obj, new_level, "state");
+
+    if (found && level != new_level) {
+        // check for pins this is wired to
+        ZVAL wired = zjs_get_property(pin_obj, "wired");
+        if (jerry_value_is_array(wired)) {
+            // trigger edges on change
+            uint32_t len = jerry_get_array_length(wired);
+            for (uint32_t i = 0; i < len; ++i) {
+                ZVAL connection = jerry_get_property_by_index(wired, i);
+                uint32_t conn_pin = 0;
+                zjs_obj_get_uint32(connection, "pin", &conn_pin);
+
+                if (zjs_obj_get_uint32(connection, "flags", &flags)) {
+                    // make sure it has interrupt and edge-triggering enabled
+                    uint32_t expect = GPIO_INT | GPIO_INT_EDGE;
+                    if ((flags & expect) != expect) {
+                        continue;
+                    }
+
+                    if ((flags & GPIO_INT_DOUBLE_EDGE) ||
+                        ((flags & GPIO_INT_ACTIVE_HIGH) == GPIO_INT_ACTIVE_HIGH
+                         && new_level) ||
+                        ((flags & GPIO_INT_ACTIVE_LOW) == GPIO_INT_ACTIVE_LOW
+                         && !new_level)) {
+
+                        // simulate onchange interrupt
+                        uintptr_t ptr;
+                        if (jerry_get_object_native_handle(connection, &ptr)) {
+                            mock_cb_item_t *item = (mock_cb_item_t *)ptr;
+                            if (BIT(conn_pin) & item->enabled_mask) {
+                                item->handler(port, item->callback,
+                                              item->enabled_mask);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+int mock_gpio_pin_configure(DEVICE port, uint8_t pin, int flags)
+{
+    if (!find_property_with_value(mock_root_obj, port)) {
+        ERR_PRINT("invalid port object\n");
+        return -1;
+    }
+
+    // create or update pin object
+    ZVAL pin_obj = ensure_pin(port, pin);
+    zjs_set_property(pin_obj, "flags", jerry_create_number(flags));
+    zjs_set_property(pin_obj, "pin", jerry_create_number(pin));
+
+    return 0;
+}
+
+void mock_gpio_init_callback(struct gpio_callback *callback,
+                             gpio_callback_handler_t handler,
+                             uint32_t pin_mask)
+{
+    mock_cb_item_t *item = (mock_cb_item_t *)malloc(sizeof(mock_cb_item_t));
+    if (item) {
+        item->next = mock_cb_list;
+        item->callback = callback;
+        item->handler = handler;
+        item->pin_mask = pin_mask;
+        item->enabled_mask = 0;
+        item->port = 0;
+        mock_cb_list = item;
+    }
+}
+
+int mock_gpio_add_callback(DEVICE port, struct gpio_callback *callback)
+{
+    if (!find_property_with_value(mock_root_obj, port)) {
+        ERR_PRINT("invalid port object\n");
+        return -1;
+    }
+
+    mock_cb_item_t *item = mock_cb_list;
+    while (item) {
+        if (item->callback == callback) {
+            item->port = port;
+            break;
+        }
+        item = item->next;
+    }
+    return 0;
+}
+
+int mock_gpio_remove_callback(DEVICE port, struct gpio_callback *callback)
+{
+    // disable the callback for this port
+    if (!find_property_with_value(mock_root_obj, port)) {
+        ERR_PRINT("invalid port object\n");
+        return -1;
+    }
+
+    mock_cb_item_t *item = mock_cb_list;
+    while (item) {
+        if (item->callback == callback && item->port == port) {
+            item->enabled_mask = 0;
+            item = item->next;
+            break;
+        }
+        item = item->next;
+    }
+
+    return 0;
+}
+
+int mock_gpio_pin_enable_callback(DEVICE port, uint32_t pin)
+{
+    if (!find_property_with_value(mock_root_obj, port)) {
+        ERR_PRINT("invalid port object\n");
+        return -1;
+    }
+
+    ZVAL pin_obj = get_pin(port, pin);
+    if (!jerry_value_is_object(pin_obj)) {
+        ERR_PRINT("invalid pin object\n");
+        return -1;
+    }
+
+    mock_cb_item_t *item = mock_cb_list;
+    while (item) {
+        if (item->port == port) {
+            uint32_t bit = BIT(pin);
+            if (bit & item->pin_mask) {
+                item->enabled_mask |= bit;
+                jerry_set_object_native_handle(pin_obj, (uintptr_t)item, NULL);
+                // FIXME: maybe need to clean up on re-open w/o close
+                break;
+           }
+        }
+        item = item->next;
+    }
+    return 0;
+}
+
+void zjs_gpio_mock_pre_init()
+{
+    mock_root_obj = jerry_create_object();
+}
+
+void zjs_gpio_mock_post_init(jerry_value_t gpio_obj)
+{
+    // use the mock property to check for mock APIs
+    zjs_obj_add_boolean(gpio_obj, true, "mock");
+    zjs_obj_add_function(gpio_obj, zjs_gpio_mock_wire, "wire");
+}
+
+void zjs_gpio_mock_cleanup()
+{
+    jerry_release_value(mock_root_obj);
+
+    mock_cb_item_t *item = mock_cb_list;
+    while (item) {
+        mock_cb_item_t *next = item->next;
+        zjs_free(item);
+        item = next;
+    }
+}

--- a/src/zjs_gpio_mock.h
+++ b/src/zjs_gpio_mock.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifndef __zjs_gpio_mock_h__
+#define __zjs_gpio_mock_h__
+
+#if defined(ZJS_GPIO_MOCK) && !defined(__zjs_gpio_h__)
+#error zjs_gpio.h must be included before zjs_gpio_mock.h!
+#endif
+
+#include "jerryscript.h"
+
+#define DEVICE jerry_value_t
+
+struct mock_gpio_callback;
+typedef void (*mock_gpio_callback_handler_t)(DEVICE port,
+                                             struct mock_gpio_callback *cb,
+                                             uint32_t pins);
+struct mock_gpio_callback {
+    mock_gpio_callback_handler_t handler;
+    uint32_t pin_mask;
+};
+
+// redefine calls to Zephyr APIs we're mocking
+#define gpio_callback mock_gpio_callback
+#define gpio_callback_handler_t mock_gpio_callback_handler_t
+
+#define device_get_binding mock_gpio_device_get_binding
+#define gpio_pin_read mock_gpio_pin_read
+#define gpio_pin_write mock_gpio_pin_write
+#define gpio_pin_configure mock_gpio_pin_configure
+#define gpio_init_callback mock_gpio_init_callback
+#define gpio_add_callback mock_gpio_add_callback
+#define gpio_remove_callback mock_gpio_remove_callback
+#define gpio_pin_enable_callback mock_gpio_pin_enable_callback
+
+DEVICE mock_gpio_device_get_binding(const char *name);
+int mock_gpio_pin_read(DEVICE port, uint32_t pin, uint32_t *value);
+int mock_gpio_pin_write(DEVICE port, uint32_t pin, uint32_t value);
+int mock_gpio_pin_configure(DEVICE port, uint8_t pin, int flags);
+void mock_gpio_init_callback(struct gpio_callback *callback,
+                             gpio_callback_handler_t handler,
+                             uint32_t pin_mask);
+int mock_gpio_add_callback(DEVICE port, struct gpio_callback *callback);
+int mock_gpio_remove_callback(DEVICE port, struct gpio_callback *callback);
+int mock_gpio_pin_enable_callback(DEVICE port, uint32_t pin);
+
+#ifdef ZJS_LINUX_BUILD
+// provide Zephyr dependencies
+#define GPIO_DIR_IN           (0 << 0)
+#define GPIO_DIR_OUT          (1 << 0)
+#define GPIO_INT              (1 << 1)
+#define GPIO_INT_ACTIVE_LOW   (0 << 2)
+#define GPIO_INT_ACTIVE_HIGH  (1 << 2)
+#define GPIO_INT_EDGE         (1 << 5)
+#define GPIO_INT_DOUBLE_EDGE  (1 << 6)
+#define GPIO_POL_NORMAL       (0 << 7)
+#define GPIO_POL_INV          (1 << 7)
+#define GPIO_PUD_NORMAL       (0 << 8)
+#define GPIO_PUD_PULL_UP      (1 << 8)
+#define GPIO_PUD_PULL_DOWN    (2 << 8)
+
+#define BIT(n)  (1UL << (n))
+#define CONTAINER_OF(ptr, type, field) \
+	((type *)(((char *)(ptr)) - offsetof(type, field)))
+#endif  // ZJS_LINUX_BUILD
+
+// hook to initialize mock before the rest of gpio init
+void zjs_gpio_mock_pre_init();
+
+// hook to add mock functions into gpio object before it's returned to JS
+void zjs_gpio_mock_post_init(jerry_value_t gpio_obj);
+
+// hook to clean up mock after gpio cleanup
+void zjs_gpio_mock_cleanup();
+
+#endif  // __zjs_gpio_mock_h__

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -15,6 +15,9 @@
 #endif
 
 // ZJS includes
+#if defined(CONFIG_BOARD_ARDUINO_101) || defined(ZJS_LINUX_BUILD)
+#include "zjs_a101_pins.h"
+#endif
 #ifdef BUILD_MODULE_BUFFER
 #include "zjs_buffer.h"
 #endif
@@ -25,6 +28,7 @@
 #include "zjs_net.h"
 #include "zjs_web_sockets.h"
 #include "zjs_event.h"
+#include "zjs_gpio.h"
 #include "zjs_modules.h"
 #include "zjs_performance.h"
 #include "zjs_callbacks.h"
@@ -46,14 +50,12 @@
 #ifndef ZJS_LINUX_BUILD
 #include "zjs_aio.h"
 #include "zjs_ble.h"
-#include "zjs_gpio.h"
 #include "zjs_grove_lcd.h"
 #include "zjs_i2c.h"
 #include "zjs_pwm.h"
 #include "zjs_uart.h"
 #include "zjs_fs.h"
 #ifdef CONFIG_BOARD_ARDUINO_101
-#include "zjs_a101_pins.h"
 #include "zjs_ipm.h"
 #endif
 #ifdef CONFIG_BOARD_FRDM_K64F
@@ -85,9 +87,6 @@ module_t zjs_modules_array[] = {
 #ifdef BUILD_MODULE_BLE
     { "ble", zjs_ble_init, zjs_ble_cleanup },
 #endif
-#ifdef BUILD_MODULE_GPIO
-    { "gpio", zjs_gpio_init, zjs_gpio_cleanup },
-#endif
 #ifdef BUILD_MODULE_GROVE_LCD
     { "grove_lcd", zjs_grove_lcd_init, zjs_grove_lcd_cleanup },
 #endif
@@ -100,11 +99,6 @@ module_t zjs_modules_array[] = {
 #ifdef BUILD_MODULE_FS
     { "fs", zjs_fs_init, zjs_fs_cleanup },
 #endif
-#ifdef CONFIG_BOARD_ARDUINO_101
-#ifdef BUILD_MODULE_A101
-    { "arduino101_pins", zjs_a101_init },
-#endif
-#endif
 #ifdef CONFIG_BOARD_FRDM_K64F
     { "k64f_pins", zjs_k64f_init },
 #endif
@@ -113,6 +107,12 @@ module_t zjs_modules_array[] = {
     { "uart", zjs_uart_init, zjs_uart_cleanup },
 #endif
 #endif // ZJS_LINUX_BUILD
+#ifdef BUILD_MODULE_A101
+    { "arduino101_pins", zjs_a101_init },
+#endif
+#ifdef BUILD_MODULE_GPIO
+    { "gpio", zjs_gpio_init, zjs_gpio_cleanup },
+#endif
 #ifdef BUILD_MODULE_DGRAM
     { "dgram", zjs_dgram_init, zjs_dgram_cleanup },
 #endif

--- a/tests/test-gpio.js
+++ b/tests/test-gpio.js
@@ -21,7 +21,7 @@ var mark = 0;
 
 var edgeInterval = setInterval(function () {
     var count = 0;
-    pinA = gpio.open({ pin: pins.IO7 });
+    pinA = gpio.open({pin: pins.IO7});
     pinA.write(changes[mark][2]);
     pinB = gpio.open({
         pin: pins.IO8,
@@ -56,8 +56,8 @@ var edgeInterval = setInterval(function () {
 }, 2000);
 
 // test GPIO open
-pinA = gpio.open({ pin: pins.IO7 });
-pinB = gpio.open({ pin: pins.IO8, direction: "in" });
+pinA = gpio.open({pin: pins.IO7});
+pinB = gpio.open({pin: pins.IO8, direction: "in"});
 
 assert(pinA != null && typeof pinA == "object",
       "open: defined pin and default as 'out' direction");
@@ -66,7 +66,7 @@ assert(pinB != null && typeof pinB == "object",
       "open: defined pin with direction 'in'");
 
 assert.throws(function () {
-    gpio.open({ pin: 1024 });
+    gpio.open({pin: 1024});
 }, "open: invalid pin");
 
 // test GPIOPin read and write
@@ -74,6 +74,7 @@ pinA.write(true);
 bValue = pinB.read();
 assert(bValue, "gpiopin: write and read");
 
+// reading an output pin may not be valid; this is probably a bad test
 aValue = pinA.read();
 assert(aValue, "gpiopin: read output pin");
 
@@ -86,7 +87,7 @@ assert.throws(function () {
 }, "gpiopin: write invalid argument");
 
 // test activeLow
-pinB = gpio.open({ pin: pins.IO8, activeLow:true, direction: "in" });
+pinB = gpio.open({pin: pins.IO8, activeLow: true, direction: "in"});
 pinA.write(false);
 bValue = pinB.read();
 assert(bValue, "activeLow: true");

--- a/tests/test-gpio.js
+++ b/tests/test-gpio.js
@@ -2,12 +2,17 @@
 
 // Testing GPIO APIs
 
-// Pre-conditions
-console.log("Wire IO7 to IO8");
-
 var gpio = require("gpio");
 var pins = require("arduino101_pins");
 var assert = require("Assert.js");
+
+if (gpio.mock) {
+    gpio.wire(gpio.open({pin: pins.IO7}), gpio.open({pin: pins.IO8}));
+}
+else {
+    // Pre-conditions
+    console.log("Wire IO7 to IO8");
+}
 
 var pinA, pinB, aValue, bValue;
 

--- a/tests/test-gpio.js
+++ b/tests/test-gpio.js
@@ -11,7 +11,7 @@ if (gpio.mock) {
 }
 else {
     // Pre-conditions
-    console.log("Wire IO7 to IO8");
+    console.log("Hardware setup: Wire IO7 to IO8!");
 }
 
 var pinA, pinB, aValue, bValue;
@@ -57,8 +57,8 @@ var edgeInterval = setInterval(function () {
             assert.result();
             clearInterval(edgeInterval);
         }
-    }, 1000);
-}, 2000);
+    }, 100);
+}, 200);
 
 // test GPIO open
 pinA = gpio.open({pin: pins.IO7});


### PR DESCRIPTION
This patchset adds a ZJS_GPIO_MOCK #ifdef that controls whether the GPIO module uses Zephyr APIs or replaces them with mock implementations. In the latter case, it also adds a gpio.mock === True to the JS API and a wire(pin1, pin2) function that lets you simulate a wire connection from a JS test.

This lets you do hardware-dependent testing like our test-gpio.js completely in software, while running every line of our GPIO module code w/o modification.

Warning: This contains some black magic. In particular, I substituted a jerry_value_t for an opaque struct device *. I can probably come up with a cleaner way to do that, but first wanted to just get this out there for comment to see whether it's completely insane to go down this path. :)

My biggest concern is that this roughly doubled the code size of the GPIO module, which means it's roughly as likely to contain bugs as the the code itself. So now when we change the module, we may have double the maintenance burden, etc. And this was just what was needed to accomodate the test-gpio.js test case. More sophisticated mocking from JS might be desired. But it's at least an interesting experiment and something to start discussion more concretely.

I'd really like feedback!