### PR TITLE
[ashell] Buffer stdout before sending on wire

### DIFF
--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -282,8 +282,14 @@ static void comms_interrupt_handler(struct device *dev)
 
 static int comms_out(int c)
 {
+    static char buf[80];
+    static int size = 0;
     char ch = (char)c;
-    comms_write_buf(&ch, 1);
+    buf[size++] = ch;
+    if (ch == '\n' || size == 80) {
+        comms_write_buf(buf, size);
+        size = 0;
+    }
     return 1;
 }
 
@@ -313,6 +319,7 @@ void comms_write_buf(const char *buf, int len)
     while (data_transmitted == false);
     uart_irq_tx_disable(dev_upload);
 }
+
 void comms_print(const char *buf)
 {
     comms_write_buf(buf, strnlen(buf, MAX_LINE_LEN));


### PR DESCRIPTION
Waits until a newline or 80 chars on stdout arrive before sending.

This seems to solve, or at least radically decrease likelihood,
of duplicated characters on redirected stdout.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>