### PR TITLE
[ashell] Fixing duplicate characters on UART

### DIFF
--- a/src/ashell/comms-shell.c
+++ b/src/ashell/comms-shell.c
@@ -57,23 +57,23 @@ static bool echo_mode = true;
 static inline void cursor_forward(unsigned int count)
 {
     for (int t = 0; t < count; t++)
-        comms_print("\x1b[1C", false);
+        comms_print("\x1b[1C");
 }
 
 static inline void cursor_backward(unsigned int count)
 {
     for (int t = 0; t < count; t++)
-        comms_print("\x1b[1D", false);
+        comms_print("\x1b[1D");
 }
 
 static inline void cursor_save(void)
 {
-    comms_print("\x1b[s", false);
+    comms_print("\x1b[s");
 }
 
 static inline void cursor_restore(void)
 {
-    comms_print("\x1b[u", false);
+    comms_print("\x1b[u");
 }
 
 static void insert_char(char *pos, char c, uint8_t end)
@@ -107,13 +107,11 @@ static void insert_char(char *pos, char c, uint8_t end)
 
 static void del_char(char *pos, uint8_t end)
 {
-    char bs = '\b';
-    char space = ' ';
-    comms_write_buf(&bs, 1);
+    comms_write_buf("\b", 1);
 
     if (end == 0) {
-        comms_write_buf(&space, 1);
-        comms_write_buf(&bs, 1);
+        comms_write_buf(" ", 1);
+        comms_write_buf("\b", 1);
         return;
     }
 
@@ -124,7 +122,7 @@ static void del_char(char *pos, uint8_t end)
         comms_write_buf((pos++), 1);
     }
 
-    comms_write_buf(&space, 1);
+    comms_write_buf(" ", 1);
 
     /* Move cursor back to right place */
     cursor_restore();
@@ -402,14 +400,13 @@ void ashell_process_line(const char *buf, uint32_t len)
 #else
     printk("\n%s", system_get_prompt());
 #endif
-    comms_print(comms_get_prompt(), false);
+    comms_print(comms_get_prompt());
 }
 
 uint32_t ashell_process_data(const char *buf, uint32_t len)
 {
     uint32_t processed = 0;
     bool flush_line = false;
-    char tab = '\t';
     if (shell_line == NULL) {
         DBG("[Process]%d\n", (int)len);
         DBG("[%s]\n", buf);
@@ -470,7 +467,7 @@ uint32_t ashell_process_data(const char *buf, uint32_t len)
                 flush_line = true;
                 break;
             case ASCII_TAB:
-                comms_write_buf(&tab, 1);
+                comms_write_buf("\t", 1);
                 break;
             case ASCII_IF:
                 flush_line = true;

--- a/src/ashell/comms-shell.c
+++ b/src/ashell/comms-shell.c
@@ -400,6 +400,7 @@ void ashell_process_line(const char *buf, uint32_t len)
 #else
     printk("\n%s", system_get_prompt());
 #endif
+    comms_print("\r\n");
     comms_print(comms_get_prompt());
 }
 

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -309,12 +309,9 @@ void comms_write_buf(const char *buf, int len)
     while (data_transmitted == false);
     uart_irq_tx_disable(dev_upload);
 }
-void comms_print(const char *buf, bool newline)
+void comms_print(const char *buf)
 {
     comms_write_buf(buf, strnlen(buf, MAX_LINE_LEN));
-
-    if (newline)
-        comms_write_buf("\r\n", 2);
 }
 
 /**
@@ -378,7 +375,7 @@ void comms_runner_init()
     setbuf(stdout, NULL);
 
     ashell_help("");
-    comms_print(comms_get_prompt(), false);
+    comms_print(comms_get_prompt());
     process_state = 0;
 
     atomic_set(&uart_state, UART_INIT);

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -284,7 +284,8 @@ static void comms_interrupt_handler(struct device *dev)
 
 static int comms_out(int c)
 {
-    comms_write_buf((char*)((int*)&c), 1);
+    char ch = (char)c;
+    comms_write_buf(&ch, 1);
     return 1;
 }
 

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -148,21 +148,6 @@ void fifo_recycle_buffer(struct comms_input *data)
     }
     k_fifo_put(&avail_queue, data);
 }
-void comms_clear(void)
-{
-    void *data = NULL;
-    do {
-        if (data != NULL)
-            zjs_free(data);
-        data = k_fifo_get(&avail_queue, K_NO_WAIT);
-    } while (data);
-
-    do {
-        if (data != NULL)
-            zjs_free(data);
-        data = k_fifo_get(&data_queue, K_NO_WAIT);
-    } while (data);
-}
 
 /**************************** UART CAPTURE **********************************/
 
