### PR TITLE
[general] Fix reversed order args from recent ZJS_DECL_FUNC patch

### DIFF
--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -139,52 +139,52 @@ static ZJS_DECL_FUNC_ARGS(zjs_buffer_write_bytes, int bytes, bool big_endian)
 
 static ZJS_DECL_FUNC(zjs_buffer_read_uint8)
 {
-    return zjs_buffer_read_bytes(this, function_obj, argv, argc, 1, true);
+    return zjs_buffer_read_bytes(function_obj, this, argv, argc, 1, true);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_read_uint16_be)
 {
-    return zjs_buffer_read_bytes(this, function_obj, argv, argc, 2, true);
+    return zjs_buffer_read_bytes(function_obj, this, argv, argc, 2, true);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_read_uint16_le)
 {
-    return zjs_buffer_read_bytes(this, function_obj, argv, argc, 2, false);
+    return zjs_buffer_read_bytes(function_obj, this, argv, argc, 2, false);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_read_uint32_be)
 {
-    return zjs_buffer_read_bytes(this, function_obj, argv, argc, 4, true);
+    return zjs_buffer_read_bytes(function_obj, this, argv, argc, 4, true);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_read_uint32_le)
 {
-    return zjs_buffer_read_bytes(this, function_obj, argv, argc, 4, false);
+    return zjs_buffer_read_bytes(function_obj, this, argv, argc, 4, false);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_write_uint8)
 {
-    return zjs_buffer_write_bytes(this, function_obj, argv, argc, 1, true);
+    return zjs_buffer_write_bytes(function_obj, this, argv, argc, 1, true);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_write_uint16_be)
 {
-    return zjs_buffer_write_bytes(this, function_obj, argv, argc, 2, true);
+    return zjs_buffer_write_bytes(function_obj, this, argv, argc, 2, true);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_write_uint16_le)
 {
-    return zjs_buffer_write_bytes(this, function_obj, argv, argc, 2, false);
+    return zjs_buffer_write_bytes(function_obj, this, argv, argc, 2, false);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_write_uint32_be)
 {
-    return zjs_buffer_write_bytes(this, function_obj, argv, argc, 4, true);
+    return zjs_buffer_write_bytes(function_obj, this, argv, argc, 4, true);
 }
 
 static ZJS_DECL_FUNC(zjs_buffer_write_uint32_le)
 {
-    return zjs_buffer_write_bytes(this, function_obj, argv, argc, 4, false);
+    return zjs_buffer_write_bytes(function_obj, this, argv, argc, 4, false);
 }
 
 char zjs_int_to_hex(int value) {

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -91,7 +91,7 @@ static ZJS_DECL_FUNC(zjs_i2c_read)
     //           from the register address. Returns a buffer object
     //           that size containing the data.
 
-    return zjs_i2c_read_base(this, function_obj, argv, argc, false);
+    return zjs_i2c_read_base(function_obj, this, argv, argc, false);
 }
 
 static ZJS_DECL_FUNC(zjs_i2c_burst_read)
@@ -106,7 +106,7 @@ static ZJS_DECL_FUNC(zjs_i2c_burst_read)
     //           Reads the number of bytes requested from the I2C device.
     //           Returns a buffer object containing the data.
 
-    return zjs_i2c_read_base(this, function_obj, argv, argc, true);
+    return zjs_i2c_read_base(function_obj, this, argv, argc, true);
 }
 
 static ZJS_DECL_FUNC(zjs_i2c_write)


### PR DESCRIPTION
Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>