### PR TITLE
[sensor] Fix sensor cannot stop/start in IDE/Ashell

### DIFF
--- a/arc/src/main.c
+++ b/arc/src/main.c
@@ -859,7 +859,7 @@ static void handle_sensor_bmi160(struct zjs_ipm_message *msg)
                 error_code = ERROR_IPM_OPERATION_FAILED;
             }
 #else
-            if (accel_poll) {
+            if (!accel_poll) {
                 error_code = ERROR_IPM_OPERATION_FAILED;
             } else {
                 accel_poll = false;
@@ -871,14 +871,14 @@ static void handle_sensor_bmi160(struct zjs_ipm_message *msg)
                 error_code = ERROR_IPM_OPERATION_FAILED;
             }
 #else
-            if (gyro_poll) {
+            if (!gyro_poll) {
                 error_code = ERROR_IPM_OPERATION_FAILED;
             } else {
                 gyro_poll = false;
             }
 #endif
         } else if (msg->data.sensor.channel == SENSOR_CHAN_TEMP) {
-            if (temp_poll) {
+            if (!temp_poll) {
                 error_code = ERROR_IPM_OPERATION_FAILED;
             } else {
                 temp_poll = false;

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -99,6 +99,11 @@ static void zjs_sensor_free_handles(sensor_handle_t *handles)
     sensor_handle_t *tmp;
     while (handles) {
         tmp = handles;
+        if (tmp->state == SENSOR_STATE_ACTIVATED) {
+            // we need to stop all sensors so that ARC
+            // do not continue to send change events
+            zjs_sensor_stop_sensor(tmp->sensor_obj);
+        }
         if (tmp->controller) {
             zjs_free(tmp->controller);
         }
@@ -544,6 +549,7 @@ void zjs_sensor_cleanup()
             zjs_sensor_free_handles(mod->instance->handles);
         }
         mod->cleanup();
+        mod->instance = NULL;
     }
     jerry_release_value(zjs_sensor_prototype);
 }


### PR DESCRIPTION
There are two bugs in ashell, where we aren't checking
the polling flag correctly on ARC and we are not
stopping the ARC from sending sensor changes when you
stop the JS.  Also fixes bug where we are not cleaning
up the module properly in the cleanup() function.

Fixes #1029

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>