@@ -233,10 +218,6 @@ static void comms_interrupt_handler(struct device *dev)
             bytes_received += bytes_read;
             tail += bytes_read;
 
-            for (uint32_t t = 0; t<bytes_read; t++) {
-                printk("%c",buf[t]);
-            }
-
             /* We don't want to flush data too fast otherwise we would be allocating
             * but we want to flush as soon as we have processed the data on the task
             * so we don't queue too much and delay the system response.
@@ -303,7 +284,7 @@ static void comms_interrupt_handler(struct device *dev)
 
 static int comms_out(int c)
 {
-    comms_writec((char)c);
+    comms_write_buf((char*)((int*)&c), 1);
     return 1;
 }
 
@@ -322,31 +303,18 @@ void comms_write_buf(const char *buf, int len)
     if (len == 0)
         return;
 
-    struct device *dev = dev_upload;
-    uart_irq_tx_enable(dev);
-
+    uart_irq_tx_enable(dev_upload);
     data_transmitted = false;
-    uart_fifo_fill(dev, buf, len);
-
+    uart_fifo_fill(dev_upload, (const uint8_t *)buf, len);
     while (data_transmitted == false);
-
-    uart_irq_tx_disable(dev);
+    uart_irq_tx_disable(dev_upload);
 }
-
-void comms_writec(char byte)
-{
-    comms_write_buf(&byte, 1);
-}
-
-void comms_print(const char *buf)
-{
-    comms_write_buf(buf, strnlen(buf, MAX_LINE_LEN * 4));
-}
-
-void comms_println(const char *buf)
+void comms_print(const char *buf, bool newline)
 {
     comms_write_buf(buf, strnlen(buf, MAX_LINE_LEN));
-    comms_write_buf("\r\n", 2);
+
+    if (newline)
+        comms_write_buf("\r\n", 2);
 }
 
 /**
@@ -410,7 +378,7 @@ void comms_runner_init()
     setbuf(stdout, NULL);
 
     ashell_help("");
-    comms_print(comms_get_prompt());
+    comms_print(comms_get_prompt(), false);
     process_state = 0;
 
     atomic_set(&uart_state, UART_INIT);

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -305,7 +305,12 @@ void comms_write_buf(const char *buf, int len)
 
     uart_irq_tx_enable(dev_upload);
     data_transmitted = false;
-    uart_fifo_fill(dev_upload, (const uint8_t *)buf, len);
+    int bytes = 0;
+    while (bytes != len) {
+        buf += bytes;
+        len -= bytes;
+        bytes = uart_fifo_fill(dev_upload, (const uint8_t *)buf, len);
+    }
     while (data_transmitted == false);
     uart_irq_tx_disable(dev_upload);
 }

--- a/src/ashell/comms-uart.h
+++ b/src/ashell/comms-uart.h
@@ -139,14 +139,9 @@ struct comms_cfg_data
 };
 
 void comms_uart_set_config(struct comms_cfg_data *config);
-
 void comms_print_status();
-void comms_clear();
-
-void comms_println(const char *buf);
 void comms_write_buf(const char *buf, int len);
-void comms_writec(char byte);
-void comms_print(const char *buf);
+void comms_print(const char *buf, bool newline);
 void comms_printf(const char *format, ...);
 void zjs_ashell_process();
 void zjs_ashell_init();

--- a/src/ashell/comms-uart.h
+++ b/src/ashell/comms-uart.h
@@ -141,7 +141,7 @@ struct comms_cfg_data
 void comms_uart_set_config(struct comms_cfg_data *config);
 void comms_print_status();
 void comms_write_buf(const char *buf, int len);
-void comms_print(const char *buf, bool newline);
+void comms_print(const char *buf);
 void comms_printf(const char *format, ...);
 void zjs_ashell_process();
 void zjs_ashell_init();

--- a/src/ashell/ihex-handler.c
+++ b/src/ashell/ihex-handler.c
@@ -54,7 +54,7 @@ ihex_bool_t ihex_data_read(struct ihex_state *ihex,
 
     if (checksum_error) {
         upload_state = UPLOAD_ERROR;
-        comms_print("[ERR] Checksum_error", true);
+        comms_print("[ERR] Checksum_error\r\n");
         return false;
     };
 
@@ -96,8 +96,8 @@ uint32_t ihex_process_init()
 {
     upload_state = UPLOAD_START;
     printk("[READY]\n");
-    comms_print("\n", false);
-    comms_print("[RDY]\n", false);
+    comms_print("\n");
+    comms_print("[RDY]\n");
 
     ihex_begin_read(&ihex);
     zfile = fs_open_alloc(TEMPORAL_FILENAME, "w+");
@@ -162,7 +162,7 @@ uint32_t ihex_process_finish()
 
     fs_close(zfile);
     ihex_end_read(&ihex);
-    comms_print("[EOF]\n", false);
+    comms_print("[EOF]\n");
 
 #ifdef CONFIG_IHEX_UPLOADER_DEBUG
     printf("Saved file '%s'\n", TEMPORAL_FILENAME);

--- a/src/ashell/ihex-handler.c
+++ b/src/ashell/ihex-handler.c
@@ -54,7 +54,7 @@ ihex_bool_t ihex_data_read(struct ihex_state *ihex,
 
     if (checksum_error) {
         upload_state = UPLOAD_ERROR;
-        comms_println("[ERR] Checksum_error");
+        comms_print("[ERR] Checksum_error", true);
         return false;
     };
 
@@ -96,8 +96,8 @@ uint32_t ihex_process_init()
 {
     upload_state = UPLOAD_START;
     printk("[READY]\n");
-    comms_print("\n");
-    comms_print("[RDY]\n");
+    comms_print("\n", false);
+    comms_print("[RDY]\n", false);
 
     ihex_begin_read(&ihex);
     zfile = fs_open_alloc(TEMPORAL_FILENAME, "w+");
@@ -162,7 +162,7 @@ uint32_t ihex_process_finish()
 
     fs_close(zfile);
     ihex_end_read(&ihex);
-    comms_print("[EOF]\n");
+    comms_print("[EOF]\n", false);
 
 #ifdef CONFIG_IHEX_UPLOADER_DEBUG
     printf("Saved file '%s'\n", TEMPORAL_FILENAME);

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -345,7 +345,7 @@ void javascript_stop()
     restore_zjs_api();
 }
 
-int javascript_parse_code(const char *file_name, bool show_lines)
+int javascript_parse_code(const char *file_name)
 {
     int ret = -1;
     javascript_stop();
@@ -356,28 +356,6 @@ int javascript_parse_code(const char *file_name, bool show_lines)
     buf = read_file_alloc(file_name, &size);
 
     if (buf && size > 0) {
-        if (show_lines) {
-            comms_printf("[READ] %d\n", (int)size);
-
-            // Print buffer test
-            int line = 0;
-            comms_println("[START]");
-            comms_printf("%5d  ", line++);
-            for (int t = 0; t < size; t++) {
-                uint8_t byte = buf[t];
-                if (byte == '\n' || byte == '\r') {
-                    comms_write_buf("\r\n", 2);
-                    comms_printf("%5d  ", line++);
-                } else {
-                    if (!isprint(byte)) {
-                        comms_printf("(%x)", byte);
-                    } else
-                        comms_writec(byte);
-                }
-            }
-            comms_println("[END]");
-        }
-
         // Find and load all required js modules
         if (load_require_modules(buf)) {
             /* Setup Global scope code */
