### PR TITLE
[boards] New board support/docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,17 @@ else
 JERRYLIB=outdir/$(BOARD)/libjerry-core-parser.a
 endif
 
+.PHONY: flash
+flash:  analyze generate $(JERRYLIB) $(ARC)
+	@make -f Makefile.zephyr flash	BOARD=$(BOARD) \
+									VARIANT=$(VARIANT) \
+									CB_STATS=$(CB_STATS) \
+									PRINT_FLOAT=$(PRINT_FLOAT) \
+									SNAPSHOT=$(SNAPSHOT) \
+									BLE_ADDR=$(BLE_ADDR) \
+									ASHELL=$(ASHELL) \
+									NETWORK_BUILD=$(NET_BUILD)
+
 # Build for zephyr, default target
 .PHONY: zephyr
 zephyr: analyze generate $(JERRYLIB) $(ARC)

--- a/Makefile
+++ b/Makefile
@@ -158,13 +158,13 @@ endif
 .PHONY: flash
 flash:  analyze generate $(JERRYLIB) $(ARC)
 	@make -f Makefile.zephyr flash	BOARD=$(BOARD) \
-									VARIANT=$(VARIANT) \
-									CB_STATS=$(CB_STATS) \
-									PRINT_FLOAT=$(PRINT_FLOAT) \
-									SNAPSHOT=$(SNAPSHOT) \
-									BLE_ADDR=$(BLE_ADDR) \
-									ASHELL=$(ASHELL) \
-									NETWORK_BUILD=$(NET_BUILD)
+		VARIANT=$(VARIANT) \
+		CB_STATS=$(CB_STATS) \
+		PRINT_FLOAT=$(PRINT_FLOAT) \
+		SNAPSHOT=$(SNAPSHOT) \
+		BLE_ADDR=$(BLE_ADDR) \
+		ASHELL=$(ASHELL) \
+		NETWORK_BUILD=$(NET_BUILD)
 
 # Build for zephyr, default target
 .PHONY: zephyr

