### PR TITLE
[sensor] Support polling mode for Ashell

### DIFF
--- a/fragments/zjs.conf.dev
+++ b/fragments/zjs.conf.dev
@@ -12,8 +12,11 @@ ZJS_I2C=y
 #ZJS_OCF=y
 ZJS_PERFORMANCE=y
 ZJS_PWM=y
-# Note: enabling sensor will disable GPIO input on all pins.
-#ZJS_SENSOR=y
+ZJS_SENSOR=y
+ZJS_SENSOR_ACCEL=y
+ZJS_SENSOR_GYRO=y
+ZJS_SENSOR_LIGHT=y
+ZJS_SENSOR_TEMP=y
 ZJS_TIMERS=y
 ZJS_UART=y
 ZJS_FS=y

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -536,6 +536,7 @@ void zjs_sensor_cleanup()
         }
         mod->cleanup();
     }
+    jerry_release_value(zjs_sensor_prototype);
 }
 
 #endif // QEMU_BUILD


### PR DESCRIPTION
Polling mode is enabled by default when GPIO module is
enabled, instead of using triggers to monitor change events,
the ARC will poll the sensor data, this patch will allow
Ashell to have both GPIO and Sensor enabled.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>