### PR TITLE
[BLE] Fixes disconnect callback not getting called

### DIFF
--- a/docs/ble.md
+++ b/docs/ble.md
@@ -33,7 +33,7 @@ specific API functions.
 
 [NoInterfaceObject]
 interface BLE {
-    void disconnect();
+    void disconnect(string address);
     void on(string eventType, EventCallback callback);
     void startAdvertising(string name, string[] uuids, string url);
     void stopAdvertising();
@@ -94,9 +94,11 @@ API Documentation
 -----------------
 ### BLE.disconnect
 
-`void disconnect();`
+`void disconnect(string address);`
 
 Disconnect the remote client.
+
+The `address` is the address of the connected client.
 
 ### BLE.on
 

--- a/tests/test-ble.js
+++ b/tests/test-ble.js
@@ -192,9 +192,7 @@ ble.on('accept', function (clientAddress) {
 
     if (stopFlag) {
         setTimeout(function () {
-            // FIXME: this function actually requires a string argument but
-            //   that's not documented
-            ble.disconnect();
+            ble.disconnect(clientAddress);
             console.log("please connect again");
         }, 1000);
     }


### PR DESCRIPTION
The issue is that the c callback is immediately removed
after the callback is signaled, and the main loop have not
serviced the callback yet.  We don't need to keep a separate
callback for each connection anyway, so instead use
a singal C callback for connect and disconnects.

Fixes #1088

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>