### PR TITLE
[general] Use Zephyr defined types

### DIFF
--- a/arc/prj.mdef
+++ b/arc/prj.mdef
@@ -1,5 +1,0 @@
-% Application       : WebBT demo ARC
-
-% TASK NAME  PRIO ENTRY STACK GROUPS
-% ==================================
-  TASK TASKA    7 mainloop  2048 [EXE]

--- a/arc/src/arc_curie_pme.h
+++ b/arc/src/arc_curie_pme.h
@@ -3,16 +3,16 @@
 #ifndef _ARC_CURIE_PME_H_
 #define _ARC_CURIE_PME_H_
 
-#include <stdint.h>
+#include <zephyr/types.h>
 
-static const uint32_t NO_MATCH = 0x7fff;
-static const uint16_t MIN_CONTEXT = 0;
-static const uint16_t MAX_CONTEXT = 127;
-static const int32_t MAX_VECTOR_SIZE = 128;
-static const int32_t FIRST_NEURON_ID = 1;
-static const int32_t LAST_NEURON_ID = 128;
-static const int32_t MAX_NEURONS = 128;
-static const int32_t SAVE_RESTORE_SIZE = 128;
+static const u32_t NO_MATCH = 0x7fff;
+static const u16_t MIN_CONTEXT = 0;
+static const u16_t MAX_CONTEXT = 127;
+static const s32_t MAX_VECTOR_SIZE = 128;
+static const s32_t FIRST_NEURON_ID = 1;
+static const s32_t LAST_NEURON_ID = 128;
+static const s32_t MAX_NEURONS = 128;
+static const s32_t SAVE_RESTORE_SIZE = 128;
 
 typedef enum {
     RBF_MODE = 0,
@@ -25,11 +25,11 @@ typedef enum {
 } PATTERN_MATCHING_DISTANCE_MODE;
 
 typedef struct neuron_data {
-    uint16_t context;
-    uint16_t aif;
-    uint16_t min_if;
-    uint16_t category;
-    uint8_t vector[128];
+    u16_t context;
+    u16_t aif;
+    u16_t min_if;
+    u16_t category;
+    u8_t vector[128];
 } neuron_data_t;
 
 // Default initializer
@@ -37,53 +37,53 @@ void curie_pme_begin(void);
 
 void curie_pme_forget(void);
 
-void curie_pme_configure(uint16_t global_context,
+void curie_pme_configure(u16_t global_context,
                          PATTERN_MATCHING_DISTANCE_MODE distance_mode,
                          PATTERN_MATCHING_CLASSIFICATION_MODE classification_mode,
-                         uint16_t min_if,
-                         uint16_t max_if);
+                         u16_t min_if,
+                         u16_t max_if);
 
-uint16_t curie_pme_learn(uint8_t *pattern_vector,
-                         int32_t vector_length,
-                         uint16_t category);
-uint16_t curie_pme_classify(uint8_t *pattern_vector, int32_t vector_length);
+u16_t curie_pme_learn(u8_t *pattern_vector,
+                      s32_t vector_length,
+                      u16_t category);
+u16_t curie_pme_classify(u8_t *pattern_vector, s32_t vector_length);
 
-uint16_t curie_pme_read_neuron(int32_t neuron_id, neuron_data_t *data_array);
+u16_t curie_pme_read_neuron(s32_t neuron_id, neuron_data_t *data_array);
 
 // save and restore knowledge
 void curie_pme_begin_save_mode(void); // saves the contents of the NSR register
-uint16_t curie_pme_iterate_neurons_to_save(neuron_data_t *data_array);
+u16_t curie_pme_iterate_neurons_to_save(neuron_data_t *data_array);
 void curie_pme_end_save_mode(void); // restores the NSR value saved by beginSaveMode
 
 void curie_pme_begin_restore_mode(void);
-uint16_t curie_pme_iterate_neurons_to_restore(neuron_data_t *data_array);
+u16_t curie_pme_iterate_neurons_to_restore(neuron_data_t *data_array);
 void curie_pme_end_restore_mode(void);
 
 // getter and setters
 PATTERN_MATCHING_DISTANCE_MODE curie_pme_get_distance_mode(void);
 void curie_pme_set_distance_mode(PATTERN_MATCHING_DISTANCE_MODE mode);
-uint16_t curie_pme_get_global_context(void);
-void curie_pme_set_global_context(uint16_t context); // valid range is 1-127
-uint16_t curie_pme_get_neuron_context(void);
-void curie_pme_set_neuron_context(uint16_t context); // valid range is 1-127
+u16_t curie_pme_get_global_context(void);
+void curie_pme_set_global_context(u16_t context); // valid range is 1-127
+u16_t curie_pme_get_neuron_context(void);
+void curie_pme_set_neuron_context(u16_t context); // valid range is 1-127
 
 // NOTE: get_committed_count() will give inaccurate value if the network is in
 // Save/Restore mode.
 // It should not be called between the begin_save_mode() and end_save_mode() or
 // between
 // begin_restore_mode() and end_restore_mode()
-uint16_t curie_pme_get_committed_count(void);
+u16_t curie_pme_get_committed_count(void);
 
 PATTERN_MATCHING_CLASSIFICATION_MODE curie_pme_get_classifier_mode(void); // RBF or KNN
 void curie_pme_set_classifier_mode(PATTERN_MATCHING_CLASSIFICATION_MODE mode);
 
 // write vector is used for kNN recognition and does not alter
 // the CAT register, which moves the chain along.
-uint16_t curie_pme_write_vector(uint8_t *pattern_vector, int32_t vector_length);
+u16_t curie_pme_write_vector(u8_t *pattern_vector, s32_t vector_length);
 
 // base address of the pattern matching accelerator in Intel(r) Curie(tm) and
 // QuarkSE(tm)
-static const uint32_t baseAddress = 0xB0600000L;
+static const u32_t baseAddress = 0xB0600000L;
 
 typedef enum {
     NCR = 0x00, // Neuron Context Register
@@ -119,31 +119,31 @@ typedef enum {
 
 // all pattern matching accelerator registers are 16-bits wide, memory-addressed
 // define efficient inline register access
-inline volatile uint16_t* reg_address(registers_t reg)
+inline volatile u16_t *reg_address(registers_t reg)
 {
-    return (uint16_t*)(0xB0600000L + reg);
+    return (u16_t *)(0xB0600000L + reg);
 }
 
-inline uint16_t reg_read16(registers_t reg) { return *reg_address(reg); }
+inline u16_t reg_read16(registers_t reg) { return *reg_address(reg); }
 
-inline void reg_write16(registers_t reg, uint16_t value)
+inline void reg_write16(registers_t reg, u16_t value)
 {
     *reg_address(reg) = value;
 }
 
 // raw register access - not recommended.
-inline uint16_t getNCR(void) { return reg_read16(NCR); }
-inline uint16_t getCOMP(void) { return reg_read16(COMP); }
-inline uint16_t getLCOMP(void) { return reg_read16(LCOMP); }
-inline uint16_t getIDX_DIST(void) { return reg_read16(IDX_DIST); }
-inline uint16_t getCAT(void) { return reg_read16(CAT); }
-inline uint16_t getAIF(void) { return reg_read16(AIF); }
-inline uint16_t getMINIF(void) { return reg_read16(MINIF); }
-inline uint16_t getMAXIF(void) { return reg_read16(MAXIF); }
-inline uint16_t getNID(void) { return reg_read16(NID); }
-inline uint16_t getGCR(void) { return reg_read16(GCR); }
-inline uint16_t getRSTCHAIN(void) { return reg_read16(RSTCHAIN); }
-inline uint16_t getNSR(void) { return reg_read16(NSR); }
-inline uint16_t getFORGET_NCOUNT(void) { return reg_read16(FORGET_NCOUNT); }
+inline u16_t getNCR(void) { return reg_read16(NCR); }
+inline u16_t getCOMP(void) { return reg_read16(COMP); }
+inline u16_t getLCOMP(void) { return reg_read16(LCOMP); }
+inline u16_t getIDX_DIST(void) { return reg_read16(IDX_DIST); }
+inline u16_t getCAT(void) { return reg_read16(CAT); }
+inline u16_t getAIF(void) { return reg_read16(AIF); }
+inline u16_t getMINIF(void) { return reg_read16(MINIF); }
+inline u16_t getMAXIF(void) { return reg_read16(MAXIF); }
+inline u16_t getNID(void) { return reg_read16(NID); }
+inline u16_t getGCR(void) { return reg_read16(GCR); }
+inline u16_t getRSTCHAIN(void) { return reg_read16(RSTCHAIN); }
+inline u16_t getNSR(void) { return reg_read16(NSR); }
+inline u16_t getFORGET_NCOUNT(void) { return reg_read16(FORGET_NCOUNT); }
 
 #endif

--- a/src/ashell/comms-shell.c
+++ b/src/ashell/comms-shell.c
@@ -5,7 +5,7 @@
  * @brief Shell to keep the different states of the machine
  */
 
-#include <stdint.h>
+#include <zephyr/types.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -50,7 +50,7 @@ const char *comms_get_prompt()
 
 static ashell_line_parser_t app_line_cb = NULL;
 static char *shell_line = NULL;
-static uint8_t tail = 0;
+static u8_t tail = 0;
 static bool ashell_is_done = false;
 static bool echo_mode = true;
 
@@ -76,7 +76,7 @@ static inline void cursor_restore(void)
     comms_print("\x1b[u");
 }
 
-static void insert_char(char *pos, char c, uint8_t end)
+static void insert_char(char *pos, char c, u8_t end)
 {
     char tmp;
 
@@ -101,7 +101,7 @@ static void insert_char(char *pos, char c, uint8_t end)
     cursor_restore();
 }
 
-static void del_char(char *pos, uint8_t end)
+static void del_char(char *pos, u8_t end)
 {
     comms_write_buf("\b", 1);
 
@@ -135,9 +135,9 @@ enum
 
 static atomic_t esc_state;
 static unsigned int ansi_val, ansi_val_2;
-static uint8_t cur, end;
+static u8_t cur, end;
 
-static void handle_ansi(uint8_t byte)
+static void handle_ansi(u8_t byte)
 {
     if (atomic_test_and_clear_bit(&esc_state, ESC_ANSI_FIRST)) {
         if (!isdigit(byte)) {
@@ -207,12 +207,12 @@ ansi_cmd:
  * @return Returns the number of arguments on the string
  */
 
-uint32_t ashell_get_argc(const char *str, uint32_t nsize)
+u32_t ashell_get_argc(const char *str, u32_t nsize)
 {
     if (str == NULL || nsize == 0 || *str == '\0')
         return 0;
 
-    uint32_t size = 1;
+    u32_t size = 1;
     bool div = false;
 
     /* Skip the first spaces */
@@ -246,7 +246,7 @@ uint32_t ashell_get_argc(const char *str, uint32_t nsize)
  * @return 0      Pointer to where this argument finishes
  */
 
-const char *ashell_get_next_arg(const char *str, uint32_t nsize, char *str_arg, uint32_t *length)
+const char *ashell_get_next_arg(const char *str, u32_t nsize, char *str_arg, u32_t *length)
 {
     *length = 0;
     if (nsize == 0 || str == NULL || *str == '\0') {
@@ -281,7 +281,7 @@ const char *ashell_get_next_arg(const char *str, uint32_t nsize, char *str_arg, 
 * @return 0 Pointer to where this argument finishes
 */
 
-const char *ashell_get_next_arg_s(const char *str, uint32_t nsize, char *str_arg, const uint32_t max_arg_size, uint32_t *length)
+const char *ashell_get_next_arg_s(const char *str, u32_t nsize, char *str_arg, const u32_t max_arg_size, u32_t *length)
 {
     /* Check size and allocate for string termination */
     if (nsize >= max_arg_size) {
@@ -383,13 +383,13 @@ char *ashell_get_token_arg(char *str)
     return ashell_skip_spaces(str);
 }
 
-uint32_t ashell_process_init()
+u32_t ashell_process_init()
 {
     DBG("[SHELL] Init\n");
     return 0;
 }
 
-void ashell_process_line(const char *buf, uint32_t len)
+void ashell_process_line(const char *buf, u32_t len)
 {
 #ifdef CONFIG_SHELL_UPLOADER_DEBUG
     printk("%s", buf);
@@ -400,11 +400,11 @@ void ashell_process_line(const char *buf, uint32_t len)
     comms_print(comms_get_prompt());
 }
 
-uint32_t ashell_process_data(const char *buf, uint32_t len)
+u32_t ashell_process_data(const char *buf, u32_t len)
 {
-    uint32_t processed = 0;
+    u32_t processed = 0;
     // printed Is used to make sure we don't re-print characters
-    uint8_t printed = cur;
+    u8_t printed = cur;
     bool flush_line = false;
     if (shell_line == NULL) {
         DBG("[Process]%d\n", (int)len);
@@ -421,7 +421,7 @@ uint32_t ashell_process_data(const char *buf, uint32_t len)
 
     while (len-- > 0) {
         processed++;
-        uint8_t byte = *buf++;
+        u8_t byte = *buf++;
 
         if (tail == MAX_LINE) {
             DBG("Line size exceeded \n");
@@ -488,8 +488,8 @@ uint32_t ashell_process_data(const char *buf, uint32_t len)
                 comms_write_buf("\r\n", 2);
             }
 
-            uint32_t length = strnlen(shell_line, MAX_LINE);
-            int32_t ret = 0;
+            u32_t length = strnlen(shell_line, MAX_LINE);
+            s32_t ret = 0;
             if (app_line_cb != NULL)
                 ret = app_line_cb(shell_line, length);
 
@@ -539,7 +539,7 @@ bool comms_get_echo_mode()
     return echo_mode;
 }
 
-uint32_t ashell_process_finish()
+u32_t ashell_process_finish()
 {
     DBG("[SHELL CLOSE]\n");
     ihex_process_start();
@@ -591,8 +591,8 @@ void ashell_process_start()
 struct shell_tests
 {
     char *str;
-    uint32_t size;
-    uint32_t result;
+    u32_t size;
+    u32_t result;
 };
 
 #define TEST_PARAMS(str,size, params) { str, size, params }
@@ -640,8 +640,8 @@ struct shell_tests param_test[] =
 
 void shell_unit_test()
 {
-    uint32_t t = 0;
-    uint32_t argc;
+    u32_t t = 0;
+    u32_t argc;
     char tmp[512];
     char *buf;
     char *next;
@@ -659,7 +659,7 @@ void shell_unit_test()
     }
 
     char arg[32];
-    uint32_t len;
+    u32_t len;
     t = 0;
 
     while (t != sizeof(test) / sizeof(shell_tests)) {
@@ -709,7 +709,7 @@ void shell_unit_test()
 
     t = 0;
     while (t != sizeof(param_test) / sizeof(shell_tests)) {
-        uint32_t res = ashell_check_parameter(param_test[t].str, (char)param_test[t].size);
+        u32_t res = ashell_check_parameter(param_test[t].str, (char)param_test[t].size);
         if (res != param_test[t].result) {
             printf("Failed test (%s) %c\n", param_test[t].str, (char)param_test[t].size);
         };

--- a/src/ashell/comms-shell.h
+++ b/src/ashell/comms-shell.h
@@ -11,7 +11,7 @@ bool comms_get_echo_mode();
 /**
  * Callback function when a line arrives
  */
-typedef int32_t(*ashell_line_parser_t)(char *buf, uint32_t len);
+typedef s32_t(*ashell_line_parser_t)(char *buf, u32_t len);
 
 void ashell_process_start();
 void ashell_process_close();
@@ -22,7 +22,7 @@ char *ashell_skip_spaces(char *str);
 char *ashell_get_token_arg(char *str);
 bool ashell_check_parameter(const char *buf, const char parameter);
 
-uint32_t ashell_get_argc(const char *str, uint32_t nsize);
-const char *ashell_get_next_arg_s(const char *str, uint32_t nsize, char *str_arg, uint32_t max_arg_size, uint32_t *length);
+u32_t ashell_get_argc(const char *str, u32_t nsize);
+const char *ashell_get_next_arg_s(const char *str, u32_t nsize, char *str_arg, u32_t max_arg_size, u32_t *length);
 
 #endif  // __comms_shell_h__

--- a/src/ashell/comms-uart.c
+++ b/src/ashell/comms-uart.c
@@ -94,16 +94,16 @@ struct comms_input
 static struct k_fifo avail_queue;
 static struct k_fifo data_queue;
 static bool uart_process_done = false;
-static uint8_t fifo_size = 0;
-static uint8_t max_fifo_size = 0;
+static u8_t fifo_size = 0;
+static u8_t max_fifo_size = 0;
 
 atomic_t data_queue_count = 0;
 
-uint32_t alloc_count = 0;
-uint32_t free_count = 0;
+u32_t alloc_count = 0;
+u32_t free_count = 0;
 
 static struct comms_input *isr_data = NULL;
-static uint32_t tail = 0;
+static u32_t tail = 0;
 static char *buf;
 
 struct comms_input *fifo_get_isr_buffer()
@@ -153,8 +153,8 @@ static struct device *dev_upload;
 
 static volatile bool data_transmitted;
 
-uint32_t bytes_received = 0;
-uint32_t bytes_processed = 0;
+u32_t bytes_received = 0;
+u32_t bytes_processed = 0;
 
 atomic_t uart_state = 0;
 
@@ -189,8 +189,8 @@ static void comms_interrupt_handler(struct device *dev)
 {
     char byte;
 
-    uint32_t bytes_read = 0;
-    uint32_t len = 0;
+    u32_t bytes_read = 0;
+    u32_t len = 0;
 
     atomic_set(&uart_state, UART_IRQ_UPDATE);
 
@@ -314,7 +314,7 @@ void comms_write_buf(const char *buf, int len)
     while (bytes != len) {
         buf += bytes;
         len -= bytes;
-        bytes = uart_fifo_fill(dev_upload, (const uint8_t *)buf, len);
+        bytes = uart_fifo_fill(dev_upload, (const u8_t *)buf, len);
     }
     while (data_transmitted == false);
     uart_irq_tx_disable(dev_upload);
@@ -337,9 +337,9 @@ void comms_printf(const char *format, ...)
 }
 
 #ifdef CONFIG_UART_LINE_CTRL
-uint32_t comms_get_baudrate(void)
+u32_t comms_get_baudrate(void)
 {
-    uint32_t baudrate;
+    u32_t baudrate;
 
     int ret = uart_line_ctrl_get(dev_upload, LINE_CTRL_BAUD_RATE, &baudrate);
     if (ret)
@@ -404,7 +404,7 @@ void zjs_ashell_process()
 {
     static struct comms_input *data = NULL;
     char *buf = NULL;
-    uint32_t len = 0;
+    u32_t len = 0;
     atomic_set(&uart_state, UART_INIT);
 
     while (!comms_config.interface.is_done()) {
@@ -483,7 +483,7 @@ void zjs_ashell_init()
     ashell_run_boot_cfg();
 
 #ifdef CONFIG_UART_LINE_CTRL
-    uint32_t dtr = 0;
+    u32_t dtr = 0;
 
     while (1) {
         uart_line_ctrl_get(dev_upload, LINE_CTRL_DTR, &dtr);

--- a/src/ashell/comms-uart.h
+++ b/src/ashell/comms-uart.h
@@ -64,17 +64,17 @@ const char *system_get_prompt();
 /**
  * Callback function initialize the process
  */
-typedef uint32_t(*process_init_callback_t)();
+typedef u32_t(*process_init_callback_t)();
 
 /**
  * Callback function to pass an error from the transmision
  */
-typedef void(*process_error_callback_t)(uint32_t error);
+typedef void(*process_error_callback_t)(u32_t error);
 
 /**
  * Callback function to pass an error from the transmision
  */
-typedef uint32_t(*process_data_callback_t)(const char *buf, uint32_t len);
+typedef u32_t(*process_data_callback_t)(const char *buf, u32_t len);
 
 /**
  * Callback to tell when the data transfered is finished or process completed
@@ -84,7 +84,7 @@ typedef bool(*process_is_done)();
 /**
  * Callback function to pass an error from the transmision
  */
-typedef uint32_t(*process_close_callback_t)();
+typedef u32_t(*process_close_callback_t)();
 
 /* Callback to print debug data or state to the user */
 typedef void(*process_print_state_t)();

--- a/src/ashell/ihex-handler.c
+++ b/src/ashell/ihex-handler.c
@@ -39,7 +39,7 @@ const char TEMPORAL_FILENAME[] = "temp.dat";
 static bool marker = false;
 static struct ihex_state ihex;
 
-static int8_t upload_state = 0;
+static s8_t upload_state = 0;
 #define UPLOAD_START       0
 #define UPLOAD_IN_PROGRESS 1
 #define UPLOAD_FINISHED    2
@@ -83,7 +83,7 @@ ihex_bool_t ihex_data_read(struct ihex_state *ihex,
 /*
  * Negotiate a re-upload
  */
-void ihex_process_error(uint32_t error)
+void ihex_process_error(u32_t error)
 {
     printf("[Download Error]\n");
 }
@@ -91,7 +91,7 @@ void ihex_process_error(uint32_t error)
 /*
  * Capture for the Intel Hex parser
  */
-uint32_t ihex_process_init()
+u32_t ihex_process_init()
 {
     upload_state = UPLOAD_START;
     printk("[READY]\n");
@@ -109,9 +109,9 @@ uint32_t ihex_process_init()
     return (!zfile);
 }
 
-uint32_t ihex_process_data(const char *buf, uint32_t len)
+u32_t ihex_process_data(const char *buf, u32_t len)
 {
-    uint32_t processed = 0;
+    u32_t processed = 0;
     while (len-- > 0) {
         processed++;
         char byte = *buf++;
@@ -146,7 +146,7 @@ bool ihex_process_is_done()
     return (upload_state == UPLOAD_FINISHED || upload_state == UPLOAD_ERROR);
 }
 
-uint32_t ihex_process_finish()
+u32_t ihex_process_finish()
 {
     if (upload_state == UPLOAD_ERROR) {
         printf("[Error] Callback handle error \n");

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -5,7 +5,7 @@
  * @brief Shell to keep the different states of the machine
  */
 
-#include <stdint.h>
+#include <zephyr/types.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -79,10 +79,10 @@ const char *BUILD_TIMESTAMP = __DATE__ " " __TIME__ "\n";
 #define DBG printk
 #endif /* CONFIG_IHEX_UPLOADER_DEBUG */
 
-int32_t ashell_get_filename_buffer(const char *buf, char *destination)
+s32_t ashell_get_filename_buffer(const char *buf, char *destination)
 {
-    uint32_t arg_len = 0;
-    uint32_t len = strnlen(buf, MAX_FILENAME_SIZE);
+    u32_t arg_len = 0;
+    u32_t len = strnlen(buf, MAX_FILENAME_SIZE);
     if (len == 0)
         return RET_ERROR;
 
@@ -100,7 +100,7 @@ int32_t ashell_get_filename_buffer(const char *buf, char *destination)
     return arg_len;
 }
 
-int32_t ashell_remove_file(char *buf)
+s32_t ashell_remove_file(char *buf)
 {
     char filename[MAX_FILENAME_SIZE];
     if (ashell_get_filename_buffer(buf, filename) <= 0) {
@@ -115,17 +115,17 @@ int32_t ashell_remove_file(char *buf)
     return RET_ERROR;
 }
 
-int32_t ashell_remove_dir(char *buf)
+s32_t ashell_remove_dir(char *buf)
 {
     return RET_OK;
 }
 
-int32_t ashell_make_dir(char *buf)
+s32_t ashell_make_dir(char *buf)
 {
     return RET_OK;
 }
 
-int32_t ashell_disk_usage(char *buf)
+s32_t ashell_disk_usage(char *buf)
 {
     char filename[MAX_FILENAME_SIZE];
     if (ashell_get_filename_buffer(buf, filename) <= 0) {
@@ -144,7 +144,7 @@ int32_t ashell_disk_usage(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_rename(char *buf)
+s32_t ashell_rename(char *buf)
 {
     static struct fs_dirent entry;
     char path_org[MAX_FILENAME_SIZE];
@@ -183,14 +183,14 @@ int32_t ashell_rename(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_error(char *buf)
+s32_t ashell_error(char *buf)
 {
     printk("[Error](%s)\n", buf);
     jerry_port_log(JERRY_LOG_LEVEL_ERROR, "stderr test (%s)\n", buf);
     return 0;
 }
 
-int32_t ashell_reboot(char *buf)
+s32_t ashell_reboot(char *buf)
 {
 #ifdef CONFIG_REBOOT
     //TODO Waiting for patch https://gerrit.zephyrproject.org/r/#/c/3161/
@@ -202,11 +202,11 @@ int32_t ashell_reboot(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_list_dir(char *buf)
+s32_t ashell_list_dir(char *buf)
 {
     char filename[MAX_FILENAME_SIZE];
     static struct fs_dirent entry;
-    int32_t res;
+    s32_t res;
     fs_dir_t dp;
     *filename = '\0';
 
@@ -261,7 +261,7 @@ int32_t ashell_list_dir(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_print_file(char *buf)
+s32_t ashell_print_file(char *buf)
 {
     char filename[MAX_FILENAME_SIZE];
     char data[READ_BUFFER_SIZE];
@@ -315,7 +315,7 @@ int32_t ashell_print_file(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_parse_javascript(char *buf)
+s32_t ashell_parse_javascript(char *buf)
 {
     char filename[MAX_FILENAME_SIZE];
     if (ashell_get_filename_buffer(buf, filename) <= 0) {
@@ -326,7 +326,7 @@ int32_t ashell_parse_javascript(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_run_javascript(char *buf)
+s32_t ashell_run_javascript(char *buf)
 {
     char filename[MAX_FILENAME_SIZE];
     if (ashell_get_filename_buffer(buf, filename) <= 0) {
@@ -339,7 +339,7 @@ int32_t ashell_run_javascript(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_start_raw_capture(char *filename)
+s32_t ashell_start_raw_capture(char *filename)
 {
     file_code = fs_open_alloc(filename, "w+");
 
@@ -350,24 +350,24 @@ int32_t ashell_start_raw_capture(char *filename)
     return RET_OK;
 }
 
-int32_t ashell_close_capture()
+s32_t ashell_close_capture()
 {
     return fs_close_alloc(file_code);
 }
 
-int32_t ashell_discard_capture()
+s32_t ashell_discard_capture()
 {
     fs_close_alloc(file_code);
     //TODO ashell_remove_file(file_code);
     return RET_OK;
 }
 
-int32_t ashell_eval_javascript(const char *buf, uint32_t len)
+s32_t ashell_eval_javascript(const char *buf, u32_t len)
 {
     const char *src = buf;
 
     while (len > 0) {
-        uint8_t byte = *buf++;
+        u8_t byte = *buf++;
         if (!isprint(byte)) {
             switch (byte) {
             case ASCII_END_OF_TRANS:
@@ -387,12 +387,12 @@ int32_t ashell_eval_javascript(const char *buf, uint32_t len)
     return RET_OK;
 }
 
-int32_t ashell_raw_capture(const char *buf, uint32_t len)
+s32_t ashell_raw_capture(const char *buf, u32_t len)
 {
-    uint8_t eol = '\n';
+    u8_t eol = '\n';
 
     while (len > 0) {
-        uint8_t byte = *buf++;
+        u8_t byte = *buf++;
         if (!isprint(byte)) {
             switch (byte) {
             case ASCII_END_OF_TRANS:
@@ -431,7 +431,7 @@ int32_t ashell_raw_capture(const char *buf, uint32_t len)
     return RET_OK_NO_RET;
 }
 
-int32_t ashell_set_echo_mode(char *buf)
+s32_t ashell_set_echo_mode(char *buf)
 {
     if (!strcmp("on", buf)) {
         comms_print("echo_on");
@@ -443,7 +443,7 @@ int32_t ashell_set_echo_mode(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_read_data(char *buf)
+s32_t ashell_read_data(char *buf)
 {
     if (shell.state_flags & kShellTransferIhex) {
         ashell_process_close();
@@ -471,7 +471,7 @@ int32_t ashell_read_data(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_js_immediate_mode(char *buf)
+s32_t ashell_js_immediate_mode(char *buf)
 {
     shell.state_flags |= kShellEvalJavascript;
     comms_print(ANSI_CLEAR);
@@ -480,7 +480,7 @@ int32_t ashell_js_immediate_mode(char *buf)
     return RET_OK;
 }
 
-int32_t ashell_set_transfer_state(char *buf)
+s32_t ashell_set_transfer_state(char *buf)
 {
     char *next;
     if (buf == 0) {
@@ -506,7 +506,7 @@ int32_t ashell_set_transfer_state(char *buf)
     return RET_UNKNOWN;
 }
 
-int32_t ashell_set_state(char *buf)
+s32_t ashell_set_state(char *buf)
 {
     if (buf == 0) {
         comms_print(ERROR_NOT_ENOUGH_ARGUMENTS);
@@ -521,7 +521,7 @@ int32_t ashell_set_state(char *buf)
     return RET_UNKNOWN;
 }
 
-int32_t ashell_get_state(char *buf)
+s32_t ashell_get_state(char *buf)
 {
     if (buf == 0) {
         comms_print(ERROR_NOT_ENOUGH_ARGUMENTS);
@@ -543,28 +543,28 @@ int32_t ashell_get_state(char *buf)
     return RET_UNKNOWN;
 }
 
-int32_t ashell_at(char *buf)
+s32_t ashell_at(char *buf)
 {
     comms_print("OK\r\n\r\n");
     return RET_OK;
 }
 
-int32_t ashell_clear(char *buf)
+s32_t ashell_clear(char *buf)
 {
     comms_print(ANSI_CLEAR);
     return RET_OK;
 }
 
-int32_t ashell_stop_javascript(char *buf)
+s32_t ashell_stop_javascript(char *buf)
 {
     javascript_stop();
     return RET_OK;
 }
 
-int32_t ashell_check_control(const char *buf, uint32_t len)
+s32_t ashell_check_control(const char *buf, u32_t len)
 {
     while (len > 0) {
-        uint8_t byte = *buf++;
+        u8_t byte = *buf++;
         if (!isprint(byte)) {
             switch (byte) {
                 case ASCII_SUBSTITUTE:
@@ -581,7 +581,7 @@ int32_t ashell_check_control(const char *buf, uint32_t len)
     return RET_OK;
 }
 
-int32_t ashell_set_bootcfg(char *buf)
+s32_t ashell_set_bootcfg(char *buf)
 {
     if (!fs_exist(buf)) {
         comms_print("File passed to cfg doesn't exist\n\r\n");
@@ -645,11 +645,11 @@ static const struct ashell_cmd commands[] =
 
 #define ASHELL_COMMANDS_COUNT (sizeof(commands)/sizeof(*commands))
 
-int32_t ashell_help(char *buf)
+s32_t ashell_help(char *buf)
 {
     comms_print("'A Shell' bash\r\n\r\n");
     comms_print("Commands list:\r\n");
-    for (uint32_t t = 0; t < ASHELL_COMMANDS_COUNT; t++) {
+    for (u32_t t = 0; t < ASHELL_COMMANDS_COUNT; t++) {
         // skip commands with empty description
         if (!commands[t].syntax[0]) {
             continue;
@@ -701,7 +701,7 @@ void ashell_run_boot_cfg()
     fs_close_alloc(file);
 }
 
-int32_t ashell_main_state(char *buf, uint32_t len)
+s32_t ashell_main_state(char *buf, u32_t len)
 {
     /* Raw line to be evaluated by JS */
     if (shell.state_flags & kShellEvalJavascript) {
@@ -717,7 +717,7 @@ int32_t ashell_main_state(char *buf, uint32_t len)
     DBG("[BOF]%s[EOF]", buf);
     ashell_check_control(buf, len);
 
-    uint32_t argc = ashell_get_argc(buf, len);
+    u32_t argc = ashell_get_argc(buf, len);
     DBG("[ARGS %u]\n", argc);
 
     if (argc == 0)
@@ -737,9 +737,9 @@ int32_t ashell_main_state(char *buf, uint32_t len)
         comms_print("[BCMD]\n");
     }
 
-    for (uint8_t t = 0; t < ASHELL_COMMANDS_COUNT; t++) {
+    for (u8_t t = 0; t < ASHELL_COMMANDS_COUNT; t++) {
         if (!strcmp(commands[t].cmd_name, buf)) {
-            int32_t res = commands[t].cb(next);
+            s32_t res = commands[t].cb(next);
             /* End command */
             if (shell.state_flags & kShellTransferIhex) {
                 comms_print("[ECMD]\n");

--- a/src/ashell/shell-state.h
+++ b/src/ashell/shell-state.h
@@ -30,7 +30,7 @@ enum
  * @param buf Raw buffer containing the rest of the parameters from the last command
  * @return RET_OK, RET_ERROR, RET_UNKNOWN
  */
-typedef int32_t(*ashell_cmd)(char *buf);
+typedef s32_t(*ashell_cmd)(char *buf);
 
 struct ashell_cmd
 {
@@ -45,7 +45,7 @@ struct ashell_cmd
  */
 struct shell_state_config
 {
-    uint32_t state_flags;
+    u32_t state_flags;
 };
 
 /**
@@ -54,7 +54,7 @@ struct shell_state_config
  * @param buf Zero terminated string, length of the buffer.
  * @return RET_OK, RET_ERROR, RET_UNKNOWN
  */
-int32_t ashell_main_state(char *buf, uint32_t len);
+s32_t ashell_main_state(char *buf, u32_t len);
 
 /**
  * @brief Gets called when main loop starts and runs the JavaScript file found in
@@ -62,5 +62,5 @@ int32_t ashell_main_state(char *buf, uint32_t len);
  */
 void ashell_run_boot_cfg();
 
-int32_t ashell_help(char *buf);
+s32_t ashell_help(char *buf);
 #endif

--- a/src/ashell/webusb-handler.c
+++ b/src/ashell/webusb-handler.c
@@ -12,7 +12,7 @@
 #include "webusb-handler.h"
 
 /* WebUSB Platform Capability Descriptor */
-static const uint8_t webusb_bos_descriptor[] = {
+static const u8_t webusb_bos_descriptor[] = {
     /* Binary Object Store descriptor */
     0x05, 0x0F, 0x39, 0x00, 0x02,
 
@@ -43,7 +43,7 @@ static const uint8_t webusb_bos_descriptor[] = {
 };
 
 /* Microsoft OS 2.0 Descriptor Set */
-static const uint8_t ms_os_20_descriptor_set[] = {
+static const u8_t ms_os_20_descriptor_set[] = {
     0x0A, 0x00,  // wLength
     0x00, 0x00,  // MS OS 2.0 descriptor set header
     0x00, 0x00, 0x03, 0x06,  // Windows 8.1
@@ -91,7 +91,7 @@ static const uint8_t ms_os_20_descriptor_set[] = {
 };
 
 /* WebUSB Device Requests */
-static const uint8_t webusb_allowed_origins[] = {
+static const u8_t webusb_allowed_origins[] = {
     /* Allowed Origins Header:
      * https://wicg.github.io/webusb/#get-allowed-origins
      */
@@ -115,7 +115,7 @@ static const uint8_t webusb_allowed_origins[] = {
 #define MS_OS_20_REQUEST_DESCRIPTOR 0x07
 
 /* URL Descriptor: https://wicg.github.io/webusb/#url-descriptor */
-static const uint8_t webusb_origin_url_1[] = {
+static const u8_t webusb_origin_url_1[] = {
     0x1F,  // Length
     0x03,  // URL descriptor
     0x01,  // Scheme https://
@@ -125,7 +125,7 @@ static const uint8_t webusb_origin_url_1[] = {
 };
 
 /* URL Descriptor: https://wicg.github.io/webusb/#url-descriptor */
-const uint8_t webusb_origin_url_2[] = {
+const u8_t webusb_origin_url_2[] = {
     0x11,  // Length
     0x03,  // URL descriptor
     0x00,  // Scheme http://
@@ -143,11 +143,11 @@ const uint8_t webusb_origin_url_2[] = {
  *
  * @return  0 on success, negative errno code on fail
  */
-int webusb_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
-                          uint8_t **data)
+int webusb_custom_handler(struct usb_setup_packet *pSetup, s32_t *len,
+                          u8_t **data)
 {
     if (GET_DESC_TYPE(pSetup->wValue) == DESCRIPTOR_TYPE_BOS) {
-        *data = (uint8_t *)(&webusb_bos_descriptor);
+        *data = (u8_t *)(&webusb_bos_descriptor);
         *len = sizeof(webusb_bos_descriptor);
 
         return 0;
@@ -165,35 +165,35 @@ int webusb_custom_handler(struct usb_setup_packet *pSetup, int32_t *len,
  *
  * @return  0 on success, negative errno code on fail.
  */
-int webusb_vendor_handler(struct usb_setup_packet *pSetup, int32_t *len,
-                          uint8_t **data)
+int webusb_vendor_handler(struct usb_setup_packet *pSetup, s32_t *len,
+                          u8_t **data)
 {
     /* Get Allowed origins request */
     if (pSetup->bRequest == 0x01 && pSetup->wIndex == 0x01) {
-        *data = (uint8_t *)(&webusb_allowed_origins);
+        *data = (u8_t *)(&webusb_allowed_origins);
         *len = sizeof(webusb_allowed_origins);
 
         return 0;
     } else if (pSetup->bRequest == 0x01 && pSetup->wIndex == 0x02) {
         /* Get URL request */
-        uint8_t index = GET_DESC_INDEX(pSetup->wValue);
+        u8_t index = GET_DESC_INDEX(pSetup->wValue);
 
         if (index == 0 || index > NUMBER_OF_ALLOWED_ORIGINS)
             return -ENOTSUP;
 
         if (index == 1) {
-            *data = (uint8_t *)(&webusb_origin_url_1);
+            *data = (u8_t *)(&webusb_origin_url_1);
             *len = sizeof(webusb_origin_url_1);
             return 0;
         } else if (index == 2) {
-            *data = (uint8_t *)(&webusb_origin_url_2);
+            *data = (u8_t *)(&webusb_origin_url_2);
             *len = sizeof(webusb_origin_url_2);
             return 0;
         }
     } else if (pSetup->bRequest == 0x02 &&
         pSetup->wIndex == MS_OS_20_REQUEST_DESCRIPTOR) {
 
-        *data = (uint8_t *)(ms_os_20_descriptor_set);
+        *data = (u8_t *)(ms_os_20_descriptor_set);
         *len = sizeof(ms_os_20_descriptor_set);
         return 0;
     }

--- a/src/jerry-port/zjs_jerry_port.c
+++ b/src/jerry-port/zjs_jerry_port.c
@@ -41,6 +41,7 @@ void jerry_port_log(jerry_log_level_t level, const char *fmat, ...)
 }
 
 #ifdef JERRY_PORT_ENABLE_JOBQUEUE
+#include "../zjs_common.h"
 #include "../zjs_callbacks.h"
 #include "../zjs_util.h"
 // The job queue is essentially C callbacks, this is a simple wrapper

--- a/src/main.c
+++ b/src/main.c
@@ -52,12 +52,12 @@ const char script_jscode[] = {
 
 #ifdef ZJS_LINUX_BUILD
 // enabled if --noexit is passed to jslinux
-static uint8_t no_exit = 0;
+static u8_t no_exit = 0;
 // if > 0, jslinux will exit after this many milliseconds
-static uint32_t exit_after = 0;
+static u32_t exit_after = 0;
 static struct timespec exit_timer;
 
-uint8_t process_cmd_line(int argc, char *argv[])
+u8_t process_cmd_line(int argc, char *argv[])
 {
     int i;
     for (i = 0; i < argc; ++i) {
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     const char *script = NULL;
 #endif
     jerry_value_t code_eval;
-    uint32_t len;
+    u32_t len;
 #endif
 #ifndef ZJS_LINUX_BUILD
     zjs_loop_init();
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
     jerry_release_value(result);
 
 #ifdef ZJS_LINUX_BUILD
-    uint8_t last_serviced = 1;
+    u8_t last_serviced = 1;
 #endif
 #ifdef ZJS_ASHELL
     zjs_ashell_init();
@@ -201,8 +201,8 @@ int main(int argc, char *argv[])
 #ifdef ZJS_ASHELL
         zjs_ashell_process();
 #endif
-        int32_t wait_time = ZJS_TICKS_FOREVER;
-        uint8_t serviced = 0;
+        s32_t wait_time = ZJS_TICKS_FOREVER;
+        u8_t serviced = 0;
 
         // callback cannot return a wait time
         if (zjs_service_callbacks()) {
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
             // an exit timeout was passed in
             struct timespec now;
             clock_gettime(CLOCK_MONOTONIC, &now);
-            uint32_t elapsed = (1000 * (now.tv_sec - exit_timer.tv_sec)) +
+            u32_t elapsed = (1000 * (now.tv_sec - exit_timer.tv_sec)) +
                     ((now.tv_nsec / 1000000) - (exit_timer.tv_nsec / 1000000));
             if (elapsed >= exit_after) {
                 ZJS_PRINT("%u milliseconds have passed, exiting!\n",

--- a/src/zjs_a101_pins.c
+++ b/src/zjs_a101_pins.c
@@ -1,12 +1,13 @@
 // Copyright (c) 2016-2017, Intel Corporation.
 
 // ZJS includes
-#include <zjs_gpio.h>
-#include <zjs_pwm.h>
-#include <zjs_util.h>
+#include "zjs_common.h"
+#include "zjs_gpio.h"
+#include "zjs_pwm.h"
+#include "zjs_util.h"
 
 #ifdef BUILD_MODULE_PWM
-static void zjs_a101_num_to_pwm(uint32_t num, int *dev, int *pin)
+static void zjs_a101_num_to_pwm(u32_t num, int *dev, int *pin)
 {
     *dev = 0;
     if (num < 0) {

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -51,7 +51,7 @@ static const jerry_object_native_info_t aio_type_info =
    .free_cb = zjs_aio_free_cb
 };
 
-static bool zjs_aio_ipm_send_async(uint32_t type, uint32_t pin, void *data) {
+static bool zjs_aio_ipm_send_async(u32_t type, u32_t pin, void *data) {
     zjs_ipm_message_t msg;
     msg.id = MSG_ID_AIO;
     msg.flags = 0;
@@ -110,12 +110,12 @@ static jerry_value_t zjs_aio_call_remote_function(zjs_ipm_message_t *send)
         return zjs_error_context("error received", 0, 0);
     }
 
-    uint32_t value = reply.data.aio.value;
+    u32_t value = reply.data.aio.value;
     return jerry_create_number(value);
 }
 
 // INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or likely prints!
-static void ipm_msg_receive_callback(void *context, uint32_t id,
+static void ipm_msg_receive_callback(void *context, u32_t id,
                                      volatile void *data)
 {
     if (id != MSG_ID_AIO)
@@ -134,9 +134,9 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
     } else {
         // asynchronous ipm
         aio_handle_t *handle = (aio_handle_t *)msg->user_data;
-        uint32_t pin_value = msg->data.aio.value;
+        u32_t pin_value = msg->data.aio.value;
 #ifdef DEBUG_BUILD
-        uint32_t pin = msg->data.aio.pin;
+        u32_t pin = msg->data.aio.pin;
 #endif
 
         switch(msg->type) {
@@ -162,7 +162,7 @@ static void ipm_msg_receive_callback(void *context, uint32_t id,
 
 static ZJS_DECL_FUNC(zjs_aio_pin_read)
 {
-    uint32_t pin;
+    u32_t pin;
     zjs_obj_get_uint32(this, "pin", &pin);
 
     if (pin < ARC_AIO_MIN || pin > ARC_AIO_MAX) {
@@ -181,7 +181,7 @@ static ZJS_DECL_FUNC(zjs_aio_pin_read)
 
 static ZJS_DECL_FUNC(zjs_aio_pin_close)
 {
-    uint32_t pin;
+    u32_t pin;
     zjs_obj_get_uint32(this, "pin", &pin);
 
     aio_handle_t *handle;
@@ -203,7 +203,7 @@ static ZJS_DECL_FUNC(zjs_aio_pin_on)
     // args: event name, callback
     ZJS_VALIDATE_ARGS(Z_STRING, Z_FUNCTION Z_NULL);
 
-    uint32_t pin;
+    u32_t pin;
     zjs_obj_get_uint32(this, "pin", &pin);
 
     jerry_size_t size = MAX_TYPE_LEN;
@@ -252,7 +252,7 @@ static ZJS_DECL_FUNC(zjs_aio_pin_read_async)
     // args: callback
     ZJS_VALIDATE_ARGS(Z_FUNCTION);
 
-    uint32_t pin;
+    u32_t pin;
     zjs_obj_get_uint32(this, "pin", &pin);
 
     aio_handle_t *handle = zjs_aio_alloc_handle();
@@ -280,7 +280,7 @@ static ZJS_DECL_FUNC(zjs_aio_open)
 
     jerry_value_t data = argv[0];
 
-    uint32_t pin;
+    u32_t pin;
     if (!zjs_obj_get_uint32(data, "pin", &pin))
         return zjs_error("missing required field (pin)");
 

--- a/src/zjs_board.c
+++ b/src/zjs_board.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 // ZJS includes
+#include "zjs_common.h"
 #include "zjs_board.h"
 #include "zjs_gpio.h"
 #include "zjs_util.h"

--- a/src/zjs_board.h
+++ b/src/zjs_board.h
@@ -18,12 +18,12 @@ typedef struct zjs_pin {
     const char *name;      // string name
     const char *altname;   // alternate name, e.g. number as string
     const char *altname2;  // second alternate name, e.g. PWM channel
-    uint8_t device;
-    uint8_t gpio;
+    u8_t device;
+    u8_t gpio;
 #if defined(CONFIG_BOARD_ARDUINO_101) || defined(ZJS_LINUX_BUILD)
-    uint8_t gpio_ss;
+    u8_t gpio_ss;
 #endif
-    uint8_t pwm;
+    u8_t pwm;
 } zjs_pin_t;
 
 // return codes from zjs_board_find_pin

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -8,6 +8,7 @@
 #include "jerryscript.h"
 
 // ZJS includes
+#include "zjs_common.h"
 #include "zjs_util.h"
 #include "zjs_buffer.h"
 
@@ -68,9 +69,9 @@ static ZJS_DECL_FUNC_ARGS(zjs_buffer_read_bytes, int bytes, bool big_endian)
     // args: offset
     ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_NUMBER);
 
-    uint32_t offset = 0;
+    u32_t offset = 0;
     if (argc >= 1)
-        offset = (uint32_t)jerry_get_number_value(argv[0]);
+        offset = (u32_t)jerry_get_number_value(argv[0]);
 
     zjs_buffer_t *buf = zjs_buffer_find(this);
     if (!buf)
@@ -83,7 +84,7 @@ static ZJS_DECL_FUNC_ARGS(zjs_buffer_read_bytes, int bytes, bool big_endian)
     if (!big_endian)
         offset += bytes - 1;  // start on the big end
 
-    uint32_t value = 0;
+    u32_t value = 0;
     for (int i = 0; i < bytes; i++) {
         value <<= 8;
         value |= buf->buffer[offset];
@@ -111,11 +112,11 @@ static ZJS_DECL_FUNC_ARGS(zjs_buffer_write_bytes, int bytes, bool big_endian)
 
     // technically negatives aren't supported but this makes them behave better
     double dval = jerry_get_number_value(argv[0]);
-    uint32_t value = (uint32_t)(dval < 0 ? (int32_t)dval : dval);
+    u32_t value = (u32_t)(dval < 0 ? (s32_t)dval : dval);
 
-    uint32_t offset = 0;
+    u32_t offset = 0;
     if (argc > 1)
-        offset = (uint32_t)jerry_get_number_value(argv[1]);
+        offset = (u32_t)jerry_get_number_value(argv[1]);
 
     zjs_buffer_t *buf = zjs_buffer_find(this);
     if (!buf)
@@ -289,13 +290,13 @@ static ZJS_DECL_FUNC(zjs_buffer_write_string)
         return zjs_error("buffer not found");
     }
 
-    uint32_t offset = 0;
+    u32_t offset = 0;
     if (argc > 1)
-        offset = (uint32_t)jerry_get_number_value(argv[1]);
+        offset = (u32_t)jerry_get_number_value(argv[1]);
 
-    uint32_t length = buf->bufsize - offset;
+    u32_t length = buf->bufsize - offset;
     if (argc > 2)
-        length = (uint32_t)jerry_get_number_value(argv[2]);
+        length = (u32_t)jerry_get_number_value(argv[2]);
 
     if (length > size) {
         zjs_free(str);
@@ -313,7 +314,7 @@ static ZJS_DECL_FUNC(zjs_buffer_write_string)
     return jerry_create_number(length);
 }
 
-jerry_value_t zjs_buffer_create(uint32_t size, zjs_buffer_t **ret_buf)
+jerry_value_t zjs_buffer_create(u32_t size, zjs_buffer_t **ret_buf)
 {
     // requires: size is size of desired buffer, in bytes
     //  effects: allocates a JS Buffer object, an underlying C buffer, and a
@@ -321,7 +322,7 @@ jerry_value_t zjs_buffer_create(uint32_t size, zjs_buffer_t **ret_buf)
     //             otherwise return the JS object
 
     // follow Node's Buffer.kMaxLength limits though we don't expose that
-    uint32_t maxLength = (1UL << 31) - 1;
+    u32_t maxLength = (1UL << 31) - 1;
     if (sizeof(size_t) == 4) {
         // detected 32-bit architecture
         maxLength = (1 << 30) - 1;
@@ -372,7 +373,7 @@ static ZJS_DECL_FUNC(zjs_buffer)
 
     if (jerry_value_is_number(argv[0])) {
         double dnum = jerry_get_number_value(argv[0]);
-        uint32_t unum;
+        u32_t unum;
         if (dnum < 0) {
             unum = 0;
         }
@@ -381,7 +382,7 @@ static ZJS_DECL_FUNC(zjs_buffer)
         }
         else {
             // round to the nearest integer
-            unum = (uint32_t)(dnum + 0.5);
+            unum = (u32_t)(dnum + 0.5);
         }
 
         // treat a number argument as a length
@@ -390,7 +391,7 @@ static ZJS_DECL_FUNC(zjs_buffer)
     else if (jerry_value_is_array(argv[0])) {
         // treat array argument as byte initializers
         jerry_value_t array = argv[0];
-        uint32_t len = jerry_get_array_length(array);
+        u32_t len = jerry_get_array_length(array);
 
         zjs_buffer_t *buf;
         jerry_value_t new_buf = zjs_buffer_create(len, &buf);
@@ -398,7 +399,7 @@ static ZJS_DECL_FUNC(zjs_buffer)
             for (int i = 0; i < len; i++) {
                 ZVAL item = jerry_get_property_by_index(array, i);
                 if (jerry_value_is_number(item)) {
-                    buf->buffer[i] = (uint8_t)jerry_get_number_value(item);
+                    buf->buffer[i] = (u8_t)jerry_get_number_value(item);
                 } else {
                     ERR_PRINT("non-numeric value in array, treating as 0\n");
                     buf->buffer[i] = 0;

--- a/src/zjs_buffer.h
+++ b/src/zjs_buffer.h
@@ -13,8 +13,8 @@ void zjs_buffer_cleanup();
 
 // FIXME: We should make this private and have accessor methods
 typedef struct zjs_buffer {
-    uint8_t *buffer;
-    uint32_t bufsize;
+    u8_t *buffer;
+    u32_t bufsize;
 } zjs_buffer_t;
 
 /**
@@ -44,6 +44,6 @@ zjs_buffer_t *zjs_buffer_find(const jerry_value_t obj);
  * @return  New JS Buffer or Error object, and sets *ret_buf to C handle or
  *            NULL, if given
  */
-jerry_value_t zjs_buffer_create(uint32_t size, zjs_buffer_t **ret_buf);
+jerry_value_t zjs_buffer_create(u32_t size, zjs_buffer_t **ret_buf);
 
 #endif  // __zjs_buffer_h__

--- a/src/zjs_callbacks.h
+++ b/src/zjs_callbacks.h
@@ -5,7 +5,7 @@
 
 #include "jerryscript.h"
 
-typedef int16_t zjs_callback_id;
+typedef s16_t zjs_callback_id;
 
 /*
  * Function that will be called AFTER the JS function is called.
@@ -95,7 +95,7 @@ void zjs_remove_all_callbacks(void);
 
 void signal_callback_priv(zjs_callback_id id,
                           const void *args,
-                          uint32_t size
+                          u32_t size
 #ifdef DEBUG_BUILD
                           , const char *file,
                           const char *func);
@@ -137,7 +137,7 @@ zjs_callback_id add_callback_priv(jerry_value_t js_func,
                                   jerry_value_t this,
                                   void *handle,
                                   zjs_post_callback_func post,
-                                  uint8_t once
+                                  u8_t once
 #ifdef DEBUG_BUILD
                                   , const char *file,
                                   const char *func);
@@ -230,7 +230,7 @@ zjs_callback_id zjs_add_c_callback(void *handle, zjs_c_callback_func callback);
  * @param data          Callback arguments
  * @param sz            Size of callback arguments in bytes
  */
-void zjs_call_callback(zjs_callback_id id, const void *data, uint32_t sz);
+void zjs_call_callback(zjs_callback_id id, const void *data, u32_t sz);
 
 /*
  * Service the callback module. Any callback's that have been signaled will
@@ -239,6 +239,6 @@ void zjs_call_callback(zjs_callback_id id, const void *data, uint32_t sz);
  * @return              1 if any callbacks were processed
  *                      0 if no callbacks were processed
  */
-uint8_t zjs_service_callbacks(void);
+u8_t zjs_service_callbacks(void);
 
 #endif /* SRC_ZJS_CALLBACKS_H_ */

--- a/src/zjs_common.c
+++ b/src/zjs_common.c
@@ -1,5 +1,6 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
+#include <stdint.h>
 #include <string.h>
 
 // ZJS includes
@@ -60,7 +61,7 @@ int zjs_get_ms(void)
 
 static zjs_port_timer_t print_timer;
 // Millisecond counter to increment
-static uint32_t milli = 0;
+static u32_t milli = 0;
 
 void update_print_timer(void)
 {

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -10,6 +10,19 @@
 #include <misc/printk.h>
 #endif
 
+#ifdef ZJS_LINUX_BUILD
+typedef int8_t s8_t;
+typedef uint8_t u8_t;
+typedef int16_t s16_t;
+typedef uint16_t u16_t;
+typedef int32_t s32_t;
+typedef uint32_t u32_t;
+typedef int64_t s64_t;
+typedef uint64_t u64_t;
+#else
+#include <zephyr/types.h>
+#endif
+
 #ifdef CONFIG_ARC
 #define ZJS_PRINT printk
 #else

--- a/src/zjs_console.c
+++ b/src/zjs_console.c
@@ -58,7 +58,7 @@ static bool value2str(const jerry_value_t value, char *buf, int maxlen,
         return false;
     }
     else if (jerry_value_is_boolean(value)) {
-        uint8_t val = jerry_get_boolean_value(value);
+        u8_t val = jerry_get_boolean_value(value);
         sprintf(buf, (val) ? "true" : "false");
     }
     else if (jerry_value_is_function(value)) {
@@ -121,7 +121,7 @@ static void print_value(const jerry_value_t value, FILE *out, bool deep,
     char buf[MAX_STR_LENGTH];
     if (!value2str(value, buf, MAX_STR_LENGTH, quotes) && deep) {
         if (jerry_value_is_array(value)) {
-            uint32_t len = jerry_get_array_length(value);
+            u32_t len = jerry_get_array_length(value);
             fprintf(out, "[");
             for (int i = 0; i < len; i++) {
                 if (i) {
@@ -166,7 +166,7 @@ static ZJS_DECL_FUNC(console_time)
     // args: label
     ZJS_VALIDATE_ARGS(Z_STRING);
 
-    uint32_t start = zjs_port_timer_get_uptime();
+    u32_t start = zjs_port_timer_get_uptime();
 
     ZVAL num = jerry_create_number(start);
     jerry_set_property(gbl_time_obj, argv[0], num);
@@ -185,7 +185,7 @@ static ZJS_DECL_FUNC(console_time_end)
         return TYPE_ERROR("unexpected value");
     }
 
-    uint32_t start = (uint32_t)jerry_get_number_value(num);
+    u32_t start = (u32_t)jerry_get_number_value(num);
     unsigned int milli = zjs_port_timer_get_uptime() - start;
 
     char *label = zjs_alloc_from_jstring(argv[0], NULL);

--- a/src/zjs_error.c
+++ b/src/zjs_error.c
@@ -86,7 +86,7 @@ static char *construct_message(jerry_value_t this, jerry_value_t func,
     if (!jerry_value_is_array(keys_array)) {
         return NULL;
     }
-    uint32_t arr_length = jerry_get_array_length(keys_array);
+    u32_t arr_length = jerry_get_array_length(keys_array);
     int i;
     for (i = 0; i < arr_length; ++i) {
         ZVAL val = jerry_get_property_by_index(keys_array, i);

--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -38,31 +38,31 @@ void post_event(void *h, jerry_value_t ret_val)
     }
 }
 
-static uint32_t get_num_events(jerry_value_t emitter)
+static u32_t get_num_events(jerry_value_t emitter)
 {
     ZVAL val = zjs_get_property(emitter, "numEvents");
     if (!jerry_value_is_number(val)) {
         ERR_PRINT("emitter had no numEvents property\n");
         return 0;
     }
-    uint32_t num = jerry_get_number_value(val);
+    u32_t num = jerry_get_number_value(val);
     return num;
 }
 
-static uint32_t get_max_event_listeners(jerry_value_t emitter)
+static u32_t get_max_event_listeners(jerry_value_t emitter)
 {
     ZVAL val = zjs_get_property(emitter, "maxListeners");
     if (!jerry_value_is_number(val)) {
         ERR_PRINT("emitter had no maxListeners property\n");
         return 0;
     }
-    uint32_t num = jerry_get_number_value(val);
+    u32_t num = jerry_get_number_value(val);
     return num;
 }
 
-static int32_t get_callback_id(jerry_value_t event_obj)
+static s32_t get_callback_id(jerry_value_t event_obj)
 {
-    int32_t callback_id = -1;
+    s32_t callback_id = -1;
     ZVAL id_prop = zjs_get_property(event_obj, "callback_id");
     if (jerry_value_is_number(id_prop)) {
         // If there already is an event object, get the callback ID
@@ -79,8 +79,8 @@ void zjs_add_event_listener(jerry_value_t obj, const char *event,
         ERR_PRINT("no event '%s' found\n", event);
         return;
     }
-    uint32_t num_events = get_num_events(event_emitter);
-    uint32_t max_listeners = get_max_event_listeners(event_emitter);
+    u32_t num_events = get_num_events(event_emitter);
+    u32_t max_listeners = get_max_event_listeners(event_emitter);
 
     if (num_events >= max_listeners) {
         ERR_PRINT("max listeners reached\n");
@@ -98,7 +98,7 @@ void zjs_add_event_listener(jerry_value_t obj, const char *event,
     sprintf(name, "%s: %s", "event", event);
     zjs_obj_add_string(listener, name, ZJS_HIDDEN_PROP("function_name"));
 #endif
-    int32_t callback_id = get_callback_id(event_obj);
+    s32_t callback_id = get_callback_id(event_obj);
     callback_id = zjs_add_callback_list(listener, obj, NULL, post_event,
                                         callback_id);
     // Add callback ID to event object
@@ -167,7 +167,7 @@ static ZJS_DECL_FUNC(remove_listener)
         return ZJS_UNDEFINED;
     }
 
-    int32_t callback_id = get_callback_id(event_obj);
+    s32_t callback_id = get_callback_id(event_obj);
     if (callback_id != -1) {
         zjs_remove_callback_list_func(callback_id, argv[1]);
     } else {
@@ -200,7 +200,7 @@ static ZJS_DECL_FUNC(remove_all_listeners)
         return ZJS_UNDEFINED;
     }
 
-    int32_t callback_id = get_callback_id(event_obj);
+    s32_t callback_id = get_callback_id(event_obj);
     if (callback_id != -1) {
         zjs_remove_callback(callback_id);
 
@@ -232,7 +232,7 @@ static ZJS_DECL_FUNC(get_event_names)
     event_names_t names;
 
     ZVAL event_emitter = zjs_get_property(this, ZJS_HIDDEN_PROP("event"));
-    uint32_t num_events = get_num_events(event_emitter);
+    u32_t num_events = get_num_events(event_emitter);
     ZVAL map = zjs_get_property(event_emitter, "map");
 
     names.idx = 0;
@@ -246,7 +246,7 @@ static ZJS_DECL_FUNC(get_event_names)
 static ZJS_DECL_FUNC(get_max_listeners)
 {
     ZVAL event_emitter = zjs_get_property(this, ZJS_HIDDEN_PROP("event"));
-    uint32_t max_listeners = get_max_event_listeners(event_emitter);
+    u32_t max_listeners = get_max_event_listeners(event_emitter);
     return jerry_create_number(max_listeners);
 }
 
@@ -287,7 +287,7 @@ static ZJS_DECL_FUNC(get_listener_count)
         return jerry_create_number(0);
     }
 
-    int32_t callback_id = get_callback_id(event_obj);
+    s32_t callback_id = get_callback_id(event_obj);
     int count = 0;
     if (callback_id != -1) {
         count = zjs_get_num_callbacks(callback_id);
@@ -319,7 +319,7 @@ static ZJS_DECL_FUNC(get_listeners)
         return zjs_error("event object not found");
     }
 
-    int32_t callback_id = get_callback_id(event_obj);
+    s32_t callback_id = get_callback_id(event_obj);
     if (callback_id == -1) {
         ERR_PRINT("callback_id not found for '%s'\n", event);
         return ZJS_UNDEFINED;
@@ -340,7 +340,7 @@ static ZJS_DECL_FUNC(get_listeners)
 bool zjs_trigger_event(jerry_value_t obj,
                        const char *event,
                        const jerry_value_t argv[],
-                       uint32_t argc,
+                       u32_t argc,
                        zjs_post_event post,
                        void *h)
 {
@@ -353,7 +353,7 @@ bool zjs_trigger_event(jerry_value_t obj,
         return false;
     }
 
-    int32_t callback_id = get_callback_id(event_obj);
+    s32_t callback_id = get_callback_id(event_obj);
     if (callback_id == -1) {
         ERR_PRINT("callback_id not found\n");
         return false;
@@ -380,7 +380,7 @@ bool zjs_trigger_event(jerry_value_t obj,
 bool zjs_trigger_event_now(jerry_value_t obj,
                            const char *event,
                            const jerry_value_t argv[],
-                           uint32_t argc,
+                           u32_t argc,
                            zjs_post_event post,
                            void *h)
 {
@@ -393,7 +393,7 @@ bool zjs_trigger_event_now(jerry_value_t obj,
         return false;
     }
 
-    int32_t callback_id = get_callback_id(event_obj);
+    s32_t callback_id = get_callback_id(event_obj);
     if (callback_id == -1) {
         ERR_PRINT("callback_id not found\n");
         return false;

--- a/src/zjs_event.h
+++ b/src/zjs_event.h
@@ -54,7 +54,7 @@ void zjs_add_event_listener(jerry_value_t obj, const char *event,
  * @return              True if there were listeners
  */
 bool zjs_trigger_event(jerry_value_t obj, const char *event,
-                       const jerry_value_t argv[], uint32_t argc,
+                       const jerry_value_t argv[], u32_t argc,
                        zjs_post_event post, void *handle);
 
 /**
@@ -70,7 +70,7 @@ bool zjs_trigger_event(jerry_value_t obj, const char *event,
  * @return              True if there were listeners
  */
 bool zjs_trigger_event_now(jerry_value_t obj, const char *event,
-                           const jerry_value_t argv[], uint32_t argc,
+                           const jerry_value_t argv[], u32_t argc,
                            zjs_post_event post, void *h);
 
 /**

--- a/src/zjs_gpio_mock.h
+++ b/src/zjs_gpio_mock.h
@@ -14,10 +14,10 @@
 struct mock_gpio_callback;
 typedef void (*mock_gpio_callback_handler_t)(DEVICE port,
                                              struct mock_gpio_callback *cb,
-                                             uint32_t pins);
+                                             u32_t pins);
 struct mock_gpio_callback {
     mock_gpio_callback_handler_t handler;
-    uint32_t pin_mask;
+    u32_t pin_mask;
 };
 
 // redefine calls to Zephyr APIs we're mocking
@@ -34,15 +34,15 @@ struct mock_gpio_callback {
 #define gpio_pin_enable_callback mock_gpio_pin_enable_callback
 
 DEVICE mock_gpio_device_get_binding(const char *name);
-int mock_gpio_pin_read(DEVICE port, uint32_t pin, uint32_t *value);
-int mock_gpio_pin_write(DEVICE port, uint32_t pin, uint32_t value);
-int mock_gpio_pin_configure(DEVICE port, uint8_t pin, int flags);
+int mock_gpio_pin_read(DEVICE port, u32_t pin, u32_t *value);
+int mock_gpio_pin_write(DEVICE port, u32_t pin, u32_t value);
+int mock_gpio_pin_configure(DEVICE port, u8_t pin, int flags);
 void mock_gpio_init_callback(struct gpio_callback *callback,
                              gpio_callback_handler_t handler,
-                             uint32_t pin_mask);
+                             u32_t pin_mask);
 int mock_gpio_add_callback(DEVICE port, struct gpio_callback *callback);
 int mock_gpio_remove_callback(DEVICE port, struct gpio_callback *callback);
-int mock_gpio_pin_enable_callback(DEVICE port, uint32_t pin);
+int mock_gpio_pin_enable_callback(DEVICE port, u32_t pin);
 
 #ifdef ZJS_LINUX_BUILD
 // provide Zephyr dependencies

--- a/src/zjs_grove_lcd.c
+++ b/src/zjs_grove_lcd.c
@@ -63,8 +63,8 @@ static ZJS_DECL_FUNC(zjs_glcd_set_cursor_pos)
         return zjs_error("Grove LCD device not found");
     }
 
-    uint8_t col = (uint8_t)jerry_get_number_value(argv[0]);
-    uint8_t row = (uint8_t)jerry_get_number_value(argv[1]);
+    u8_t col = (u8_t)jerry_get_number_value(argv[0]);
+    u8_t row = (u8_t)jerry_get_number_value(argv[1]);
     glcd_cursor_pos_set(glcd, col, row);
 
     return ZJS_UNDEFINED;
@@ -79,7 +79,7 @@ static ZJS_DECL_FUNC(zjs_glcd_select_color)
         return zjs_error("Grove LCD device not found");
     }
 
-    uint8_t value = (uint8_t)jerry_get_number_value(argv[0]);
+    u8_t value = (u8_t)jerry_get_number_value(argv[0]);
     glcd_color_select(glcd, value);
 
     return ZJS_UNDEFINED;
@@ -94,9 +94,9 @@ static ZJS_DECL_FUNC(zjs_glcd_set_color)
         return zjs_error("Grove LCD device not found");
     }
 
-    uint8_t r = (uint8_t)jerry_get_number_value(argv[0]);
-    uint8_t g = (uint8_t)jerry_get_number_value(argv[1]);
-    uint8_t b = (uint8_t)jerry_get_number_value(argv[2]);
+    u8_t r = (u8_t)jerry_get_number_value(argv[0]);
+    u8_t g = (u8_t)jerry_get_number_value(argv[1]);
+    u8_t b = (u8_t)jerry_get_number_value(argv[2]);
     glcd_color_set(glcd, r, g, b);
 
     return ZJS_UNDEFINED;
@@ -111,7 +111,7 @@ static ZJS_DECL_FUNC(zjs_glcd_set_function)
         return zjs_error("Grove LCD device not found");
     }
 
-    uint8_t value = (uint8_t)jerry_get_number_value(argv[0]);
+    u8_t value = (u8_t)jerry_get_number_value(argv[0]);
     glcd_function_set(glcd, value);
 
     return ZJS_UNDEFINED;
@@ -123,7 +123,7 @@ static ZJS_DECL_FUNC(zjs_glcd_get_function)
         return zjs_error("Grove LCD device not found");
     }
 
-    uint8_t value = glcd_function_get(glcd);
+    u8_t value = glcd_function_get(glcd);
 
     return jerry_create_number(value);
 }
@@ -134,7 +134,7 @@ static ZJS_DECL_FUNC(zjs_glcd_set_display_state)
         return zjs_error("Grove LCD device not found");
     }
 
-    uint8_t value = (uint8_t)jerry_get_number_value(argv[0]);
+    u8_t value = (u8_t)jerry_get_number_value(argv[0]);
     glcd_display_state_set(glcd, value);
 
     return ZJS_UNDEFINED;
@@ -146,7 +146,7 @@ static ZJS_DECL_FUNC(zjs_glcd_get_display_state)
         return zjs_error("Grove LCD device not found");
     }
 
-    uint8_t value = glcd_display_state_get(glcd);
+    u8_t value = glcd_display_state_get(glcd);
 
     return jerry_create_number(value);
 }

--- a/src/zjs_grove_lcd_ipm.c
+++ b/src/zjs_grove_lcd_ipm.c
@@ -64,7 +64,7 @@ static jerry_value_t zjs_glcd_call_remote_function(zjs_ipm_message_t *send)
         return zjs_error_context("error received", 0, 0);
     }
 
-    uint8_t value = reply.data.glcd.value;
+    u8_t value = reply.data.glcd.value;
 
     return jerry_create_number(value);
 }
@@ -79,7 +79,7 @@ static jerry_value_t zjs_glcd_call_remote_ignore(zjs_ipm_message_t *send)
     return ZJS_UNDEFINED;
 }
 
-static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *data)
+static void ipm_msg_receive_callback(void *context, u32_t id, volatile void *data)
 {
     if (id != MSG_ID_GLCD)
         return;
@@ -138,8 +138,8 @@ static ZJS_DECL_FUNC(zjs_glcd_set_cursor_pos)
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
     send.type = TYPE_GLCD_SET_CURSOR_POS;
-    send.data.glcd.col = (uint8_t)jerry_get_number_value(argv[0]);
-    send.data.glcd.row = (uint8_t)jerry_get_number_value(argv[1]);
+    send.data.glcd.col = (u8_t)jerry_get_number_value(argv[0]);
+    send.data.glcd.row = (u8_t)jerry_get_number_value(argv[1]);
 
     return zjs_glcd_call_remote_ignore(&send);
 }
@@ -152,7 +152,7 @@ static ZJS_DECL_FUNC(zjs_glcd_select_color)
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
     send.type = TYPE_GLCD_SELECT_COLOR;
-    send.data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
+    send.data.glcd.value = (u8_t)jerry_get_number_value(argv[0]);
 
     return zjs_glcd_call_remote_ignore(&send);
 }
@@ -165,9 +165,9 @@ static ZJS_DECL_FUNC(zjs_glcd_set_color)
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
     send.type = TYPE_GLCD_SET_COLOR;
-    send.data.glcd.color_r = (uint8_t)jerry_get_number_value(argv[0]);
-    send.data.glcd.color_g = (uint8_t)jerry_get_number_value(argv[1]);
-    send.data.glcd.color_b = (uint8_t)jerry_get_number_value(argv[2]);
+    send.data.glcd.color_r = (u8_t)jerry_get_number_value(argv[0]);
+    send.data.glcd.color_g = (u8_t)jerry_get_number_value(argv[1]);
+    send.data.glcd.color_b = (u8_t)jerry_get_number_value(argv[2]);
 
     return zjs_glcd_call_remote_ignore(&send);
 }
@@ -180,7 +180,7 @@ static ZJS_DECL_FUNC(zjs_glcd_set_function)
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
     send.type = TYPE_GLCD_SET_FUNCTION;
-    send.data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
+    send.data.glcd.value = (u8_t)jerry_get_number_value(argv[0]);
 
     return zjs_glcd_call_remote_ignore(&send);
 }
@@ -203,7 +203,7 @@ static ZJS_DECL_FUNC(zjs_glcd_set_display_state)
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
     send.type = TYPE_GLCD_SET_DISPLAY_STATE;
-    send.data.glcd.value = (uint8_t)jerry_get_number_value(argv[0]);
+    send.data.glcd.value = (u8_t)jerry_get_number_value(argv[0]);
 
     return zjs_glcd_call_remote_ignore(&send);
 }

--- a/src/zjs_i2c.c
+++ b/src/zjs_i2c.c
@@ -34,20 +34,20 @@ static ZJS_DECL_FUNC_ARGS(zjs_i2c_read_base, bool burst)
     // args: device, length[, register]
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER, Z_OPTIONAL Z_NUMBER);
 
-    uint32_t register_addr = 0;
-    uint32_t size = (uint32_t)jerry_get_number_value(argv[1]);
+    u32_t register_addr = 0;
+    u32_t size = (u32_t)jerry_get_number_value(argv[1]);
 
     if (argc >= 3) {
-        register_addr = (uint32_t)jerry_get_number_value(argv[2]);
+        register_addr = (u32_t)jerry_get_number_value(argv[2]);
     }
 
     if (size < 1) {
         return zjs_error("size should be greater than zero");
     }
 
-    uint32_t bus;
+    u32_t bus;
     zjs_obj_get_uint32(this, "bus", &bus);
-    uint32_t address = (uint32_t)jerry_get_number_value(argv[0]);
+    u32_t address = (u32_t)jerry_get_number_value(argv[0]);
     zjs_buffer_t *buf;
     jerry_value_t buf_obj = zjs_buffer_create(size, &buf);
     if (buf) {
@@ -55,22 +55,22 @@ static ZJS_DECL_FUNC_ARGS(zjs_i2c_read_base, bool burst)
             if (register_addr != 0) {
                 // i2c_read checks the first byte for the register address
                 // i2c_burst_read doesn't
-                buf->buffer[0] = (uint8_t)register_addr;
+                buf->buffer[0] = (u8_t)register_addr;
             }
-            int error_msg = zjs_i2c_handle_read((uint8_t)bus,
+            int error_msg = zjs_i2c_handle_read((u8_t)bus,
                                                 buf->buffer,
                                                 buf->bufsize,
-                                                (uint16_t)address);
+                                                (u16_t)address);
             if (error_msg != 0) {
                 ERR_PRINT("i2c_read failed with error %i\n", error_msg);
             }
         }
         else {
-            int error_msg = zjs_i2c_handle_burst_read((uint8_t)bus,
+            int error_msg = zjs_i2c_handle_burst_read((u8_t)bus,
                                                       buf->buffer,
                                                       buf->bufsize,
-                                                      (uint16_t)address,
-                                                      (uint16_t)register_addr);
+                                                      (u16_t)address,
+                                                      (u16_t)register_addr);
             if (error_msg != 0) {
                 ERR_PRINT("i2c_read failed with error %i\n", error_msg);
             }
@@ -123,28 +123,28 @@ static ZJS_DECL_FUNC(zjs_i2c_write)
     // args: device, buffer[, register]
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_BUFFER, Z_OPTIONAL Z_NUMBER);
 
-    uint32_t register_addr = 0;
+    u32_t register_addr = 0;
 
     if (argc >= 3) {
-        register_addr = (uint32_t)jerry_get_number_value(argv[2]);
+        register_addr = (u32_t)jerry_get_number_value(argv[2]);
     }
 
-    uint32_t bus;
+    u32_t bus;
     zjs_obj_get_uint32(this, "bus", &bus);
     zjs_buffer_t *dataBuf = zjs_buffer_find(argv[1]);
 
     if (register_addr != 0) {
         // If the user supplied a register address, add it to the beginning
         // of the buffer, as that's where i2c_write will expect it.
-        dataBuf->buffer[0] = (uint8_t)register_addr;
+        dataBuf->buffer[0] = (u8_t)register_addr;
     }
 
-    uint32_t address = (uint32_t)jerry_get_number_value(argv[0]);
+    u32_t address = (u32_t)jerry_get_number_value(argv[0]);
 
-    int error_msg = zjs_i2c_handle_write((uint8_t)bus,
+    int error_msg = zjs_i2c_handle_write((u8_t)bus,
                                          dataBuf->buffer,
                                          dataBuf->bufsize,
-                                         (uint16_t)address);
+                                         (u16_t)address);
 
     return jerry_create_number(error_msg);
 }
@@ -172,8 +172,8 @@ static ZJS_DECL_FUNC(zjs_i2c_open)
     ZJS_VALIDATE_ARGS(Z_OBJECT);
 
     jerry_value_t data = argv[0];
-    uint32_t bus;
-    uint32_t speed;
+    u32_t bus;
+    u32_t speed;
 
     if (!zjs_obj_get_uint32(data, "bus", &bus)) {
         return zjs_error("missing required field (bus)");
@@ -183,7 +183,7 @@ static ZJS_DECL_FUNC(zjs_i2c_open)
         return zjs_error("missing required field (speed)");
     }
 
-    if (zjs_i2c_handle_open((uint8_t)bus)) {
+    if (zjs_i2c_handle_open((u8_t)bus)) {
         return zjs_error("failed to open connection to I2C bus");
     }
     // create the I2C object

--- a/src/zjs_i2c_handler.c
+++ b/src/zjs_i2c_handler.c
@@ -14,7 +14,7 @@
 
 static struct device *i2c_device[MAX_I2C_BUS];
 
-int zjs_i2c_handle_open(uint8_t msg_bus)
+int zjs_i2c_handle_open(u8_t msg_bus)
 {
     int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {
@@ -44,8 +44,8 @@ int zjs_i2c_handle_open(uint8_t msg_bus)
     return error_code;
 }
 
-int zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data,
-                         uint32_t length, uint16_t address)
+int zjs_i2c_handle_write(u8_t msg_bus, u8_t *data,
+                         u32_t length, u16_t address)
 {
     int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {
@@ -69,8 +69,8 @@ int zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data,
     return error_code;
 }
 
-int zjs_i2c_handle_read(uint8_t msg_bus, uint8_t *data, uint32_t length,
-                        uint16_t address)
+int zjs_i2c_handle_read(u8_t msg_bus, u8_t *data, u32_t length,
+                        u16_t address)
 {
     int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {
@@ -92,8 +92,8 @@ int zjs_i2c_handle_read(uint8_t msg_bus, uint8_t *data, uint32_t length,
     return error_code;
 }
 
-int zjs_i2c_handle_burst_read(uint8_t msg_bus, uint8_t *data, uint32_t length,
-                              uint16_t address, uint16_t register_addr)
+int zjs_i2c_handle_burst_read(u8_t msg_bus, u8_t *data, u32_t length,
+                              u16_t address, u16_t register_addr)
 {
     int error_code = -1;
     if (msg_bus < MAX_I2C_BUS) {

--- a/src/zjs_i2c_handler.h
+++ b/src/zjs_i2c_handler.h
@@ -4,9 +4,9 @@
 
 #include <i2c.h>
 
-int zjs_i2c_handle_open(uint8_t msg_bus);
-int zjs_i2c_handle_write(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address);
-int zjs_i2c_handle_read(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address);
-int zjs_i2c_handle_burst_read(uint8_t msg_bus, uint8_t *data, uint32_t length, uint16_t address, uint16_t register_addr);
+int zjs_i2c_handle_open(u8_t msg_bus);
+int zjs_i2c_handle_write(u8_t msg_bus, u8_t *data, u32_t length, u16_t address);
+int zjs_i2c_handle_read(u8_t msg_bus, u8_t *data, u32_t length, u16_t address);
+int zjs_i2c_handle_burst_read(u8_t msg_bus, u8_t *data, u32_t length, u16_t address, u16_t register_addr);
 
 #endif  // __zjs_i2c_handler_h__

--- a/src/zjs_i2c_ipm_handler.c
+++ b/src/zjs_i2c_ipm_handler.c
@@ -28,7 +28,7 @@ static bool zjs_i2c_ipm_send_sync(zjs_ipm_message_t *send,
     return true;
 }
 
-static void ipm_msg_receive_callback(void *context, uint32_t id,
+static void ipm_msg_receive_callback(void *context, u32_t id,
                                      volatile void *data)
 {
     if (id != MSG_ID_I2C)
@@ -56,16 +56,15 @@ void zjs_i2c_ipm_init() {
     k_sem_init(&i2c_sem, 0, 1);
 }
 
-int zjs_i2c_handle_write (uint8_t msg_bus, uint8_t *data, uint32_t length,
-                              uint16_t address)
+int zjs_i2c_handle_write(u8_t msg_bus, u8_t *data, u32_t length, u16_t address)
 {
     zjs_ipm_message_t send;
     zjs_ipm_message_t reply;
 
     send.type = TYPE_I2C_WRITE;
-    send.data.i2c.bus = (uint8_t)msg_bus;
+    send.data.i2c.bus = (u8_t)msg_bus;
     send.data.i2c.data = data;
-    send.data.i2c.address = (uint16_t)address;
+    send.data.i2c.address = (u16_t)address;
     send.data.i2c.length = length;
 
 
@@ -79,15 +78,15 @@ int zjs_i2c_handle_write (uint8_t msg_bus, uint8_t *data, uint32_t length,
     return send.error_code;
 }
 
-int zjs_i2c_handle_open (uint8_t msg_bus)
+int zjs_i2c_handle_open(u8_t msg_bus)
 {
     // send IPM message to the ARC side
     zjs_ipm_message_t send;
     zjs_ipm_message_t reply;
 
     send.type = TYPE_I2C_OPEN;
-    send.data.i2c.bus = (uint8_t)msg_bus;
-    send.data.i2c.speed = (uint8_t)I2C_SPEED_STANDARD;
+    send.data.i2c.bus = (u8_t)msg_bus;
+    send.data.i2c.speed = (u8_t)I2C_SPEED_STANDARD;
 
     bool success = zjs_i2c_ipm_send_sync(&send, &reply);
 
@@ -102,16 +101,15 @@ int zjs_i2c_handle_open (uint8_t msg_bus)
     return send.error_code;
 }
 
-int zjs_i2c_handle_read (uint8_t msg_bus, uint8_t *data, uint32_t length,
-                             uint16_t address)
+int zjs_i2c_handle_read(u8_t msg_bus, u8_t *data, u32_t length, u16_t address)
 {
     zjs_ipm_message_t send;
     zjs_ipm_message_t reply;
 
     send.type = TYPE_I2C_READ;
-    send.data.i2c.bus = (uint8_t)msg_bus;
+    send.data.i2c.bus = (u8_t)msg_bus;
     send.data.i2c.data = data;
-    send.data.i2c.address = (uint16_t)address;
+    send.data.i2c.address = (u16_t)address;
     send.data.i2c.length = length;
 
     bool success = zjs_i2c_ipm_send_sync(&send, &reply);
@@ -122,17 +120,16 @@ int zjs_i2c_handle_read (uint8_t msg_bus, uint8_t *data, uint32_t length,
     return send.error_code;
 }
 
-int zjs_i2c_handle_burst_read (uint8_t msg_bus, uint8_t *data,
-                                   uint32_t length, uint16_t address,
-                                   uint16_t register_addr)
+int zjs_i2c_handle_burst_read(u8_t msg_bus, u8_t *data, u32_t length,
+                              u16_t address, u16_t register_addr)
 {
     zjs_ipm_message_t send;
     zjs_ipm_message_t reply;
 
     send.type = TYPE_I2C_BURST_READ;
-    send.data.i2c.bus = (uint8_t)msg_bus;
+    send.data.i2c.bus = (u8_t)msg_bus;
     send.data.i2c.data = data;
-    send.data.i2c.address = (uint16_t)address;
+    send.data.i2c.address = (u16_t)address;
     send.data.i2c.register_addr = register_addr;
     send.data.i2c.length = length;
 

--- a/src/zjs_ipm.c
+++ b/src/zjs_ipm.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 #ifndef QEMU_BUILD
 // ipm for ARC communication
 #include <ipm/ipm_quark_se.h>
@@ -18,7 +18,7 @@ QUARK_SE_IPM_DEFINE(ipm_msg_send, IPM_CHANNEL_ARC_TO_X86, QUARK_SE_IPM_OUTBOUND)
 #endif
 
 struct zjs_ipm_callback {
-    uint32_t msg_id;
+    u32_t msg_id;
     ipm_callback_t callback;
     struct zjs_ipm_callback *next;
 };
@@ -29,7 +29,7 @@ static struct device *ipm_receive_dev;
 #ifdef CONFIG_X86
 static struct zjs_ipm_callback *zjs_ipm_callbacks = NULL;
 
-static void zjs_ipm_msg_callback(void *context, uint32_t id, volatile void *data)
+static void zjs_ipm_msg_callback(void *context, u32_t id, volatile void *data)
 {
     for (struct zjs_ipm_callback *cb = zjs_ipm_callbacks; cb; cb = cb->next) {
         if (cb->msg_id == id) {
@@ -60,7 +60,7 @@ void zjs_ipm_init()
 #endif
 }
 
-int zjs_ipm_send(uint32_t id, zjs_ipm_message_t *data)
+int zjs_ipm_send(u32_t id, zjs_ipm_message_t *data)
 {
     if (!ipm_send_dev) {
         ERR_PRINT("Cannot find outbound ipm device!\n" );
@@ -71,7 +71,7 @@ int zjs_ipm_send(uint32_t id, zjs_ipm_message_t *data)
     return ipm_send(ipm_send_dev, 1, id, &data, sizeof(void *));
 }
 
-void zjs_ipm_register_callback(uint32_t msg_id, ipm_callback_t cb)
+void zjs_ipm_register_callback(u32_t msg_id, ipm_callback_t cb)
 {
     if (!ipm_receive_dev) {
         ERR_PRINT("Cannot find inbound ipm device!\n" );

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -99,40 +99,40 @@ enum {
 #define TYPE_PME_END_RESTORE_MODE                          0x0055
 
 typedef struct zjs_ipm_message {
-    uint32_t id;
-    uint32_t type;
-    uint32_t flags;
+    u32_t id;
+    u32_t type;
+    u32_t flags;
     void *user_data;
-    uint32_t error_code;
+    u32_t error_code;
 
     union {
 #ifdef BUILD_MODULE_AIO
         struct aio_data {
-            uint32_t pin;
-            uint32_t value;
+            u32_t pin;
+            u32_t value;
         } aio;
 #endif // AIO
 
 #ifdef BUILD_MODULE_I2C
         struct i2c_data {
-            uint8_t bus;
-            uint8_t speed;
-            uint16_t address;
-            uint16_t register_addr;
-            uint8_t *data;
-            uint32_t length;
+            u8_t bus;
+            u8_t speed;
+            u16_t address;
+            u16_t register_addr;
+            u8_t *data;
+            u32_t length;
         } i2c;
 #endif // I2C
 
 #ifdef BUILD_MODULE_GROVE_LCD
         // GROVE_LCD
         struct glcd_data {
-            uint8_t value;
-            uint8_t col;
-            uint8_t row;
-            uint8_t color_r;
-            uint8_t color_g;
-            uint8_t color_b;
+            u8_t value;
+            u8_t col;
+            u8_t row;
+            u8_t color_r;
+            u8_t color_g;
+            u8_t color_b;
             void *buffer;
         } glcd;
 #endif // GROVE_LCD
@@ -141,8 +141,8 @@ typedef struct zjs_ipm_message {
         struct sensor_data {
             enum sensor_channel channel;
             char *controller;
-            uint32_t pin;
-            uint32_t frequency;
+            u32_t pin;
+            u32_t frequency;
             union sensor_reading {
                 // x y z axis for Accelerometer and Gyroscope
                 struct {
@@ -158,18 +158,18 @@ typedef struct zjs_ipm_message {
 
 #ifdef BUILD_MODULE_PME
         struct pme_data {
-            uint8_t c_mode;
-            uint8_t d_mode;
-            uint8_t vector[128];
-            uint8_t vector_size;
-            uint16_t category;
-            uint16_t committed_count;
-            uint16_t g_context;
-            uint16_t n_context;
-            uint16_t aif;
-            uint16_t min_if;
-            uint16_t max_if;
-            uint32_t neuron_id;
+            u8_t c_mode;
+            u8_t d_mode;
+            u8_t vector[128];
+            u8_t vector_size;
+            u16_t category;
+            u16_t committed_count;
+            u16_t g_context;
+            u16_t n_context;
+            u16_t aif;
+            u16_t min_if;
+            u16_t max_if;
+            u32_t neuron_id;
         } pme;
 #endif // PME
     } data;
@@ -177,9 +177,9 @@ typedef struct zjs_ipm_message {
 
 void zjs_ipm_init();
 
-int zjs_ipm_send(uint32_t id, zjs_ipm_message_t *data);
+int zjs_ipm_send(u32_t id, zjs_ipm_message_t *data);
 
-void zjs_ipm_register_callback(uint32_t msg_id, ipm_callback_t cb);
+void zjs_ipm_register_callback(u32_t msg_id, ipm_callback_t cb);
 
 void zjs_ipm_free_callbacks();
 

--- a/src/zjs_k64f_pins.c
+++ b/src/zjs_k64f_pins.c
@@ -4,12 +4,12 @@
 #include <zephyr.h>
 
 // ZJS includes
-#include <zjs_gpio.h>
-#include <zjs_pwm.h>
-#include <zjs_util.h>
+#include "zjs_gpio.h"
+#include "zjs_pwm.h"
+#include "zjs_util.h"
 
 #ifdef BUILD_MODULE_PWM
-static void zjs_k64f_num_to_pwm(uint32_t num, int *dev, int *pin)
+static void zjs_k64f_num_to_pwm(u32_t num, int *dev, int *pin)
 {
     int devnum = (num & 0xe0) >> 5;
     if (devnum > 3) {

--- a/src/zjs_linux_port.h
+++ b/src/zjs_linux_port.h
@@ -11,56 +11,56 @@
 typedef uint32_t u32_t;
 
 typedef struct zjs_port_timer {
-    uint32_t sec;
-    uint32_t milli;
-    uint32_t interval;
+    u32_t sec;
+    u32_t milli;
+    u32_t interval;
     void *data;
 } zjs_port_timer_t;
 
 #define zjs_port_timer_init(t) do {} while (0)
 
-void zjs_port_timer_start(zjs_port_timer_t *timer, uint32_t interval);
+void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval);
 
 void zjs_port_timer_stop(zjs_port_timer_t *timer);
 
-uint8_t zjs_port_timer_test(zjs_port_timer_t *timer);
+u8_t zjs_port_timer_test(zjs_port_timer_t *timer);
 
-uint32_t zjs_port_timer_get_uptime(void);
+u32_t zjs_port_timer_get_uptime(void);
 
 #define ZJS_TICKS_NONE          0
 #define ZJS_TICKS_FOREVER       0
 #define CONFIG_SYS_CLOCK_TICKS_PER_SEC 100
 #define zjs_sleep usleep
 
-#define SIZE32_OF(x) (sizeof((x))/sizeof(uint32_t))
+#define SIZE32_OF(x) (sizeof((x))/sizeof(u32_t))
 
 #define EAGAIN      11
 #define EMSGSIZE    12
 #define ENOSPC      28
 
 struct zjs_port_ring_buf {
-    uint32_t head;   /**< Index in buf for the head element */
-    uint32_t tail;   /**< Index in buf for the tail element */
-    uint32_t size;   /**< Size of buf in 32-bit chunks */
-    uint32_t *buf;   /**< Memory region for stored entries */
-    uint32_t mask;   /**< Modulo mask if size is a power of 2 */
+    u32_t head;   /**< Index in buf for the head element */
+    u32_t tail;   /**< Index in buf for the tail element */
+    u32_t size;   /**< Size of buf in 32-bit chunks */
+    u32_t *buf;   /**< Memory region for stored entries */
+    u32_t mask;   /**< Modulo mask if size is a power of 2 */
 };
 
 void zjs_port_ring_buf_init(struct zjs_port_ring_buf *buf,
-                            uint32_t size,
-                            uint32_t *data);
+                            u32_t size,
+                            u32_t *data);
 
 int zjs_port_ring_buf_get(struct zjs_port_ring_buf *buf,
-                          uint16_t *type,
-                          uint8_t *value,
-                          uint32_t *data,
-                          uint8_t *size32);
+                          u16_t *type,
+                          u8_t *value,
+                          u32_t *data,
+                          u8_t *size32);
 
 // INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or release prints!
 int zjs_port_ring_buf_put(struct zjs_port_ring_buf *buf,
-                          uint16_t type,
-                          uint8_t value,
-                          uint32_t *data,
-                          uint8_t size32);
+                          u16_t type,
+                          u8_t value,
+                          u32_t *data,
+                          u8_t size32);
 
 #endif /* ZJS_LINUX_PORT_H_ */

--- a/src/zjs_linux_ring_buffer.c
+++ b/src/zjs_linux_ring_buffer.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016, Intel Corporation.
+// Copyright (c) 2015-2017, Intel Corporation.
 
 /*
  * This ring buffer implementation was taken from the Zephyr source and
@@ -15,9 +15,9 @@
 #endif
 
 struct ring_element {
-    uint32_t  type   :16; /**< Application-specific */
-    uint32_t  length :8;  /**< length in 32-bit chunks */
-    uint32_t  value  :8;  /**< Room for small integral values */
+    u32_t  type   :16; /**< Application-specific */
+    u32_t  length :8;  /**< length in 32-bit chunks */
+    u32_t  value  :8;  /**< Room for small integral values */
 };
 
 static int get_space(struct zjs_port_ring_buf *buf)
@@ -35,8 +35,8 @@ static int get_space(struct zjs_port_ring_buf *buf)
 }
 
 void zjs_port_ring_buf_init(struct zjs_port_ring_buf *buf,
-                            uint32_t size,
-                            uint32_t *data)
+                            u32_t size,
+                            u32_t *data)
 {
     int i;
     for (i = 0; i < 20; ++i) {
@@ -58,13 +58,13 @@ void zjs_port_ring_buf_init(struct zjs_port_ring_buf *buf,
 }
 
 int zjs_port_ring_buf_get(struct zjs_port_ring_buf *buf,
-                          uint16_t *type,
-                          uint8_t *value,
-                          uint32_t *data,
-                          uint8_t *size32)
+                          u16_t *type,
+                          u8_t *value,
+                          u32_t *data,
+                          u8_t *size32)
 {
     struct ring_element *header;
-    uint32_t i, index;
+    u32_t i, index;
 
     if (buf->head == buf->tail) {
         return -EAGAIN;
@@ -101,12 +101,12 @@ int zjs_port_ring_buf_get(struct zjs_port_ring_buf *buf,
 }
 
 int zjs_port_ring_buf_put(struct zjs_port_ring_buf *buf,
-                          uint16_t type,
-                          uint8_t value,
-                          uint32_t *data,
-                          uint8_t size32)
+                          u16_t type,
+                          u8_t value,
+                          u32_t *data,
+                          u8_t size32)
 {
-    uint32_t i, space, index, rc = -1;
+    u32_t i, space, index, rc = -1;
 
     space = get_space(buf);
     if (space >= (size32 + 1)) {

--- a/src/zjs_linux_time.c
+++ b/src/zjs_linux_time.c
@@ -1,11 +1,11 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #include "zjs_linux_port.h"
 #include <time.h>
 
 #define ZEPHYR_TICKS_PER_SEC
 
-void zjs_port_timer_start(zjs_port_timer_t *timer, uint32_t interval)
+void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval)
 {
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
@@ -19,9 +19,9 @@ void zjs_port_timer_stop(zjs_port_timer_t *timer)
     timer->interval = 0;
 }
 
-uint8_t zjs_port_timer_test(zjs_port_timer_t *timer)
+u8_t zjs_port_timer_test(zjs_port_timer_t *timer)
 {
-    uint32_t elapsed;
+    u32_t elapsed;
     struct timespec now;
 
     clock_gettime(CLOCK_MONOTONIC, &now);
@@ -34,7 +34,7 @@ uint8_t zjs_port_timer_test(zjs_port_timer_t *timer)
     return 0;
 }
 
-uint32_t zjs_port_timer_get_uptime(void)
+u32_t zjs_port_timer_get_uptime(void)
 {
     struct timespec now;
 

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -27,7 +27,7 @@ struct routine_map {
     void *handle;
 };
 
-static uint8_t num_routines = 0;
+static u8_t num_routines = 0;
 struct routine_map svc_routine_map[NUM_SERVICE_ROUTINES];
 
 static ZJS_DECL_FUNC(native_require_handler)
@@ -60,7 +60,7 @@ static ZJS_DECL_FUNC(native_require_handler)
     // JS modules now rather than at compile time
     char full_path[size + 9];
     char *str;
-    uint32_t len;
+    u32_t len;
     sprintf(full_path, "modules/%s", module);
     full_path[size + 8] = '\0';
 
@@ -226,12 +226,12 @@ void zjs_register_service_routine(void *handle, zjs_service_routine func)
     return;
 }
 
-int32_t zjs_service_routines(void)
+s32_t zjs_service_routines(void)
 {
-    int32_t wait = ZJS_TICKS_FOREVER;
+    s32_t wait = ZJS_TICKS_FOREVER;
     int i;
     for (i = 0; i < num_routines; ++i) {
-        int32_t ret = svc_routine_map[i].func(svc_routine_map[i].handle);
+        s32_t ret = svc_routine_map[i].func(svc_routine_map[i].handle);
         wait = (wait < ret) ? wait : ret;
     }
 #ifdef ZJS_LINUX_BUILD

--- a/src/zjs_modules.h
+++ b/src/zjs_modules.h
@@ -19,11 +19,11 @@
  *
  * @return              Time until next event, ZJS_TICKS_FOREVER if unknown
  */
-typedef int32_t (*zjs_service_routine)(void* handle);
+typedef s32_t (*zjs_service_routine)(void* handle);
 
 void zjs_modules_init();
 void zjs_modules_cleanup();
 void zjs_register_service_routine(void* handle, zjs_service_routine func);
-int32_t zjs_service_routines(void);
+s32_t zjs_service_routines(void);
 
 #endif  // __zjs_modules_h__

--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -10,9 +10,9 @@
 #include "zjs_util.h"
 #include "zjs_net_config.h"
 
-static uint8_t net_enabled = 0;
+static u8_t net_enabled = 0;
 #if defined(CONFIG_NET_L2_BLUETOOTH)
-static uint8_t ble_enabled = 0;
+static u8_t ble_enabled = 0;
 #endif
 
 void zjs_net_config(void)
@@ -50,7 +50,7 @@ static bt_addr_le_t id_addr;
 static char default_ble[18] = ZJS_CONFIG_BLE_ADDRESS;
 #endif
 
-static ssize_t zjs_ble_storage_read(const bt_addr_le_t *addr, uint16_t key,
+static ssize_t zjs_ble_storage_read(const bt_addr_le_t *addr, u16_t key,
     void *data, size_t length)
 {
     if (addr) {
@@ -73,7 +73,7 @@ static ssize_t zjs_ble_storage_read(const bt_addr_le_t *addr, uint16_t key,
 static int str2bt_addr_le(const char *str, const char *type, bt_addr_le_t *addr)
 {
     int i;
-    uint8_t tmp;
+    u8_t tmp;
 
     if (strnlen(str, 18) != 17) {
         return -EINVAL;

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -40,8 +40,8 @@ struct client_resource {
     oc_server_handle_t server;
     resource_state state;
     jerry_value_t client;
-    uint32_t flags;
-    uint32_t error_code;
+    u32_t flags;
+    u32_t error_code;
     struct client_resource *next;
 };
 
@@ -145,7 +145,7 @@ static jerry_value_t get_props_from_response(oc_client_response_t *data)
             break;
         case INT:
             zjs_obj_add_number(prop_object, (double)rep->value.integer, oc_string(rep->name));
-            DBG_PRINT("%ld\n", (uint32_t)rep->value.integer);
+            DBG_PRINT("%ld\n", (u32_t)rep->value.integer);
             break;
         case BYTE_STRING:
         case STRING:
@@ -183,7 +183,7 @@ static void print_props_data(oc_client_response_t *data)
             ZJS_PRINT("%d\n", rep->value.boolean);
             break;
         case INT:
-            ZJS_PRINT("%ld\n", (uint32_t)rep->value.integer);
+            ZJS_PRINT("%ld\n", (u32_t)rep->value.integer);
             break;
         case BYTE_STRING:
         case STRING:
@@ -430,7 +430,7 @@ Found:
             /*
              * Add the array of resource types to newly discovered resource
              */
-            uint32_t sz = oc_string_array_get_allocated_size(types);
+            u32_t sz = oc_string_array_get_allocated_size(types);
             cur->types_array = jerry_create_array(sz);
 
             for (i = 0; i < sz; i++) {
@@ -861,7 +861,7 @@ static void ocf_get_platform_info_handler(oc_client_response_t *data)
                 DBG_PRINT("%d\n", rep->value.boolean);
                 break;
             case INT:
-                DBG_PRINT("%ld\n", (uint32_t)rep->value.integer);
+                DBG_PRINT("%ld\n", (u32_t)rep->value.integer);
                 break;
             case BYTE_STRING:
             case STRING:
@@ -962,7 +962,7 @@ static void ocf_get_device_info_handler(oc_client_response_t *data)
                 DBG_PRINT("%d\n", rep->value.boolean);
                 break;
             case INT:
-                DBG_PRINT("%ld\n", (uint32_t)rep->value.integer);
+                DBG_PRINT("%ld\n", (u32_t)rep->value.integer);
                 break;
             case BYTE_STRING:
             case STRING:

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -73,7 +73,7 @@ static struct props_handle *ocf_get_all_properties(jerry_value_t resource)
     struct props_handle *handle = zjs_malloc(sizeof(struct props_handle));
 
     ZVAL keys_array = jerry_get_object_keys(resource);
-    uint32_t arr_length = jerry_get_array_length(keys_array);
+    u32_t arr_length = jerry_get_array_length(keys_array);
 
     handle->props_array = jerry_create_array(arr_length - 1);
     handle->size = 0;
@@ -223,7 +223,7 @@ void zjs_set_uuid(char *uuid)
 
 static void platform_init(void *data)
 {
-    uint32_t size;
+    u32_t size;
     ZVAL platform = zjs_get_property(ocf_object, "platform");
     if (!jerry_value_is_undefined(platform)) {
         // osVersion
@@ -328,7 +328,7 @@ static void platform_init(void *data)
 
 static int app_init(void)
 {
-    uint32_t size;
+    u32_t size;
     // device props
     char *name = NULL;
     char *spec_version = NULL;
@@ -415,9 +415,9 @@ static int app_init(void)
     return ret;
 }
 
-int32_t main_poll_routine(void* handle)
+s32_t main_poll_routine(void* handle)
 {
-    return (int32_t)oc_main_poll();
+    return (s32_t)oc_main_poll();
 }
 
 static const oc_handler_t handler = {

--- a/src/zjs_ocf_common.h
+++ b/src/zjs_ocf_common.h
@@ -13,7 +13,7 @@
 
 struct props_handle {
     jerry_value_t props_array;
-    uint32_t size;
+    u32_t size;
     char **names_array;
 };
 
@@ -74,7 +74,7 @@ void zjs_ocf_free_props(void *h);
  *
  * @return              Time (ms) until next event
  */
-int32_t main_poll_routine(void* handle);
+s32_t main_poll_routine(void* handle);
 
 /**
  * Set the 'uuid' property in the device object. This API is required because

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -23,15 +23,15 @@ struct server_resource {
      *       'this' pointer so we have to save it in C.
      */
     jerry_value_t object;
-    uint32_t error_code;
+    u32_t error_code;
     oc_resource_t *res;
     char *device_id;
     char *resource_path;
     char **resource_types;
     char **resource_ifaces;
-    uint8_t num_types;
-    uint8_t num_ifaces;
-    uint8_t flags;
+    u8_t num_types;
+    u8_t num_ifaces;
+    u8_t flags;
 };
 
 typedef struct resource_list {
@@ -148,7 +148,7 @@ struct server_resource *new_server_resource(char *path)
     }
     memset(resource, 0, sizeof(struct server_resource));
 
-    uint32_t len = strlen(path);
+    u32_t len = strlen(path);
     resource->resource_path = zjs_malloc(len + 1);
     if (!resource->resource_path) {
         ERR_PRINT("resource path could not be allocated\n");
@@ -198,7 +198,7 @@ static void print_props_data(oc_request_t *data)
             ZJS_PRINT("%d\n", rep->value_boolean);
             break;
         case INT:
-            ZJS_PRINT("%ld\n", (int32_t)rep->value_int);
+            ZJS_PRINT("%ld\n", (s32_t)rep->value_int);
             break;
         case BYTE_STRING:
         case STRING:
@@ -410,7 +410,7 @@ static ZJS_DECL_FUNC(ocf_register)
     }
 
     // Optional
-    uint8_t flags = 0;
+    u8_t flags = 0;
     ZVAL observable_val = zjs_get_property(argv[0], "observable");
     if (jerry_value_is_boolean(observable_val)) {
         if (jerry_get_boolean_value(observable_val)) {
@@ -461,7 +461,7 @@ static ZJS_DECL_FUNC(ocf_register)
 
     for (i = 0; i < resource->num_types; ++i) {
         ZVAL type_val = jerry_get_property_by_index(res_type_array, i);
-        uint32_t size = OCF_MAX_RES_TYPE_LEN;
+        u32_t size = OCF_MAX_RES_TYPE_LEN;
         resource->resource_types[i] = zjs_alloc_from_jstring(type_val, &size);
         if (!resource->resource_types[i]) {
             REJECT("InternalError", "resourceType alloc failed");
@@ -482,7 +482,7 @@ static ZJS_DECL_FUNC(ocf_register)
 
     for (i = 0; i < resource->num_ifaces; ++i) {
         ZVAL val = jerry_get_property_by_index(iface_array, i);
-        uint32_t size = OCF_MAX_RES_TYPE_LEN;
+        u32_t size = OCF_MAX_RES_TYPE_LEN;
         resource->resource_ifaces[i] = zjs_alloc_from_jstring(val, &size);
         if (!resource->resource_ifaces[i]) {
             REJECT("InternalError", "resourceType alloc failed");

--- a/src/zjs_pme.c
+++ b/src/zjs_pme.c
@@ -58,7 +58,7 @@ static bool zjs_pme_ipm_send_sync(zjs_ipm_message_t *send,
     return true;
 }
 
-static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *data)
+static void ipm_msg_receive_callback(void *context, u32_t id, volatile void *data)
 {
     if (id != MSG_ID_PME)
         return;
@@ -119,7 +119,7 @@ static ZJS_DECL_FUNC(zjs_pme_learn)
     // args: pattern array, category
     ZJS_VALIDATE_ARGS(Z_ARRAY, Z_NUMBER);
     jerry_value_t vector = argv[0];
-    uint32_t vector_len = jerry_get_array_length(vector);
+    u32_t vector_len = jerry_get_array_length(vector);
 
     if (vector_len > MAX_VECTOR_SIZE) {
         return zjs_error("exceeded max vector size");
@@ -133,7 +133,8 @@ static ZJS_DECL_FUNC(zjs_pme_learn)
         if (!jerry_value_is_number(num)) {
             return zjs_error("invalid vector type");
         }
-        uint8_t byte = jerry_get_number_value(num);
+
+        u8_t byte = jerry_get_number_value(num);
         send.data.pme.vector[i] = byte;
     }
 
@@ -149,7 +150,7 @@ static ZJS_DECL_FUNC(zjs_pme_classify)
     // args: pattern array
     ZJS_VALIDATE_ARGS(Z_ARRAY);
     jerry_value_t vector = argv[0];
-    uint32_t vector_len = jerry_get_array_length(vector);
+    u32_t vector_len = jerry_get_array_length(vector);
 
     if (vector_len > MAX_VECTOR_SIZE) {
         return zjs_error("exceeded max vector size");
@@ -163,7 +164,8 @@ static ZJS_DECL_FUNC(zjs_pme_classify)
         if (!jerry_value_is_number(num)) {
             return zjs_error("invalid vector type");
         }
-        uint8_t byte = jerry_get_number_value(num);
+
+        u8_t byte = jerry_get_number_value(num);
         send.data.pme.vector[i] = byte;
     }
 
@@ -194,6 +196,7 @@ static ZJS_DECL_FUNC(zjs_pme_read_neuron)
         ZVAL val = jerry_create_number(reply.data.pme.vector[i]);
         jerry_set_property_by_index(array, i, val);
     }
+
     zjs_set_property(obj, "vector", array);
     return obj;
 }
@@ -203,7 +206,7 @@ static ZJS_DECL_FUNC(zjs_pme_write_vector)
     // args: pattern array
     ZJS_VALIDATE_ARGS(Z_ARRAY);
     jerry_value_t vector = argv[0];
-    uint32_t vector_len = jerry_get_array_length(vector);
+    u32_t vector_len = jerry_get_array_length(vector);
 
     if (vector_len > MAX_VECTOR_SIZE) {
         return zjs_error("exceeded max vector size");
@@ -212,13 +215,14 @@ static ZJS_DECL_FUNC(zjs_pme_write_vector)
     zjs_ipm_message_t send;
     send.type = TYPE_PME_WRITE_VECTOR;
 
-    memset(send.data.pme.vector, 0, sizeof(uint8_t) * MAX_VECTOR_SIZE);
+    memset(send.data.pme.vector, 0, sizeof(u8_t) * MAX_VECTOR_SIZE);
     for (int i = 0; i < vector_len; i++) {
         ZVAL num = jerry_get_property_by_index(vector, i);
         if (!jerry_value_is_number(num)) {
             return zjs_error("invalid vector type");
         }
-        uint8_t byte = jerry_get_number_value(num);
+
+        u8_t byte = jerry_get_number_value(num);
         send.data.pme.vector[i] = byte;
     }
 
@@ -384,7 +388,7 @@ static ZJS_DECL_FUNC(zjs_pme_restore_neurons)
     // args: neuron array
     ZJS_VALIDATE_ARGS(Z_ARRAY);
     jerry_value_t array = argv[0];
-    uint32_t array_len = jerry_get_array_length(array);
+    u32_t array_len = jerry_get_array_length(array);
 
     if (array_len > MAX_NEURONS) {
         return zjs_error("exceeded max neuron size");
@@ -398,7 +402,7 @@ static ZJS_DECL_FUNC(zjs_pme_restore_neurons)
 
     for (int i = 0; i < array_len; i++) {
         // iterate json object to restore neurons
-        uint32_t category, context, aif, min_if;
+        u32_t category, context, aif, min_if;
         zjs_ipm_message_t send;
 
         ZVAL neuron = jerry_get_property_by_index(array, i);
@@ -423,7 +427,7 @@ static ZJS_DECL_FUNC(zjs_pme_restore_neurons)
             return zjs_error("invalid object, missing vector array");
         }
 
-        uint32_t vector_len = jerry_get_array_length(vector);
+        u32_t vector_len = jerry_get_array_length(vector);
         if (vector_len > MAX_VECTOR_SIZE) {
             return zjs_error("vector size must be <= 128");
         }
@@ -434,13 +438,14 @@ static ZJS_DECL_FUNC(zjs_pme_restore_neurons)
         send.data.pme.aif = aif;
         send.data.pme.min_if = min_if;
 
-        memset(send.data.pme.vector, 0, sizeof(uint8_t) * MAX_VECTOR_SIZE);
+        memset(send.data.pme.vector, 0, sizeof(u8_t) * MAX_VECTOR_SIZE);
         for (int i = 0; i < vector_len; i++) {
             ZVAL num = jerry_get_property_by_index(vector, i);
             if (!jerry_value_is_number(num)) {
                  return zjs_error("invalid vector type");
             }
-            uint8_t byte = jerry_get_number_value(num);
+
+            u8_t byte = jerry_get_number_value(num);
             send.data.pme.vector[i] = byte;
         }
 

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -24,13 +24,13 @@ static const char *ZJS_POLARITY_REVERSE = "reverse";
 
 static struct device *zjs_pwm_dev[PWM_DEV_COUNT];
 
-void (*zjs_pwm_convert_pin)(uint32_t orig, int *dev, int *pin) =
+void (*zjs_pwm_convert_pin)(u32_t orig, int *dev, int *pin) =
     zjs_default_convert_pin;
 
-static void zjs_pwm_set_cycles(jerry_value_t obj, uint32_t periodHW,
-                               uint32_t pulseWidthHW)
+static void zjs_pwm_set_cycles(jerry_value_t obj, u32_t periodHW,
+                               u32_t pulseWidthHW)
 {
-    uint32_t orig_chan;
+    u32_t orig_chan;
     zjs_obj_get_uint32(obj, "channel", &orig_chan);
 
     int devnum, channel;
@@ -45,13 +45,13 @@ static void zjs_pwm_set_cycles(jerry_value_t obj, uint32_t periodHW,
     }
 
     DBG_PRINT("Setting [cycles] channel=%d dev=%d, period=%lu, pulse=%lu\n",
-              channel, devnum, (uint32_t)periodHW, (uint32_t)pulseWidthHW);
+              channel, devnum, (u32_t)periodHW, (u32_t)pulseWidthHW);
     pwm_pin_set_cycles(zjs_pwm_dev[devnum], channel, periodHW, pulseWidthHW);
 }
 
 static void zjs_pwm_set_ms(jerry_value_t obj, double period, double pulseWidth)
 {
-    uint32_t orig_chan;
+    u32_t orig_chan;
     zjs_obj_get_uint32(obj, "channel", &orig_chan);
 
     int devnum, channel;
@@ -66,10 +66,10 @@ static void zjs_pwm_set_ms(jerry_value_t obj, double period, double pulseWidth)
     }
 
     DBG_PRINT("Setting [uSec] channel=%d dev=%d, period=%lu, pulse=%lu\n",
-              channel, devnum, (uint32_t)(period * 1000),
-              (uint32_t)(pulseWidth * 1000));
-    pwm_pin_set_usec(zjs_pwm_dev[devnum], channel, (uint32_t)(period * 1000),
-                     (uint32_t)(pulseWidth * 1000));
+              channel, devnum, (u32_t)(period * 1000),
+              (u32_t)(pulseWidth * 1000));
+    pwm_pin_set_usec(zjs_pwm_dev[devnum], channel, (u32_t)(period * 1000),
+                     (u32_t)(pulseWidth * 1000));
 }
 
 static ZJS_DECL_FUNC(zjs_pwm_pin_set_cycles)
@@ -126,8 +126,8 @@ static ZJS_DECL_FUNC(zjs_pwm_pin_set_ms)
     zjs_obj_add_number(this, period, "period");
     zjs_obj_add_number(this, period, "pulseWidth");
 
-    DBG_PRINT("period: %lu, pulse: %lu\n", (uint32_t)period,
-              (uint32_t)pulseWidth);
+    DBG_PRINT("period: %lu, pulse: %lu\n", (u32_t)period,
+              (u32_t)pulseWidth);
 
     zjs_pwm_set_ms(this, period, pulseWidth);
     return ZJS_UNDEFINED;
@@ -146,7 +146,7 @@ static ZJS_DECL_FUNC(zjs_pwm_open)
     // data input object
     jerry_value_t data = argv[0];
 
-    uint32_t channel;
+    u32_t channel;
     if (!zjs_obj_get_uint32(data, "channel", &channel))
         return zjs_error("missing required field");
 

--- a/src/zjs_pwm.h
+++ b/src/zjs_pwm.h
@@ -5,7 +5,7 @@
 
 #include "jerryscript.h"
 
-extern void (*zjs_pwm_convert_pin)(uint32_t num, int *dev, int *pin);
+extern void (*zjs_pwm_convert_pin)(u32_t num, int *dev, int *pin);
 
 /**
  * Initialize the pwm module, or reinitialize after cleanup

--- a/src/zjs_script.c
+++ b/src/zjs_script.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifdef ZJS_LINUX_BUILD
 
@@ -33,7 +33,7 @@ uint8_t zjs_read_script(char *name, char **script, uint32_t *length)
             fclose(f);
             return 1;
         }
-        s = (char *)zjs_malloc(size + 1);
+        s = (char *)malloc(size + 1);
         if (!s) {
             ERR_PRINT("error allocating %u bytes, fatal\n", size);
             fclose(f);
@@ -42,7 +42,7 @@ uint8_t zjs_read_script(char *name, char **script, uint32_t *length)
         if (fread(s, size, 1, f) != 1) {
             ERR_PRINT("error reading script file\n");
             fclose(f);
-            zjs_free(s);
+            free(s);
             return 1;
         }
 
@@ -58,7 +58,7 @@ uint8_t zjs_read_script(char *name, char **script, uint32_t *length)
 void zjs_free_script(char *script)
 {
     if (script) {
-        zjs_free(script);
+        free(script);
     }
     return;
 }

--- a/src/zjs_script.h
+++ b/src/zjs_script.h
@@ -1,12 +1,10 @@
-// Copyright (c) 2016, Intel Corporation.
+// Copyright (c) 2016-2017, Intel Corporation.
 
 #ifndef ZJS_SCRIPT_H_
 #define ZJS_SCRIPT_H_
 
-#include "zjs_util.h"
-#include "zjs_common.h"
-
 #include <stdlib.h>
+#include "zjs_common.h"
 
 uint8_t zjs_read_script(char *name, char **script, uint32_t *length);
 

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -180,7 +180,7 @@ void zjs_sensor_set_state(jerry_value_t obj, sensor_state_t state)
 
 void zjs_sensor_trigger_change(jerry_value_t obj)
 {
-    uint64_t timestamp = k_uptime_get();
+    u64_t timestamp = k_uptime_get();
     zjs_obj_add_readonly_number(obj, ((double)timestamp), "timestamp");
 
     ZVAL func = zjs_get_property(obj, "onchange");
@@ -267,8 +267,8 @@ ZJS_DECL_FUNC_ARGS(zjs_sensor_create,
                    sensor_instance_t *instance,
                    enum sensor_channel channel,
                    const char *c_name,
-                   uint32_t pin,
-                   uint32_t max_frequency,
+                   u32_t pin,
+                   u32_t max_frequency,
                    zjs_c_callback_func onchange,
                    zjs_c_callback_func onstart,
                    zjs_c_callback_func onstop)
@@ -294,7 +294,7 @@ ZJS_DECL_FUNC_ARGS(zjs_sensor_create,
             return zjs_error("controller not found");
         }
 
-        uint32_t option_pin;
+        u32_t option_pin;
         if (zjs_obj_get_uint32(options, "pin", &option_pin)) {
             controller.pin = option_pin;
         } else if (pin != -1) {

--- a/src/zjs_sensor.h
+++ b/src/zjs_sensor.h
@@ -21,7 +21,7 @@ typedef enum sensor_state {
 typedef struct sensor_controller {
     struct device *dev;
     char name[SENSOR_MAX_CONTROLLER_NAME_LEN+1];
-    uint32_t pin;
+    u32_t pin;
 } sensor_controller_t;
 
 typedef struct sensor_handle {
@@ -78,8 +78,8 @@ jerry_value_t zjs_sensor_create(const jerry_value_t func_obj,
                                 sensor_instance_t *instance,
                                 enum sensor_channel channel,
                                 const char *c_name,
-                                uint32_t pin,
-                                uint32_t max_frequency,
+                                u32_t pin,
+                                u32_t max_frequency,
                                 zjs_c_callback_func onchange,
                                 zjs_c_callback_func onstart,
                                 zjs_c_callback_func onstop);

--- a/src/zjs_sensor_board_a101.c
+++ b/src/zjs_sensor_board_a101.c
@@ -124,7 +124,7 @@ static void zjs_sensor_signal_callbacks(struct sensor_data *data)
 }
 
 // INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or likely prints!
-static void ipm_msg_receive_callback(void *context, uint32_t id, volatile void *data)
+static void ipm_msg_receive_callback(void *context, u32_t id, volatile void *data)
 {
     if (id != MSG_ID_SENSOR)
         return;

--- a/src/zjs_sensor_board_k64f.c
+++ b/src/zjs_sensor_board_k64f.c
@@ -135,17 +135,17 @@ static void zjs_sensor_fetch_sample(sensor_handle_t *handle)
     }
 }
 
-static int32_t zjs_sensor_poll_routine(void* h)
+static s32_t zjs_sensor_poll_routine(void* h)
 {
     int modcount = sizeof(sensor_modules) / sizeof(sensor_module_t);
-    uint32_t uptime = k_uptime_get_32();
+    u32_t uptime = k_uptime_get_32();
 
     for (int i = 0; i < modcount; i++) {
         sensor_module_t *mod = &sensor_modules[i];
         if (mod->instance && mod->instance->handles) {
             sensor_handle_t *handle = mod->instance->handles;
-            if (uptime % (uint32_t)(CONFIG_SYS_CLOCK_TICKS_PER_SEC /
-                                    handle->frequency * 10) == 0) {
+            if (uptime % (u32_t)(CONFIG_SYS_CLOCK_TICKS_PER_SEC /
+                                 handle->frequency * 10) == 0) {
                 zjs_sensor_fetch_sample(handle);
             }
         }

--- a/src/zjs_spi.c
+++ b/src/zjs_spi.c
@@ -131,7 +131,7 @@ static ZJS_DECL_FUNC(zjs_spi_transceive)
                 for (int i = 0; i < len; i++) {
                     ZVAL item = jerry_get_property_by_index(buffer, i);
                     if (jerry_value_is_number(item)) {
-                        tx_buf->buffer[i] = (uint8_t)jerry_get_number_value(item);
+                        tx_buf->buffer[i] = (u8_t)jerry_get_number_value(item);
                     }
                     else {
                         ERR_PRINT("non-numeric value in array, treating as 0\n");
@@ -198,16 +198,16 @@ static ZJS_DECL_FUNC(zjs_spi_open)
     ZJS_VALIDATE_ARGS(Z_OPTIONAL Z_OBJECT);
 
     // Default values
-    uint32_t bus = 0;
+    u32_t bus = 0;
     double speed = 10;
     bool msbFirst = true;
-    uint32_t bits = 8;
-    uint32_t polarity = 0;
-    uint32_t phase = 0;
+    u32_t bits = 8;
+    u32_t polarity = 0;
+    u32_t phase = 0;
     char topology_str[13] = "";
     char bus_str[9];
     enum spi_topology topology = ZJS_TOPOLOGY_FULL_DUPLEX;
-    uint32_t frame_gap = 0;
+    u32_t frame_gap = 0;
     struct spi_config config = { 0 };
 
     // Get any provided optional args

--- a/src/zjs_spi.c
+++ b/src/zjs_spi.c
@@ -214,7 +214,7 @@ static ZJS_DECL_FUNC(zjs_spi_open)
     if (argc >= 1) {
         zjs_obj_get_uint32(argv[0], "bus", &bus);
         if (bus < MAX_SPI_BUS) {
-            snprintf(bus_str, 9, "%s%lu", SPI_BUS, bus);
+            snprintf(bus_str, 9, "%s%u", SPI_BUS, bus);
         }
         else
             return ZJS_STD_ERROR(RangeError, "Invalid bus");

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -20,8 +20,8 @@
 typedef struct zjs_timer {
     zjs_port_timer_t timer;
     jerry_value_t *argv;
-    uint32_t argc;
-    uint32_t interval;
+    u32_t argc;
+    u32_t interval;
     zjs_callback_id callback_id;
     bool repeat;
     bool completed;
@@ -35,7 +35,7 @@ static const jerry_object_native_info_t timer_type_info =
    .free_cb = free_handle_nop
 };
 
-jerry_value_t *pre_timer(void *h, uint32_t *argc)
+jerry_value_t *pre_timer(void *h, u32_t *argc)
 {
     zjs_timer_t *handle = (zjs_timer_t *)h;
     *argc = handle->argc;
@@ -51,11 +51,11 @@ jerry_value_t *pre_timer(void *h, uint32_t *argc)
  * argv         Array of arguments to pass to timer callback function
  * argc         Number of arguments in argv
  */
-static zjs_timer_t *add_timer(uint32_t interval,
+static zjs_timer_t *add_timer(u32_t interval,
                               jerry_value_t callback,
                               jerry_value_t this,
                               bool repeat,
-                              uint32_t argc,
+                              u32_t argc,
                               const jerry_value_t argv[])
 {
     zjs_timer_t *tm = zjs_malloc(sizeof(zjs_timer_t));
@@ -105,7 +105,7 @@ static zjs_timer_t *add_timer(uint32_t interval,
  *
  * returns      True if the timer was removed successfully (if the ID is valid)
  */
-static bool delete_timer(int32_t id)
+static bool delete_timer(s32_t id)
 {
     zjs_timer_t *tm = ZJS_LIST_FIND(zjs_timer_t, zjs_timers, callback_id, id);
     if (tm) {
@@ -130,7 +130,7 @@ static ZJS_DECL_FUNC_ARGS(add_timer_helper, bool repeat)
     // args: callback, time in milliseconds[, pass-through args]
     ZJS_VALIDATE_ARGS(Z_FUNCTION, Z_NUMBER);
 
-    uint32_t interval = (uint32_t)(jerry_get_number_value(argv[1]));
+    u32_t interval = (u32_t)(jerry_get_number_value(argv[1]));
     jerry_value_t callback = argv[0];
     jerry_value_t timer_obj = jerry_create_object();
 
@@ -179,9 +179,9 @@ static ZJS_DECL_FUNC(native_clear_interval_handler)
     return ZJS_UNDEFINED;
 }
 
-int32_t zjs_timers_process_events()
+s32_t zjs_timers_process_events()
 {
-    int32_t wait = ZJS_TICKS_FOREVER;
+    s32_t wait = ZJS_TICKS_FOREVER;
 #ifdef DEBUG_BUILD
 #ifndef ZJS_LINUX_BUILD
     extern void update_print_timer(void);
@@ -208,7 +208,7 @@ int32_t zjs_timers_process_events()
             }
         }
 #ifndef ZJS_LINUX_BUILD
-        int32_t remaining = zjs_port_timer_get_remaining(&tm->timer);
+        s32_t remaining = zjs_port_timer_get_remaining(&tm->timer);
         if (remaining > 0 && !tm->completed) {
             wait = (wait < tm->interval) ? wait : tm->interval;
         }

--- a/src/zjs_timers.h
+++ b/src/zjs_timers.h
@@ -10,7 +10,7 @@
  *
  * @return          Shortest time until next expiring timer
  */
-int32_t zjs_timers_process_events();
+s32_t zjs_timers_process_events();
 void zjs_timers_init();
 // Stops and frees all timers
 void zjs_timers_cleanup();

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -33,9 +33,9 @@ typedef struct {
     jerry_value_t uart_obj;
     jerry_value_t buf_obj;
     char *buf;
-    uint32_t size;
-    uint32_t min;
-    uint32_t max;
+    u32_t size;
+    u32_t min;
+    u32_t max;
 } uart_handle;
 
 static uart_dev_map device_map[] = {
@@ -132,7 +132,7 @@ static void uart_irq_handler(struct device *dev)
     }
 
     if (uart_irq_rx_ready(dev)) {
-        uint32_t len = uart_fifo_read(dev, handle->buf, handle->max);
+        u32_t len = uart_fifo_read(dev, handle->buf, handle->max);
         rx = true;
         handle->buf[len] = '\0';
         handle->size = len;
@@ -174,8 +174,8 @@ static ZJS_DECL_FUNC(uart_set_read_range)
     // args: min, max
     ZJS_VALIDATE_ARGS(Z_NUMBER, Z_NUMBER);
 
-    uint32_t min = jerry_get_number_value(argv[0]);
-    uint32_t max = jerry_get_number_value(argv[1]);
+    u32_t min = jerry_get_number_value(argv[0]);
+    u32_t max = jerry_get_number_value(argv[1]);
 
     if (handle->buf) {
         void *old = handle->buf;
@@ -243,7 +243,7 @@ static ZJS_DECL_FUNC(uart_init)
 #ifdef CONFIG_UART_LINE_CTRL
     DBG_PRINT("waiting for DTR\n");
     while (1) {
-        uart_line_ctrl_get(uart_dev, LINE_CTRL_DTR, (uint32_t *)&dtr);
+        uart_line_ctrl_get(uart_dev, LINE_CTRL_DTR, (u32_t *)&dtr);
         if (dtr) {
             break;
         }
@@ -269,7 +269,7 @@ static ZJS_DECL_FUNC(uart_init)
 
     int test_baud = baud;
 
-    ret = uart_line_ctrl_get(uart_dev, LINE_CTRL_BAUD_RATE, (uint32_t *)&test_baud);
+    ret = uart_line_ctrl_get(uart_dev, LINE_CTRL_BAUD_RATE, (u32_t *)&test_baud);
     if (ret) {
         DBG_PRINT("failed to get baudrate, ret code %d\n", ret);
     } else {

--- a/src/zjs_unit_tests.c
+++ b/src/zjs_unit_tests.c
@@ -24,20 +24,20 @@ static void zjs_assert(int test, char *str)
 
 // Test zjs_hex_to_byte function
 
-static int check_hex_to_byte(char *str, uint8_t byte)
+static int check_hex_to_byte(char *str, u8_t byte)
 {
-    uint8_t result;
+    u8_t result;
     zjs_hex_to_byte(str, &result);
     return result == byte;
 }
 
-static uint32_t count1 = 0;
+static u32_t count1 = 0;
 static void c_callback1(void *handle, const void *args)
 {
     count1++;
 }
 
-static uint8_t string_correct = 0;
+static u8_t string_correct = 0;
 static void c_callback2(void *handle, const void *args)
 {
     char *s = (char *)handle;
@@ -46,7 +46,7 @@ static void c_callback2(void *handle, const void *args)
     }
 }
 
-static uint8_t handle_and_args = 0;
+static u8_t handle_and_args = 0;
 static void c_callback3(void *handle, const void *args)
 {
     char *h = (char *)handle;
@@ -58,16 +58,16 @@ static void c_callback3(void *handle, const void *args)
     }
 }
 
-static uint8_t cb4_called = 0;
+static u8_t cb4_called = 0;
 static void c_callback4(void *handle, const void *args)
 {
     cb4_called = 1;
 }
 
-static uint8_t handle_correct = 0;
+static u8_t handle_correct = 0;
 static void c_callback5(void *handle, const void *args)
 {
-    uint32_t h = *((uint32_t *)handle);
+    u32_t h = *((u32_t *)handle);
     if (h == 0x44332211) {
         handle_correct = 1;
     }
@@ -125,8 +125,8 @@ static void test_c_callbacks()
     zjs_remove_callback(id4);
 
     // test zjs_edit_callback_handle()
-    uint32_t h1 = 0x11223344;
-    uint32_t h2 = 0x44332211;
+    u32_t h1 = 0x11223344;
+    u32_t h2 = 0x44332211;
     zjs_callback_id id5 = zjs_add_c_callback((void *)&h1, c_callback5);
     zjs_signal_callback(id5, NULL, 0);
     zjs_edit_callback_handle(id5, (void *)&h2);
@@ -163,18 +163,18 @@ static void test_default_convert_pin()
 
 // Test zjs_util int compression functions
 
-static int check_compress_reversible(uint32_t num)
+static int check_compress_reversible(u32_t num)
 {
     // checks whether uncompressing compressed value returns exact match
-    uint32_t reversed = zjs_uncompress_16_to_32(zjs_compress_32_to_16(num));
+    u32_t reversed = zjs_uncompress_16_to_32(zjs_compress_32_to_16(num));
     return num == reversed;
 }
 
-static int check_compress_close(uint32_t num)
+static int check_compress_close(u32_t num)
 {
     // checks whether uncompressing compressed value is within 0.05% of original
     // 11-bit mantissa means 1/2048 ~= 0.05%
-    uint32_t reversed = zjs_uncompress_16_to_32(zjs_compress_32_to_16(num));
+    u32_t reversed = zjs_uncompress_16_to_32(zjs_compress_32_to_16(num));
     double ratio = reversed * 1.0 / num;
     return ratio >= 0.9995 && ratio <= 1.0005;
 }
@@ -381,9 +381,9 @@ typedef struct test_list {
     struct test_list *next;
 } test_list_t;
 
-static uint8_t l1_freed = 0;
-static uint8_t l2_freed = 0;
-static uint8_t l3_freed = 0;
+static u8_t l1_freed = 0;
+static u8_t l2_freed = 0;
+static u8_t l3_freed = 0;
 
 void test_free_list(test_list_t *element)
 {

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 // ZJS includes
+#include "zjs_common.h"
 #include "zjs_buffer.h"
 #include "zjs_util.h"
 #ifndef ZJS_LINUX_BUILD
@@ -209,7 +210,7 @@ bool zjs_obj_get_double(jerry_value_t obj, const char *name, double *num)
     return rval;
 }
 
-bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, uint32_t *num)
+bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, u32_t *num)
 {
     // requires: obj is an existing JS object
     //  effects: retrieves field specified by name as a uint32
@@ -217,14 +218,14 @@ bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, uint32_t *num)
     bool rval = false;
 
     if (!jerry_value_has_error_flag(value) && jerry_value_is_number(value)) {
-        *num = (uint32_t)jerry_get_number_value(value);
+        *num = (u32_t)jerry_get_number_value(value);
         rval = true;
     }
 
     return rval;
 }
 
-bool zjs_obj_get_int32(jerry_value_t obj, const char *name, int32_t *num)
+bool zjs_obj_get_int32(jerry_value_t obj, const char *name, s32_t *num)
 {
     // requires: obj is an existing JS object
     //  effects: retrieves field specified by name as a int32
@@ -232,7 +233,7 @@ bool zjs_obj_get_int32(jerry_value_t obj, const char *name, int32_t *num)
     bool rval = false;
 
     if (!jerry_value_has_error_flag(value) && jerry_value_is_number(value)) {
-        *num = (int32_t)jerry_get_number_value(value);
+        *num = (s32_t)jerry_get_number_value(value);
         rval = true;
     }
 
@@ -275,12 +276,12 @@ char *zjs_alloc_from_jstring(jerry_value_t jstr, jerry_size_t *maxlen)
     return buffer;
 }
 
-bool zjs_hex_to_byte(const char *buf, uint8_t *byte)
+bool zjs_hex_to_byte(const char *buf, u8_t *byte)
 {
     // requires: buf is a string with at least two hex chars
     //  effects: converts the first two hex chars in buf to a number and
     //             returns it in *byte; returns true on success, false otherwise
-    uint8_t num = 0;
+    u8_t num = 0;
     for (int i=0; i<2; i++) {
         num <<= 4;
         if (buf[i] >= 'A' && buf[i] <= 'F')
@@ -295,7 +296,7 @@ bool zjs_hex_to_byte(const char *buf, uint8_t *byte)
     return true;
 }
 
-void zjs_default_convert_pin(uint32_t orig, int *dev, int *pin) {
+void zjs_default_convert_pin(u32_t orig, int *dev, int *pin) {
     // effects: reads top three bits of the bottom byte of orig and writes them
     //            to dev and the bottom five bits and writes them to pin; thus
     //            up to eight devices are supported and up to 32 pins each; but
@@ -311,7 +312,7 @@ void zjs_default_convert_pin(uint32_t orig, int *dev, int *pin) {
 }
 
 // when accuracy isn't as important as space
-uint16_t zjs_compress_32_to_16(uint32_t num)
+u16_t zjs_compress_32_to_16(u32_t num)
 {
     if (num == 0) {
         // GCC states that can't use __builtin_clz
@@ -322,25 +323,25 @@ uint16_t zjs_compress_32_to_16(uint32_t num)
     int zeroes = __builtin_clz(num);
 
     if (zeroes >= 17)
-        return (uint16_t)num;
+        return (u16_t)num;
 
     // take the top 16 bits
-    uint16_t compressed = (num << zeroes) >> 16;
+    u16_t compressed = (num << zeroes) >> 16;
 
     // clear the bottom five bits to save leading zeroes
     compressed &= 0xffe0;
 
     // save the number of zeroes in bottom five bits
-    return compressed | (uint16_t)zeroes;
+    return compressed | (u16_t)zeroes;
 }
 
-uint32_t zjs_uncompress_16_to_32(uint16_t num)
+u32_t zjs_uncompress_16_to_32(u16_t num)
 {
     if ((num & 0x8000) == 0)
-        return (uint32_t)num;
+        return (u32_t)num;
 
     // take top 11 bits
-    uint32_t uncompressed = (num & 0xffe0) >> 5;
+    u32_t uncompressed = (num & 0xffe0) >> 5;
 
     // recover the number of leading zeroes
     int zeroes = num & 0x1f;
@@ -418,7 +419,7 @@ static char *create_js_path(char *obj_name, name_element_t *parent)
     strcpy(str, obj_name);
 
     while (parent) {
-        uint32_t size = 32;
+        u32_t size = 32;
         char name[size];
         zjs_copy_jstring(parent->name, name, &size);
         total += size + 1;

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -32,7 +32,7 @@ void *zjs_malloc_with_retry(size_t size);
 #else
 #include <zephyr.h>
 #ifdef ZJS_TRACE_MALLOC
-#define zjs_malloc(sz) ({void *zjs_ptr = zjs_malloc_with_retry(sz); ZJS_PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, (uint32_t)sz, zjs_ptr); zjs_ptr;})
+#define zjs_malloc(sz) ({void *zjs_ptr = zjs_malloc_with_retry(sz); ZJS_PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, (u32_t)sz, zjs_ptr); zjs_ptr;})
 #define zjs_free(ptr) (ZJS_PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), free(ptr))
 #else
 #define zjs_malloc(sz) ({void *zjs_ptr = zjs_malloc_with_retry(sz); if (!zjs_ptr) {ERR_PRINT("malloc failed\n");} zjs_ptr;})
@@ -77,8 +77,8 @@ bool zjs_obj_get_boolean(jerry_value_t obj, const char *name, bool *flag);
 bool zjs_obj_get_string(jerry_value_t obj, const char *name, char *buffer,
                         int len);
 bool zjs_obj_get_double(jerry_value_t obj, const char *name, double *num);
-bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, uint32_t *num);
-bool zjs_obj_get_int32(jerry_value_t obj, const char *name, int32_t *num);
+bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, u32_t *num);
+bool zjs_obj_get_int32(jerry_value_t obj, const char *name, s32_t *num);
 
 /**
  * Copy a JerryScript string into a supplied char * buffer.
@@ -111,12 +111,12 @@ void zjs_copy_jstring(jerry_value_t jstr, char *buffer, jerry_size_t *maxlen);
  */
 char *zjs_alloc_from_jstring(jerry_value_t jstr, jerry_size_t *maxlen);
 
-bool zjs_hex_to_byte(const char *buf, uint8_t *byte);
+bool zjs_hex_to_byte(const char *buf, u8_t *byte);
 
-void zjs_default_convert_pin(uint32_t orig, int *dev, int *pin);
+void zjs_default_convert_pin(u32_t orig, int *dev, int *pin);
 
-uint16_t zjs_compress_32_to_16(uint32_t num);
-uint32_t zjs_uncompress_16_to_32(uint16_t num);
+u16_t zjs_compress_32_to_16(u32_t num);
+u32_t zjs_uncompress_16_to_32(u16_t num);
 
 void zjs_print_error_message(jerry_value_t error, jerry_value_t func);
 
@@ -433,7 +433,7 @@ void zjs_loop_init(void);
 //     }
 #define ZJS_LIST_REMOVE(type, list, p) \
     ({ \
-        uint8_t removed = 0; \
+        u8_t removed = 0; \
         type *cur = list; \
         if (p == list) { \
             list = p->next; \

--- a/src/zjs_zephyr_port.h
+++ b/src/zjs_zephyr_port.h
@@ -16,10 +16,10 @@
 #define ZJS_TICKS_FOREVER               K_FOREVER
 #define zjs_sleep                       k_sleep
 
-#define zjs_port_ring_buf ring_buf
-#define zjs_port_ring_buf_init sys_ring_buf_init
-#define zjs_port_ring_buf_get sys_ring_buf_get
-#define zjs_port_ring_buf_put sys_ring_buf_put
+#define zjs_port_ring_buf               ring_buf
+#define zjs_port_ring_buf_init          sys_ring_buf_init
+#define zjs_port_ring_buf_get           sys_ring_buf_get
+#define zjs_port_ring_buf_put           sys_ring_buf_put
 
 #define zjs_port_sem_init               k_sem_init
 #define zjs_port_sem_take               k_sem_take

--- a/tools/snapshot.c
+++ b/tools/snapshot.c
@@ -1,5 +1,6 @@
 // Copyright (c) 2016-2017, Intel Corporation.
 
+#include <stdint.h>
 #include <string.h>
 #include "zjs_script.h"
 


### PR DESCRIPTION
Update Zephyr and rebase ZJS to move away from the C99 {u}int{8,16,32,64}_t
types to Zephyr defined u{8,16,32,64}_t and s{8,16,32,64}_t.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>