@@ -398,7 +376,7 @@ int javascript_parse_code(const char *file_name, bool show_lines)
 
 void javascript_run_code(const char *file_name)
 {
-    if (javascript_parse_code(file_name, false) != 0)
+    if (javascript_parse_code(file_name) != 0)
         return;
 
     /* Execute the parsed source code in the Global scope */

--- a/src/ashell/jerry-code.h
+++ b/src/ashell/jerry-code.h
@@ -7,7 +7,7 @@
 
 void javascript_run_code(const char *file_name);
 void javascript_eval_code(const char *source_buffer, ssize_t size);
-int javascript_parse_code(const char *file_name, bool show_lines);
+int javascript_parse_code(const char *file_name);
 void javascript_stop();
 
 #endif // __jerry_code_runner_h__

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -67,7 +67,7 @@ const char *BUILD_TIMESTAMP = __DATE__ " " __TIME__ "\n";
 
 #define CMD_TRANSFER "transfer"
 
-#define READ_BUFFER_SIZE 4
+#define READ_BUFFER_SIZE 80
 
 #ifndef CONFIG_IHEX_UPLOADER_DEBUG
 #define DBG(...) { ; }
@@ -89,7 +89,7 @@ int32_t ashell_get_filename_buffer(const char *buf, char *destination)
 
     if (arg_len == 0) {
         *destination = '\0';
-        comms_println(ERROR_NOT_ENOUGH_ARGUMENTS);
+        comms_print(ERROR_NOT_ENOUGH_ARGUMENTS, true);
         return RET_ERROR;
     }
 
@@ -130,7 +130,7 @@ int32_t ashell_disk_usage(char *buf)
 
     fs_file_t *file = fs_open_alloc(filename, "r");
     if (file == NULL) {
-        comms_println(ERROR_FILE_NOT_FOUND);
+        comms_print(ERROR_FILE_NOT_FOUND, true);
         return RET_ERROR;
     }
 
@@ -158,7 +158,7 @@ int32_t ashell_rename(char *buf)
     char *next = ashell_get_token_arg(buf);
 
     if (next == NULL) {
-        comms_println(ERROR_NOT_ENOUGH_ARGUMENTS);
+        comms_print(ERROR_NOT_ENOUGH_ARGUMENTS, true);
         return RET_ERROR;
     }
 
@@ -188,8 +188,6 @@ int32_t ashell_error(char *buf)
 
 int32_t ashell_reboot(char *buf)
 {
-    comms_println("Rebooting now!");
-
 #ifdef CONFIG_REBOOT
     //TODO Waiting for patch https://gerrit.zephyrproject.org/r/#/c/3161/
     #ifdef CONFIG_BOARD_ARDUINO_101
@@ -231,6 +229,8 @@ int32_t ashell_list_dir(char *buf)
         printf(ANSI_FG_LIGHT_BLUE "      .\n      ..\n" ANSI_FG_RESTORE);
     }
 
+    char filesizeStr[16];
+
     for (;;) {
         res = fs_readdir(&dp, &entry);
 
@@ -245,7 +245,11 @@ int32_t ashell_list_dir(char *buf)
             for (; *p; ++p)
                 *p = tolower((int)*p);
 
-            printf("%5u %s\n", (unsigned int)entry.size, entry.name);
+            int filesizeStrLen = snprintf(filesizeStr, 16, "%d", (int)entry.size);
+            comms_write_buf(filesizeStr, filesizeStrLen);
+            comms_write_buf("\t", 1);
+            comms_print(entry.name, false);
+            comms_write_buf("\r\n", 2);
         }
     }
 
