### PR TITLE
[build] Update latest Zephyr to remove debug fix for AIO

### DIFF
--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -94,7 +94,7 @@ static int ipm_send_error(struct zjs_ipm_message *msg,
 {
     msg->flags |= MSG_ERROR_FLAG;
     msg->error_code = error_code;
-    DBG_PRINT("send error %lu\n", msg->error_code);
+    DBG_PRINT("send error %u\n", msg->error_code);
     return zjs_ipm_send(msg->id, msg);
 }
 
@@ -139,12 +139,12 @@ static void queue_message(struct zjs_ipm_message *incoming_msg)
         return;
     }
 
-    k_sem_take(&arc_sem, TICKS_UNLIMITED);
-    while (msg && msg < end_of_queue_ptr) {
-        if (msg->id == MSG_ID_DONE) {
-            break;
-        }
-        msg++;
+    k_sem_take(&arc_sem, K_FOREVER);
+    while(msg && msg < end_of_queue_ptr) {
+       if (msg->id == MSG_ID_DONE) {
+           break;
+       }
+       msg++;
     }
 
     if (msg != end_of_queue_ptr) {
@@ -903,7 +903,7 @@ static void handle_sensor_light(struct zjs_ipm_message* msg)
     uint32_t pin;
     uint32_t error_code = ERROR_IPM_NONE;
 
-    switch(msg->type) {
+    switch (msg->type) {
     case TYPE_SENSOR_INIT:
         // INIT
         break;
@@ -913,7 +913,7 @@ static void handle_sensor_light(struct zjs_ipm_message* msg)
             ERR_PRINT("pin #%u out of range\n", pin);
             error_code = ERROR_IPM_OPERATION_FAILED;
         } else {
-            DBG_PRINT("start ambient light %lu\n", msg->data.sensor.pin);
+            DBG_PRINT("start ambient light %u\n", msg->data.sensor.pin);
             light_send_updates[pin - ARC_AIO_MIN] = 1;
         }
         break;
@@ -923,7 +923,7 @@ static void handle_sensor_light(struct zjs_ipm_message* msg)
             ERR_PRINT("pin #%u out of range\n", pin);
             error_code = ERROR_IPM_OPERATION_FAILED;
         } else {
-            DBG_PRINT("stop ambient light %lu\n", msg->data.sensor.pin);
+            DBG_PRINT("stop ambient light %u\n", msg->data.sensor.pin);
             light_send_updates[pin - ARC_AIO_MIN] = 0;
         }
         break;

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -36,10 +36,6 @@ if [ -f $FEATUREFILE ]; then
 fi
 mkdir -p outdir/$BOARD/ && cp fragments/jerry_feature.base $FEATUREFILE
 
-if [ -n "$ZEPHYR_SDK_INSTALL_DIR" ]; then
-SDK_VERSION=$(cat ${ZEPHYR_SDK_INSTALL_DIR}/sdk_version)
-fi
-
 echo "# Modules found in $SCRIPT:" > $PRJFILE
 echo "# Modules found in $SCRIPT:" > $ARCPRJFILE
 tmpstr="# ZJS flags set by analyze.sh"
@@ -379,12 +375,6 @@ if check_for_require aio || check_config_file ZJS_AIO; then
     >&2 echo Using module: AIO
     MODULES+=" -DBUILD_MODULE_AIO"
     echo "CONFIG_ADC=y" >> $ARCPRJFILE
-    # Workaround for the Zephyr issue ZEP-1882: ADC doesn't work with
-    # SDK 0.9 due to some compiler optimization, so enable debug mode.
-    if [ $SDK_VERSION = "0.9" ]; then
-        >&2 echo Warning: Zephyr SDK 0.9 detected, compiling in debug mode!
-        echo "CONFIG_DEBUG=y" >> $ARCPRJFILE
-    fi
     echo "export ZJS_AIO=y" >> $CONFFILE
 fi
 
@@ -532,12 +522,6 @@ if check_for_feature "Accelerometer\|Gyroscope\|AmbientLightSensor\|TemperatureS
         fi
         if $sensor_light; then
             echo "CONFIG_ADC=y" >> $ARCPRJFILE
-            # Workaround for the Zephyr issue ZEP-1882: ADC doesn't work with
-            # SDK 0.9 due to some compiler optimization, so enable debug mode.
-            if [ $SDK_VERSION = "0.9" ]; then
-                >&2 echo Warning: Zephyr SDK 0.9 detected, compiling in debug mode!
-                echo "CONFIG_DEBUG=y" >> $ARCPRJFILE
-            fi
         fi
     fi
 fi

--- a/src/ashell/Makefile
+++ b/src/ashell/Makefile
@@ -8,11 +8,11 @@ endif
 DEPS_BASE ?= $(ZJS_BASE)/deps
 ZEPHYRINCLUDE += -I$(JERRY_INCLUDE) -I$(DEPS_BASE)
 ifneq ($(CONFIG_USB_CDC_ACM),y)
-ZEPHYRINCLUDE += -I$(ZEPHYR_BASE)/samples/usb/webusb/src \
+ZEPHYRINCLUDE += -I$(ZEPHYR_BASE)/samples/subsys/usb/webusb/src \
                  -I${ZEPHYR_BASE}/include/drivers/usb \
                  -I${ZEPHYR_BASE}/subsys/usb/class \
                  -I$(ZEPHYR_BASE)/include/usb
-obj-y += ../../deps/zephyr/samples/usb/webusb/src/webusb_serial.o
+obj-y += ../../deps/zephyr/samples/subsys/usb/webusb/src/webusb_serial.o
 obj-y += webusb-handler.o
 endif
 

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -11,8 +11,6 @@
  * Hooks into the printk and fputc (for printf) modules. Poll driven.
  */
 
-#include <nanokernel.h>
-
 #include <arch/cpu.h>
 
 #include <stdbool.h>

--- a/src/ashell/file-utils.c
+++ b/src/ashell/file-utils.c
@@ -7,7 +7,6 @@
 * this is a basic stub, do not expect a full implementation.
 */
 
-#include <nanokernel.h>
 #include <arch/cpu.h>
 #include <fs.h>
 

--- a/src/ashell/ihex-handler.c
+++ b/src/ashell/ihex-handler.c
@@ -8,8 +8,7 @@
  * Designed to be used from Javascript or a ECMAScript object file.
  */
 
-#include <nanokernel.h>
-
+#include <zephyr.h>
 #include <stdio.h>
 #include <misc/printk.h>
 

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -142,10 +142,10 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
             zjs_signal_callback(handle->callback_id, &num, sizeof(num));
             break;
         case TYPE_AIO_PIN_SUBSCRIBE:
-            DBG_PRINT("subscribed to events on pin %lu\n", pin);
+            DBG_PRINT("subscribed to events on pin %u\n", pin);
             break;
         case TYPE_AIO_PIN_UNSUBSCRIBE:
-            DBG_PRINT("unsubscribed to events on pin %lu\n", pin);
+            DBG_PRINT("unsubscribed to events on pin %u\n", pin);
             break;
 
         default:
@@ -161,7 +161,7 @@ static ZJS_DECL_FUNC(zjs_aio_pin_read)
     zjs_obj_get_uint32(this, "pin", &pin);
 
     if (pin < ARC_AIO_MIN || pin > ARC_AIO_MAX) {
-        DBG_PRINT("PIN: #%lu\n", pin);
+        DBG_PRINT("PIN: #%u\n", pin);
         return zjs_error("zjs_aio_pin_read: pin out of range");
     }
 

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -202,7 +202,7 @@ bool zjs_remove_callback_list_func(zjs_callback_id id, jerry_value_t js_func)
         }
         UNLOCK();
     }
