### PR TITLE
[ashell] Disable raw mode control messages in the console

### DIFF
--- a/src/ashell/comms-shell.c
+++ b/src/ashell/comms-shell.c
@@ -475,7 +475,9 @@ uint32_t ashell_process_data(const char *buf, uint32_t len)
                 DBG("<IF>");
                 break;
             default:
-                printf("<CTRL> %u\n", byte);
+                if (echo_mode) {
+                    printf("<CTRL> %u\n", byte);
+                }
                 flush_line = true;
                 shell_line[cur++] = byte;
                 break;
@@ -529,6 +531,11 @@ bool ashell_process_is_done()
 void comms_set_echo_mode(bool mode)
 {
     echo_mode = mode;
+}
+
+bool comms_get_echo_mode()
+{
+    return echo_mode;
 }
 
 uint32_t ashell_process_finish()

--- a/src/ashell/comms-shell.h
+++ b/src/ashell/comms-shell.h
@@ -6,6 +6,7 @@
 void comms_set_prompt(const char *prompt);
 const char *comms_get_prompt();
 void comms_set_echo_mode(bool echo_mode);
+bool comms_get_echo_mode();
 
 /**
  * Callback function when a line arrives

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -454,10 +454,12 @@ int32_t ashell_read_data(char *buf)
                 return RET_ERROR;
             }
 
-            comms_print(ANSI_CLEAR);
-            comms_printf("Saving to '%s'\r\n", filename);
-            comms_print(READY_FOR_RAW_DATA);
-            comms_set_prompt(raw_prompt);
+            if (comms_get_echo_mode()) {
+                comms_print(ANSI_CLEAR);
+                comms_printf("Saving to '%s'\r\n", filename);
+                comms_print(READY_FOR_RAW_DATA);
+                comms_set_prompt(raw_prompt);
+            }
             shell.state_flags |= kShellCaptureRaw;
             ashell_start_raw_capture(filename);
         }


### PR DESCRIPTION
This disables the raw mode control/transfer messages in
the console when echo is off.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>