### PR TITLE
[ashell] Add echo command to turn on/off printing commands on the console

### DIFF
--- a/docs/ashell.md
+++ b/docs/ashell.md
@@ -47,30 +47,43 @@ below instructions to connect to the device from the browser IDE directly.
      ```bash
      $ sudo udevadm control --reload-rules
      ```
-  * Disable ModemManager to stop interfering when the browser accessing the device.
-     ```bash
-     $ sudo service modemmanager stop
-     ```
+  * Blacklist the device using udev rule or disable ModemManager to stop interfering
+    when the browser accessing the device.
 
-     If you get the message "Unit modemmanager.service not loaded." try this instead:
+    * To blacklist the device: Add the following line in /etc/udev/rules.d/99-arduino-101.rules
 
-    ```bash
-    $ sudo service ModemManager stop
-    ```
+      `SUBSYSTEM=="usb", ATTRS{idVendor}=="8086" ATTRS{idProduct}=="f8a1", ENV{ID_MM_DEVICE_IGNORE}="1"`
 
-4. On Windows:
+      Then run this command:
+      ```bash
+      $ sudo udevadm control --reload-rules
+      ```
+
+      or
+
+    * To disable the ModemManager:
+       ```bash
+       $ sudo service modemmanager stop
+       ```
+
+       If you get the message "Unit modemmanager.service not loaded." try this instead:
+       ```bash
+       $ sudo service ModemManager stop
+       ```
+
+3. On Windows:
   * WebUSB compatible device is not appearing with the official WinUSB driver on
     Windows for some reason, so try installing different version of WinUSB driver
     with the Zadig utility. Also, note that the landing page detection is disabled
     on Windows on Chrome startup so you don't see a notification when the device is
     connected to the host, but the WebUSB will continue to work.
 
-5. Connect the device to the host PC using a USB cable.
-6. A notification from Chrome will appear with an URL of the IDE. If not, the
+4. Connect the device to the host PC using a USB cable.
+5. A notification from Chrome will appear with an URL of the IDE. If not, the
     address for the IDE is https://01org.github.io/zephyrjs-ide.
-7. Click on the notification to open IDE in the browser.
-8. Click on connect button and grant an access to the device.
-9. Try uploading JS code to the device.
+6. Click on the notification to open IDE in the browser.
+7. Click on connect button and grant an access to the device.
+8. Try uploading JS code to the device.
 
 Commands
 --------