@@ -258,17 +262,7 @@ int32_t ashell_print_file(char *buf)
     char filename[MAX_FILENAME_SIZE];
     char data[READ_BUFFER_SIZE];
     fs_file_t *file;
-    size_t count;
-    size_t line = 1;
-
-    // Show not printing
-    bool hidden = ashell_check_parameter(buf, 'v');
-    bool lines = ashell_check_parameter(buf, 'n');
-    if (lines)
-        printk(" Print lines \n");
-
-    if (hidden)
-        printk(" Print hidden \n");
+    ssize_t count;
 
     if (ashell_get_filename_buffer(buf, filename) <= 0) {
         return RET_ERROR;
@@ -278,37 +272,38 @@ int32_t ashell_print_file(char *buf)
 
     /* Error getting an id for our data storage */
     if (!file) {
-        comms_println(ERROR_FILE_NOT_FOUND);
+        comms_print(ERROR_FILE_NOT_FOUND, true);
         return RET_ERROR;
     }
 
     ssize_t size = fs_size(file);
     if (size == 0) {
-        comms_println("Empty file");
+        comms_print("Empty file", true);
         fs_close_alloc(file);
         return RET_OK;
     }
 
     fs_seek(file, 0, SEEK_SET);
-    if (lines)
-        comms_printf("%5d  ", line++);
 
+    int lineStart = 0;
     do {
-        count = fs_read(file, data, 4);
+        count = fs_read(file, data, READ_BUFFER_SIZE);
         for (int t = 0; t < count; t++) {
-            uint8_t byte = data[t];
-            if (byte == '\n' || byte == '\r') {
+            if (data[t] == '\n' || data[t] == '\r') {
+                int strLen = t - lineStart;
+                comms_write_buf(&data[lineStart], strLen);
                 comms_write_buf("\r\n", 2);
-                if (lines)
-                    comms_printf("%5d  ", line++);
-
-            } else {
-                if (hidden && !isprint(byte)) {
-                    comms_printf("(%x)", byte);
-                } else
-                    comms_writec(byte);
+                lineStart = t + 1;
             }
         }
+        // If we have data left that doesn't end in a newline, print it.
+        if (lineStart < count)
+        {
+            int strLen = count - lineStart;
+            comms_write_buf(&data[lineStart], strLen);
+        }
+        // Reset the line start
+        lineStart = 0;
     } while (count > 0);
 
     comms_write_buf("\r\n", 2);
@@ -323,9 +318,7 @@ int32_t ashell_parse_javascript(char *buf)
         return RET_ERROR;
     }
 
-    bool verbose = ashell_check_parameter(buf, 'v');
-
-    javascript_parse_code(filename, verbose);
+    javascript_parse_code(filename);
     return RET_OK;
 }
 
