### PR TITLE
[nRF52] Added experimental support for nRF52

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ the BOARD name:
 make JS=samples/OcfServer.js BOARD=nrf52840_pca10056
 ```
 
-You should now have a zephyr binary in `outdir/nrf52840_pca10056/`. You can
+You should now have a Zephyr binary in `outdir/nrf52840_pca10056/`. You can
 copy it to the nRF52 board with a simple `cp` command:
 ```bash
 cp outdir/nrf52840_pca10056/zephyr.bin /media/<user>/JLINK/

--- a/README.md
+++ b/README.md
@@ -309,6 +309,42 @@ install this earlier, you can do so with the command:
 sudo apt-get install node-uglify
 ```
 
+## nRF52 Platform
+This is an experimental ZJS platform and has not been tested. There should be
+no expectation that any given sample/test/application will work at all on this
+platform. The good news is that there have been ZJS networking samples run
+on the nRF52 board with success therefore we mention it here so anyone can try
+it out and contribute fixes to anything that does not work, potentially getting
+it stable enough to adopt as a supported board in the future.
+
+See the
+[Zephyr Project page](https://www.zephyrproject.org/doc/boards/arm/nrf52840_pca10056/doc/nrf52840_pca10056.html)
+for general information about running Zephyr OS on the nRF52.
+
+Connecting to serial output is quite similar to the Arduino 101, except the
+nRF52 will have an ACM port rather than USB. You can connect with minicom
+by doing:
+```bash
+minicom -D /dev/ttyACM0
+```
+
+Building is the same as any other ZJS platform, just use `nrf52840_pca10056` as
+the BOARD name:
+```bash
+make JS=samples/OcfServer.js BOARD=nrf52840_pca10056
+```
+
+You should now have a zephyr binary in `outdir/nrf52840_pca10056/`. You can
+copy it to the nRF52 board with a simple `cp` command:
+```bash
+cp outdir/nrf52840_pca10056/zephyr.bin /media/<user>/JLINK/
+```
+You should see the lights flashing on the nRF52 board. When it stops you can
+reset the board and you should see your application output on /dev/ttyACM0
+
+From here the device can be connected with BLE to a Linux machine as you do with
+an Arduino 101.
+
 ## FRDM-K64F Platform
 
 See the

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -121,7 +121,7 @@ if check_for_require net || check_config_file ZJS_NET; then
 
     if [ $BOARD = "qemu_x86" ]; then
         echo "CONFIG_NET_SLIP_TAP=y" >> $PRJFILE
-    elif [ $BOARD = "arduino_101" ]; then
+    elif [ $BOARD = "arduino_101" ] || [ $BOARD = "nrf52_pca10040" ]; then
         echo "CONFIG_BLUETOOTH=y" >> $PRJFILE
         echo "CONFIG_BLUETOOTH_SMP=y" >> $PRJFILE
         echo "CONFIG_BLUETOOTH_SIGNING=y" >> $PRJFILE
@@ -159,7 +159,7 @@ if check_for_require dgram || check_config_file ZJS_DGRAM; then
     if [ $BOARD = "qemu_x86" ]; then
         echo "CONFIG_NET_SLIP_TAP=y" >> $PRJFILE
     # BLE Options
-    elif [ $BOARD = "arduino_101" ]; then
+    elif [ $BOARD = "arduino_101" ] || [ $BOARD = "nrf52_pca10040" ]; then
         echo "CONFIG_BLUETOOTH=y" >> $PRJFILE
         echo "CONFIG_BLUETOOTH_SMP=y" >> $PRJFILE
         echo "CONFIG_BLUETOOTH_SIGNING=y" >> $PRJFILE


### PR DESCRIPTION
 - analyze was missing a case statement.
 - Zephyr BLE config options should be the same as A101

Signed-off-by: James Prestwood <james.prestwood@intel.com>