### PR TITLE
[aio] Fixed AIO read slow on ARC

### DIFF
--- a/arc/src/zjs_sensor_light_arc.json
+++ b/arc/src/zjs_sensor_light_arc.json
@@ -1,7 +1,7 @@
 {
     "module": "sensor_light_arc",
     "constructor": "AmbientLightSensor",
-    "depends": ["sensor_arc"],
+    "depends": ["aio_arc", "sensor_arc"],
     "targets": ["arc"],
     "zephyr_conf": {
         "arc": ["CONFIG_ADC=y"]


### PR DESCRIPTION
The adc_read() on Zephyr has a latency of 100ms which causes
the AIO read to be very slow.  This patch now spawns a thread
that fetch ADC for any pins that are enabled so that
the main thread on ARC will just look up the fetched value.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>