-    DBG_PRINT("could not remove callback %ld\n", (uint32_t)id);
+    DBG_PRINT("could not remove callback %u\n", id);
     return false;
 }
 
@@ -351,7 +351,7 @@ zjs_callback_id add_callback_priv(jerry_value_t js_func,
         cb_size++;
     }
 
-    DBG_PRINT("adding new callback id %d, js_func=%lu, once=%u\n",
+    DBG_PRINT("adding new callback id %d, js_func=%u, once=%u\n",
               new_cb->id, new_cb->js_func, once);
 
 #ifdef DEBUG_BUILD
@@ -438,7 +438,7 @@ void signal_callback_priv(zjs_callback_id id,
 #endif
 {
     LOCK();
-    DBG_PRINT("pushing item to ring buffer. id=%d, args=%p, size=%lu\n", id,
+    DBG_PRINT("pushing item to ring buffer. id=%d, args=%p, size=%u\n", id,
               args, size);
     if (id < 0 || id > cb_size || !cb_map[id]) {
         DBG_PRINT("callback ID %u does not exist\n", id);
@@ -521,7 +521,7 @@ void print_callbacks(void)
                 if (cb_map[i]->func_list == NULL &&
                     jerry_value_is_function(cb_map[i]->js_func)) {
                     ZJS_PRINT("Single Function\n");
-                    ZJS_PRINT("\tjs_func: %lu\n", cb_map[i]->js_func);
+                    ZJS_PRINT("\tjs_func: %u\n", cb_map[i]->js_func);
                     ZJS_PRINT("\tonce: %u\n", GET_ONCE(cb_map[i]->flags));
                 } else {
                     ZJS_PRINT("List\n");

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -87,7 +87,7 @@ static zjs_timer_t *add_timer(uint32_t interval,
 
     ZJS_LIST_APPEND(zjs_timer_t, zjs_timers, tm);
 
-    DBG_PRINT("add timer, id=%d, interval=%lu, repeat=%u, argv=%p, argc=%lu\n",
+    DBG_PRINT("add timer, id=%d, interval=%u, repeat=%u, argv=%p, argc=%u\n",
               tm->callback_id, interval, repeat, argv, argc);
     zjs_port_timer_start(&tm->timer, interval);
     return tm;
@@ -185,7 +185,7 @@ int32_t zjs_timers_process_events()
         }
         else if (zjs_port_timer_test(&tm->timer) > 0) {
             // timer has expired, signal the callback
-            DBG_PRINT("signaling timer. id=%d, argv=%p, argc=%lu\n",
+            DBG_PRINT("signaling timer. id=%d, argv=%p, argc=%u\n",
                     tm->callback_id, tm->argv, tm->argc);
             zjs_signal_callback(tm->callback_id, tm->argv,
                                 tm->argc * sizeof(jerry_value_t));

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -264,7 +264,7 @@ char *zjs_alloc_from_jstring(jerry_value_t jstr, jerry_size_t *maxlen)
 
     if (maxlen) {
         if (*maxlen && *maxlen < len) {
-            DBG_PRINT("string limited to %lu bytes\n", *maxlen);
+            DBG_PRINT("string limited to %u bytes\n", *maxlen);
             buffer[*maxlen] = '\0';
         }
         else {
@@ -559,7 +559,7 @@ int zjs_validate_args(const char *expectations[], const jerry_length_t argc,
     }
 
     if (arg_index < argc) {
-        DBG_PRINT("API received %lu unexpected arg(s)\n", argc - arg_index);
+        DBG_PRINT("API received %u unexpected arg(s)\n", argc - arg_index);
     }
     return opt_args;
 }


### PR DESCRIPTION
The latest Zephyr has a work-around to use -O2 instead of -Os to build
the ARC so it does not need debug build for AIO to function properly.

Reverted previous fix to turn on debug build and rebased code on
new Zephyr tree.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>