### PR TITLE
[ashell] Fix add_requires to allow single as well as double quotes

### DIFF
--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -221,6 +221,7 @@ static bool skip_char_with_whitespace(char **ptr, char match)
     if (**ptr != match) {
         return false;
     }
+    ++(*ptr);
     skip_whitespace(ptr);
     return true;
 }

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -229,10 +229,11 @@ static char *find_next_require(char *source, char *module, int *modlen)
 {
     // requires: source is a pointer into a null-terminated source buffer;
     //             module is a buffer with at least MAX_MODULE_STR_LEN bytes
-    // modifies: module, if one is found
+    // modifies: module, if one is found, *modlen if not NULL
     //  effects: finds the next require('modname') in the source, writes the
     //             modname to module and returns pointer into source beyond the
-    //             require, or NULL if not found
+    //             require, or NULL if not found; *modlen will be length of the
+    //             module string
     char *ptr = source;
     while (1) {
         // find the word require
@@ -263,8 +264,8 @@ static char *find_next_require(char *source, char *module, int *modlen)
         }
 
         ptr = closechar + 1;
-        *modlen = closechar - modname;
-        if (*modlen <= 0 || *modlen > MAX_MODULE_STR_LEN - 1) {
+        int len = closechar - modname;
+        if (len <= 0 || len > MAX_MODULE_STR_LEN - 1) {
             // bogus module name, try again
             continue;
         }
@@ -274,8 +275,11 @@ static char *find_next_require(char *source, char *module, int *modlen)
             continue;
         }
 
-        strncpy(module, modname, *modlen);
-        module[*modlen] = '\0';
+        strncpy(module, modname, len);
+        module[len] = '\0';
+        if (modlen) {
+            *modlen = len;
+        }
         return ptr;
     }
 }

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -231,7 +231,9 @@ static ZJS_DECL_FUNC(native_require_handler)
 
     ZVAL found_obj = zjs_get_property(exports_obj, module);
     if (!jerry_value_is_object(found_obj)) {
-        return NOTSUPPORTED_ERROR("native_require_handler: module not found");
+        char err[80];
+        snprintf(err, 80, "module not found: '%s'", module);
+        return NOTSUPPORTED_ERROR(err);
     }
 
     DBG_PRINT("JavaScript module %s loaded\n", module);


### PR DESCRIPTION
Also, improve parsing of require() by requiring parentheses, requiring
the string to be found within them, but allowing whitespace around them.

Note some of the remaining foibles with comments.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>