--- a/src/ashell/comms-shell.c
+++ b/src/ashell/comms-shell.c
@@ -542,7 +542,7 @@ uint32_t ashell_process_finish()
 
 void ashell_print_status()
 {
-    printk("Shell Status\n");
+    DBG("Shell Status\n");
 
     malloc_stats();
 

--- a/src/ashell/comms-shell.c
+++ b/src/ashell/comms-shell.c
@@ -48,11 +48,13 @@ const char *comms_get_prompt()
 
 #define MAX_LINE 90
 #define MAX_ARGUMENT_SIZE 32
+#define CMD_ECHO_OFF "echo off\n"
 
 static ashell_line_parser_t app_line_cb = NULL;
 static char *shell_line = NULL;
 static uint8_t tail = 0;
 static bool ashell_is_done = false;
+static bool echo_mode = true;
 
 static inline void cursor_forward(unsigned int count)
 {
@@ -81,7 +83,8 @@ static void insert_char(char *pos, char c, uint8_t end)
     char tmp;
 
     /* Echo back to console */
-    comms_writec(c);
+    if (echo_mode)
+        comms_writec(c);
 
     if (end == 0) {
         *pos = c;
@@ -415,6 +418,11 @@ uint32_t ashell_process_data(const char *buf, uint32_t len)
         tail = 0;
     }
 
+    /* Don't send back the 'echo off' command */
+    if (!strcmp(CMD_ECHO_OFF, buf)) {
+        echo_mode = false;
+    }
+
     while (len-- > 0) {
         processed++;
         uint8_t byte = *buf++;
@@ -518,6 +526,11 @@ uint32_t ashell_process_data(const char *buf, uint32_t len)
 bool ashell_process_is_done()
 {
     return ashell_is_done;
+}
+
+void comms_set_echo_mode(bool mode)
+{
+    echo_mode = mode;
 }
 
 uint32_t ashell_process_finish()

--- a/src/ashell/comms-shell.h
+++ b/src/ashell/comms-shell.h
@@ -5,6 +5,7 @@
 
 void comms_set_prompt(const char *prompt);
 const char *comms_get_prompt();
+void comms_set_echo_mode(bool echo_mode);
 
 /**
  * Callback function when a line arrives

--- a/src/ashell/comms-shell.h
+++ b/src/ashell/comms-shell.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef __comms_shell_h__
 #define __comms_shell_h__

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -377,7 +377,6 @@ uint32_t comms_get_baudrate(void)
 
 void comms_print_status()
 {
-    printk("******* SYSTEM STATE ********\n");
     if (atomic_get(&uart_state) == UART_INIT)
         printk(ANSI_FG_RED "JavaScript terminal not connected\n" ANSI_FG_RESTORE);
 

--- a/src/ashell/ihex-handler.c
+++ b/src/ashell/ihex-handler.c
@@ -164,7 +164,9 @@ uint32_t ihex_process_finish()
     ihex_end_read(&ihex);
     comms_print("[EOF]\n");
 
+#ifdef CONFIG_IHEX_UPLOADER_DEBUG
     printf("Saved file '%s'\n", TEMPORAL_FILENAME);
+#endif
 
     ashell_process_start();
     return 0;

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -41,10 +41,8 @@ static struct shell_state_config shell = {
     .state_flags = kShellTransferRaw
 };
 
-const char ERROR_NOT_RECOGNIZED[] = "Unknown command";
 const char ERROR_NOT_ENOUGH_ARGUMENTS[] = "Not enough arguments";
 const char ERROR_FILE_NOT_FOUND[] = "File not found";
-const char ERROR_EXCEDEED_SIZE[] = "String too long";
 
 const char MSG_FILE_SAVED[] =
      ANSI_FG_GREEN "Saving file. " ANSI_FG_RESTORE
@@ -115,13 +113,11 @@ int32_t ashell_remove_file(char *buf)
 
 int32_t ashell_remove_dir(char *buf)
 {
-    printf("rmdir: Not implemented \n");
     return RET_OK;
 }
 
 int32_t ashell_make_dir(char *buf)
 {
-    printf("mkdir: Not implemented \n");
     return RET_OK;
 }
 

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -438,6 +438,18 @@ int32_t ashell_raw_capture(const char *buf, uint32_t len)
     return RET_OK_NO_RET;
 }
 
+int32_t ashell_set_echo_mode(char *buf)
+{
+    if (!strcmp("on", buf)) {
+        comms_println("echo_on");
+        comms_set_echo_mode(true);
+    } else if (!strcmp("off", buf)) {
+        comms_println("echo_off");
+        comms_set_echo_mode(false);
+    }
+    return RET_OK;
+}
+
 int32_t ashell_read_data(char *buf)
 {
     if (shell.state_flags & kShellTransferIhex) {
@@ -634,6 +646,7 @@ static const struct ashell_cmd commands[] =
     ASHELL_COMMAND("error", "Prints an error using JerryScript"              ,ashell_error),
     ASHELL_COMMAND("ping",  "Prints '[PONG]' to check that we are alive"     ,ashell_ping),
     ASHELL_COMMAND("at",    "OK used by the driver when initializing"        ,ashell_at),
+    ASHELL_COMMAND("echo",  "[on/off] Sets console echo mode on/off"         ,ashell_set_echo_mode),
 
     ASHELL_COMMAND("set",   "Sets the input mode for 'load' accept data\r\n\ttransfer raw\r\n\ttransfer ihex\t",ashell_set_state),
     ASHELL_COMMAND("get",   "Get states on the shell"                        ,ashell_get_state),


### PR DESCRIPTION
Add ashell echo command to turn on/off printing JS transfer commands on the console. Also, update ashell docs to mention how to blacklist the device from ModemManager.