### PR TITLE
[main] Quick fix: Timer added in callback goes unnoticed

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -204,6 +204,13 @@ int main(int argc, char *argv[])
         int32_t wait_time = ZJS_TICKS_FOREVER;
         uint8_t serviced = 0;
 
+        // callback cannot return a wait time
+        if (zjs_service_callbacks()) {
+            // when this was only called at the end, if a callback created a
+            //   timer, it would think there were no timers and block forever
+            // FIXME: need to consider the chicken and egg problems here
+            serviced = 1;
+        }
         uint64_t wait = zjs_timers_process_events();
         if (wait != ZJS_TICKS_FOREVER) {
             serviced = 1;


### PR DESCRIPTION
The semaphore change recently broke some things. This showed up for me
in samples/AlarmClock.js but also may be the root cause of part of

Timers were being checked first, then callbacks, so if for example a
GPIO input interrupt came that caused a callback, and that callback
set a timer, it still thought there were no timers. This fix may or
may not be sufficient, but it's probably not the best way to do it
and the problem should be considered more carefully.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>