### PR TITLE
[sensor] Remove onstatechange event callback

### DIFF
--- a/modules/GenericSensor.js
+++ b/modules/GenericSensor.js
@@ -55,7 +55,6 @@ function GenericSensor() {
     }
 
     var currentState = null;
-    var StatechangeFlag = true;
     var changeFlag = false;
     var errorFlag = true;
     var defaultState, startState, stopState, middleState, middleNum;
@@ -78,25 +77,14 @@ function GenericSensor() {
         assert(sensor.state === middleState,
                "sensor: state is readonly property");
 
-        sensor.onstatechange = function(event) {
-            if (StatechangeFlag === true) {
-                assert(typeof event === "string" && event !== null,
-                       "sensor: callback value for 'onstatechange'");
+        sensor.onactivate = function() {
+            currentState = sensor.state
+            console.log("currentstate: " + currentState);
 
-                StatechangeFlag = false;
-            }
+            assert(currentState === "activated",
+                   "sensor: state is activated");
 
-            assert(currentState !== event,
-                   "sensor: '" + currentState +
-                   "' change to '" + event + "'");
-
-            currentState = sensor.state;
-            assert(typeof currentState === "string" && currentState !== null,
-                   "sensor: current state as '" + currentState + "'");
-
-            console.log("currentstate: " + event);
-
-            if (event === "activated") changeFlag = true;
+            changeFlag = true;
         };
 
         sensor.onchange = function() {

--- a/samples/AmbientLight.js
+++ b/samples/AmbientLight.js
@@ -54,8 +54,8 @@ sensor.onchange = function() {
         console.log("(full brightness): " + sensor.illuminance);
 };
 
-sensor.onstatechange = function(event) {
-    console.log("state: " + event);
+sensor.onactivate = function() {
+    console.log("activated");
 };
 
 sensor.onerror = function(event) {

--- a/samples/BMI160Accelerometer.js
+++ b/samples/BMI160Accelerometer.js
@@ -18,8 +18,8 @@ sensor.onchange = function() {
                 " z=" + sensor.z);
 };
 
-sensor.onstatechange = function(event) {
-    console.log("state: " + event);
+sensor.onactivate = function() {
+    console.log("activated");
 };
 
 sensor.onerror = function(event) {

--- a/samples/BMI160Gyroscope.js
+++ b/samples/BMI160Gyroscope.js
@@ -18,8 +18,8 @@ sensor.onchange = function() {
                 " z=" + sensor.z);
 };
 
-sensor.onstatechange = function(event) {
-    console.log("state: " + event);
+sensor.onactivate = function() {
+    console.log("activated");
 };
 
 sensor.onerror = function(event) {

--- a/samples/BMI160Temperature.js
+++ b/samples/BMI160Temperature.js
@@ -16,8 +16,8 @@ sensor.onchange = function() {
     console.log("BMI160 temperature (celsius): " + sensor.celsius);
 };
 
-sensor.onstatechange = function(event) {
-    console.log("state: " + event);
+sensor.onactivate = function() {
+    console.log("activated");
 };
 
 sensor.onerror = function(event) {

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -174,7 +174,7 @@ static void zjs_sensor_set_state(jerry_value_t obj, enum sensor_state state)
         return;
     }
 
-    // update state property and trigger onstatechange event
+    // update state property and trigger onactivate event if neccessary
     const char *state_str = NULL;
     switch(state) {
     case SENSOR_STATE_UNCONNECTED:
@@ -199,14 +199,6 @@ static void zjs_sensor_set_state(jerry_value_t obj, enum sensor_state state)
         return;
     }
     zjs_obj_add_readonly_string(obj, state_str, "state");
-
-    ZVAL func = zjs_get_property(obj, "onstatechange");
-    if (jerry_value_is_function(func)) {
-        // if onstatechange exists, call it
-        ZVAL new_state = jerry_create_string(state_str);
-        zjs_callback_id id = zjs_add_callback_once(func, obj, NULL, NULL);
-        zjs_signal_callback(id, &new_state, sizeof(new_state));
-    }
 
     if (old_state == SENSOR_STATE_ACTIVATING &&
         state == SENSOR_STATE_ACTIVATED) {

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -174,7 +174,7 @@ static void zjs_sensor_set_state(jerry_value_t obj, enum sensor_state state)
         return;
     }
 
-    // update state property and trigger onactivate event if neccessary
+    // update state property and trigger onactivate event if necessary
     const char *state_str = NULL;
     switch(state) {
     case SENSOR_STATE_UNCONNECTED:


### PR DESCRIPTION
Updating implementation and samples due to change of latest W3C spec
no longer has onstatechange.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>