@@ -336,7 +329,7 @@ int32_t ashell_run_javascript(char *buf)
         return RET_ERROR;
     }
     if (shell.state_flags & kShellTransferIhex) {
-        comms_print("[RUN]\n");
+        comms_print("[RUN]\n", false);
     }
     javascript_run_code(filename);
     return RET_OK;
@@ -377,7 +370,7 @@ int32_t ashell_eval_javascript(const char *buf, uint32_t len)
             case ASCII_SUBSTITUTE:
             case ASCII_END_OF_TEXT:
             case ASCII_CANCEL:
-                comms_println(MSG_EXIT);
+                comms_print(MSG_EXIT, true);
                 shell.state_flags &= ~kShellEvalJavascript;
                 comms_set_prompt(NULL);
                 return RET_OK;
@@ -400,7 +393,7 @@ int32_t ashell_raw_capture(const char *buf, uint32_t len)
             switch (byte) {
             case ASCII_END_OF_TRANS:
             case ASCII_SUBSTITUTE:
-                comms_println(MSG_FILE_SAVED);
+                comms_print(MSG_FILE_SAVED, true);
                 shell.state_flags &= ~kShellCaptureRaw;
                 comms_set_prompt(NULL);
                 ashell_close_capture();
@@ -408,17 +401,17 @@ int32_t ashell_raw_capture(const char *buf, uint32_t len)
                 break;
             case ASCII_END_OF_TEXT:
             case ASCII_CANCEL:
-                comms_println(MSG_FILE_ABORTED);
+                comms_print(MSG_FILE_ABORTED, true);
                 shell.state_flags &= ~kShellCaptureRaw;
                 comms_set_prompt(NULL);
                 ashell_discard_capture();
                 return RET_OK;
             case ASCII_CR:
             case ASCII_IF:
-                comms_println("");
+                comms_print("", true);
                 break;
             default:
-                printf("%c", byte);
+                comms_write_buf(buf, 1);
             }
         } else {
             size_t written = fs_write(file_code, &byte, 1);
@@ -461,9 +454,9 @@ int32_t ashell_read_data(char *buf)
                 return RET_ERROR;
             }
 
