### PR TITLE
[docs] Remove reference to openAsync in gpio docs

### DIFF
--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -136,5 +136,3 @@ Sample Apps
   * [Arduino Button sample](../samples/arduino/digital/Button.js)
   * [ButtonLEDs sample](../samples/ButtonLEDs.js)
   * [TwoButtons sample](../samples/TwoButtons.js)
-* Using openAsync
-  * [Async ButtonLEDs sample](../samples/ButtonLEDsAsync.js)


### PR DESCRIPTION
Fixes #1130.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>