--- a/README.md
+++ b/README.md
@@ -633,23 +633,35 @@ For additional information, see [here](https://www.zephyrproject.org/doc/getting
 There is only partial support for modules on Linux compared to Zephyr. Any hardware
 specific module (I2C, UART, GPIO, ADC etc.) is not supported on Linux. Trying
 to run a Zephyr specific module on Linux will result in the JavaScript not running
-successfully. Below is a complete table of modules and target support.
+successfully. Below is a complete table of modules and target support. Some
+Zephyr targets listed are experimental and have not been fully tested. For this
+reason we have the following possibilities for support:
 
-| Module    | Linux                    | Zephyr                   |
-| :---:     | :---:                    | :---:                    |
-|  ADC      | <ul><li>- [ ] </li></ul> | <ul><li>- [x] </li></ul> |
-|  PWM      | <ul><li>- [ ] </li></ul> | <ul><li>- [x] </li></ul> |
-|  GPIO     | <ul><li>- [ ] </li></ul> | <ul><li>- [x] </li></ul> |
-|  I2C      | <ul><li>- [ ] </li></ul> | <ul><li>- [x] </li></ul> |
-|  BLE      | <ul><li>- [ ] </li></ul> | <ul><li>- [x] </li></ul> |
-|  UART     | <ul><li>- [ ] </li></ul> | <ul><li>- [x] </li></ul> |
-| Sensor    | <ul><li>- [ ] </li></ul> | <ul><li>- [x] </li></ul> |
-| Buffer    | <ul><li>- [x] </li></ul> | <ul><li>- [x] </li></ul> |
-| Console   | <ul><li>- [x] </li></ul> | <ul><li>- [x] </li></ul> |
-| Event     | <ul><li>- [x] </li></ul> | <ul><li>- [x] </li></ul> |
-| OCF       | <ul><li>- [x] </li></ul> | <ul><li>- [x] </li></ul> |
-|Performance| <ul><li>- [x] </li></ul> | <ul><li>- [x] </li></ul> |
-| Timers    | <ul><li>- [x] </li></ul> | <ul><li>- [x] </li></ul> |
+* X - Supported
+* E - Experimental, not formally tested by QA but basic functionality verified.
+* NT - Not tested at all
+* Blank - Not Supported
+
+| Module    | Linux | Arduino 101 | K64F  | nRF52 | Arduino DUE | ST F411RE |
+| :---:     | :---: |    :---:    | :---: | :---: |    :---:    |   :---:   |
+|HelloWorld |   X   |      X      |   X   |    X  |      X      |     X     |
+|  ADC      |       |      X      |   X   |   NT  |      NT     |     NT    |
+|  PWM      |       |      X      |   X   |   NT  |      NT     |     NT    |
+|  GPIO     |       |      X      |   X   |   E   |      NT     |     NT    |
+|  I2C      |       |      X      |   X   |   NT  |      NT     |     NT    |
+|  BLE      |       |      X      |       |   NT  |             |           |
+|  UART     |       |      X      |   X   |   NT  |      NT     |     NT    |
+| Sensor    |       |      X      |       |       |             |           |
+| Buffer    |   X   |      X      |   X   |   E   |      E      |     E     |
+| Console   |   X   |      X      |   X   |   E   |      E      |     E     |
+| Event     |   X   |      X      |   X   |   E   |      E      |     E     |
+|File System|       |      X      |       |       |             |           |
+| OCF       |   X   |      X      |   NT  |   E   |             |           |
+|Performance|   X   |      X      |   X   |   E   |      E      |     E     |
+| Timers    |   X   |      X      |   X   |   E   |      E      |     E     |
+| Dgram     |       |      X      |   NT  |   NT  |             |           |
+| Net       |       |      X      |   NT  |   NT  |             |           |
+| WebSocket |       |      X      |   NT  |   NT  |             |           |
 
 ## Networking with QEMU
 QEMU has support for networking features that can be tested on your Linux

--- a/README.md
+++ b/README.md
@@ -645,8 +645,8 @@ reason we have the following possibilities for support:
 | Module    | Linux | Arduino 101 | K64F  | nRF52 | Arduino DUE | ST F411RE |
 | :---:     | :---: |    :---:    | :---: | :---: |    :---:    |   :---:   |
 |HelloWorld |   X   |      X      |   X   |    X  |      X      |     X     |
-|  ADC      |       |      X      |   X   |   NT  |      NT     |     NT    |
-|  PWM      |       |      X      |   X   |   NT  |      NT     |     NT    |
+|  ADC      |       |      X      |       |   NT  |      NT     |     NT    |
+|  PWM      |       |      X      |       |   NT  |      NT     |     NT    |
 |  GPIO     |       |      X      |   X   |   E   |      NT     |     NT    |
 |  I2C      |       |      X      |   X   |   NT  |      NT     |     NT    |
 |  BLE      |       |      X      |       |   NT  |             |           |

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -345,9 +345,9 @@ if check_for_require uart || check_config_file ZJS_UART; then
             echo "CONFIG_USB_CDC_ACM=y" >> $PRJFILE
         fi
         echo "CONFIG_SYS_LOG_USB_LEVEL=0" >> $PRJFILE
-        echo "CONFIG_SERIAL=y" >> $PRJFILE
         echo "CONFIG_UART_LINE_CTRL=y" >> $PRJFILE
     fi
+    echo "CONFIG_SERIAL=y" >> $PRJFILE
     echo "CONFIG_UART_INTERRUPT_DRIVEN=y" >> $PRJFILE
     MODULES+=" -DBUILD_MODULE_UART"
     MODULES+=" -DBUILD_MODULE_EVENTS"
@@ -397,10 +397,12 @@ if check_for_require fs || check_config_file ZJS_FS; then
     MODULES+=" -DBUILD_MODULE_FS -DBUILD_MODULE_BUFFER"
     if [ $BOARD = "arduino_101" ]; then
         echo "CONFIG_FS_FAT_FLASH_DISK_W25QXXDV=y" >> $PRJFILE
+        echo "CONFIG_DISK_ACCESS_FLASH=y" >> $PRJFILE
+    else
+        echo "CONFIG_DISK_ACCESS_RAM=y" >> $PRJFILE
     fi
     echo "CONFIG_FILE_SYSTEM=y" >> $PRJFILE
     echo "CONFIG_FILE_SYSTEM_FAT=y" >> $PRJFILE
-    echo "CONFIG_DISK_ACCESS_FLASH=y" >> $PRJFILE
 
     echo "CONFIG_FLASH=y" >> $PRJFILE
     echo "CONFIG_SPI=y" >> $PRJFILE


### PR DESCRIPTION
 - Added 'flash' target to make to support BOARD=nucleo_f411re
 - Moved around analyze.sh lines for UART/FS for possible
   support on other targets
 - Added more info in README about supported boards and features

Signed-off-by: James Prestwood <james.prestwood@intel.com>