-            comms_println(ANSI_CLEAR);
+            comms_print(ANSI_CLEAR, true);
             comms_printf("Saving to '%s'\r\n", filename);
-            comms_println(READY_FOR_RAW_DATA);
+            comms_print(READY_FOR_RAW_DATA, true);
             comms_set_prompt(raw_prompt);
             shell.state_flags |= kShellCaptureRaw;
             ashell_start_raw_capture(filename);
@@ -475,8 +468,8 @@ int32_t ashell_read_data(char *buf)
 int32_t ashell_js_immediate_mode(char *buf)
 {
     shell.state_flags |= kShellEvalJavascript;
-    comms_print(ANSI_CLEAR);
-    comms_println(MSG_IMMEDIATE_MODE);
+    comms_print(ANSI_CLEAR, false);
+    comms_print(MSG_IMMEDIATE_MODE, true);
     comms_set_prompt(eval_prompt);
     return RET_OK;
 }
@@ -485,11 +478,11 @@ int32_t ashell_set_transfer_state(char *buf)
 {
     char *next;
     if (buf == 0) {
-        comms_println(ERROR_NOT_ENOUGH_ARGUMENTS);
+        comms_print(ERROR_NOT_ENOUGH_ARGUMENTS, true);
         return RET_ERROR;
     }
     next = ashell_get_token_arg(buf);
-    comms_println(buf);
+    comms_print(buf, true);
 
     if (!strcmp("raw", buf)) {
         comms_set_prompt(NULL);
@@ -510,7 +503,7 @@ int32_t ashell_set_transfer_state(char *buf)
 int32_t ashell_set_state(char *buf)
 {
     if (buf == 0) {
-        comms_println(ERROR_NOT_ENOUGH_ARGUMENTS);
+        comms_print(ERROR_NOT_ENOUGH_ARGUMENTS, true);
         return RET_ERROR;
     }
 
@@ -525,7 +518,7 @@ int32_t ashell_set_state(char *buf)
 int32_t ashell_get_state(char *buf)
 {
     if (buf == 0) {
-        comms_println(ERROR_NOT_ENOUGH_ARGUMENTS);
+        comms_print(ERROR_NOT_ENOUGH_ARGUMENTS, true);
         return RET_ERROR;
     }
 
@@ -534,10 +527,10 @@ int32_t ashell_get_state(char *buf)
         DBG("Flags %lu\n", shell.state_flags);
 
         if (shell.state_flags & kShellTransferRaw)
-            comms_println("Raw");
+            comms_print("Raw", true);
 
         if (shell.state_flags & kShellTransferIhex)
-            comms_println("Ihex");
+            comms_print("Ihex", true);
 
         return RET_OK;
     }
@@ -546,25 +539,13 @@ int32_t ashell_get_state(char *buf)
 
 int32_t ashell_at(char *buf)
 {
-    comms_println("OK\r\n");
-    return RET_OK;
-}
-
-int32_t ashell_test(char *buf)
-{
-    comms_println("TEST OK\r\n");
-    return RET_OK;
-}
-
-int32_t ashell_ping(char *buf)
-{
-    comms_println("[PONG]\r\n");
+    comms_print("OK\r\n", true);
     return RET_OK;
 }
 
 int32_t ashell_clear(char *buf)
 {
-    comms_print(ANSI_CLEAR);
+    comms_print(ANSI_CLEAR, false);
     return RET_OK;
 }
 
@@ -597,20 +578,20 @@ int32_t ashell_check_control(const char *buf, uint32_t len)
 int32_t ashell_set_bootcfg(char *buf)
 {
     if (!fs_exist(buf)) {
-        comms_println("File passed to cfg doesn't exist\n");
+        comms_print("File passed to cfg doesn't exist\n", true);
         return RET_ERROR;
     }
 
     fs_file_t *file = fs_open_alloc("boot.cfg", "w+");
     if (!file) {
-        comms_println("Failed to create boot.cfg file");
+        comms_print("Failed to create boot.cfg file", true);
         return RET_ERROR;
     }
 
     ssize_t written = fs_write(file, BUILD_TIMESTAMP, strlen(BUILD_TIMESTAMP));
     written += fs_write(file, buf, strlen(buf));
     if (written <= 0) {
-        comms_println("Failed to write boot.cfg file");
+        comms_print("Failed to write boot.cfg file", true);
     }
 
     fs_close_alloc(file);
@@ -638,10 +619,7 @@ static const struct ashell_cmd commands[] =
 
 //    ASHELL_COMMAND("rmdir", "[TODO]"                                         ,ashell_remove_dir),
 //    ASHELL_COMMAND("mkdir", "[TODO]"                                         ,ashell_make_dir),
-    ASHELL_COMMAND("test",  "Runs your current test"                         ,ashell_test),
     ASHELL_COMMAND("error", "Prints an error using JerryScript"              ,ashell_error),
-    ASHELL_COMMAND("ping",  "Prints '[PONG]' to check that we are alive"     ,ashell_ping),
-    ASHELL_COMMAND("at",    "OK used by the driver when initializing"        ,ashell_at),
     ASHELL_COMMAND("echo",  "[on/off] Sets console echo mode on/off"         ,ashell_set_echo_mode),
 
     ASHELL_COMMAND("set",   "Sets the input mode for 'load' accept data\r\n\ttransfer raw\r\n\ttransfer ihex\t",ashell_set_state),
@@ -653,12 +631,13 @@ static const struct ashell_cmd commands[] =
 
 int32_t ashell_help(char *buf)
 {
-    comms_println("'A Shell' bash\r\n");
-    comms_println("Commands list:");
+    comms_print("'A Shell' bash\r\n", true);
+    comms_print("Commands list:", true);
     for (uint32_t t = 0; t < ASHELL_COMMANDS_COUNT; t++) {
-        comms_printf("%8s %s\r\n", commands[t].cmd_name, commands[t].syntax);
+        comms_print(commands[t].cmd_name, false);
+        comms_write_buf("\t", 1);
+        comms_print(commands[t].syntax, true);
     }
-    //comms_println("TODO: Read help file per command!");
     return RET_OK;
 }
 
@@ -733,7 +712,7 @@ int32_t ashell_main_state(char *buf, uint32_t len)
 
     /* Begin command */
     if (shell.state_flags & kShellTransferIhex) {
-        comms_print("[BCMD]\n");
+        comms_print("[BCMD]\n", false);
     }
 
     for (uint8_t t = 0; t < ASHELL_COMMANDS_COUNT; t++) {
@@ -741,7 +720,7 @@ int32_t ashell_main_state(char *buf, uint32_t len)
             int32_t res = commands[t].cb(next);
             /* End command */
             if (shell.state_flags & kShellTransferIhex) {
-                comms_print("[ECMD]\n");
+                comms_print("[ECMD]\n", false);
             }
             return res;
         }
@@ -749,10 +728,10 @@ int32_t ashell_main_state(char *buf, uint32_t len)
 
     /* Shell didn't recognize the command */
     if (shell.state_flags & kShellTransferIhex) {
-        comms_print("[ERRCMD]\n");
+        comms_print("[ERRCMD]\n", false);
     } else {
         comms_printf("%s: command not found. \r\n", buf);
-        comms_println("Type 'help' for available commands.");
+        comms_print("Type 'help' for available commands.", true);
     }
     return RET_UNKNOWN;
 }

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -430,10 +430,10 @@ int32_t ashell_raw_capture(const char *buf, uint32_t len)
 int32_t ashell_set_echo_mode(char *buf)
 {
     if (!strcmp("on", buf)) {
-        comms_println("echo_on");
+        comms_print("echo_on");
         comms_set_echo_mode(true);
     } else if (!strcmp("off", buf)) {
-        comms_println("echo_off");
+        comms_print("echo_off");
         comms_set_echo_mode(false);
     }
     return RET_OK;


### PR DESCRIPTION
This fixes the duplicate character issue on UART, removes a bunch
of unused strings, and functions that were redundant.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>