### PR TITLE
[analyze] Add zjs_common.json that always gets pulled in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,13 @@ ZJS_FLAGS := "$(ZJS_FLAGS) -DZJS_FIND_FUNC_NAME"
 endif
 
 # Settings for ashell builds
+FORCE=zjs_common.json
 ifneq (,$(filter $(MAKECMDGOALS),ide ashell))
 ASHELL=zjs_ashell.json
+FORCE=$(ASHELL)
 ASHELL_ARC=zjs_ashell_arc.json
 ZJS_FLAGS := "$(ZJS_FLAGS) -DZJS_FIND_FUNC_NAME"
+else
 endif
 
 ifeq ($(BOARD), arduino_101)
@@ -237,7 +240,7 @@ analyze: $(JS)
 		JS_OUT=js.tmp \
 		BOARD=$(BOARD) \
 		JSON_DIR=src/ \
-		FORCE=$(ASHELL) \
+		FORCE=$(FORCE) \
 		PRJCONF=prj.conf \
 		MAKEFILE=src/Makefile \
 		MAKEBASE=src/Makefile.base \

--- a/arc/src/zjs_arc.json
+++ b/arc/src/zjs_arc.json
@@ -7,8 +7,7 @@
             "CONFIG_PRINTK=y",
             "CONFIG_CONSOLE=y",
             "CONFIG_SERIAL=n",
-            "CONFIG_NS16550=n",
-            "CONFIG_NANO_TIMEOUTS=y"
+            "CONFIG_NS16550=n"
         ]
     },
     "src": ["../../src/zjs_common.c"]

--- a/src/zjs_arduino_101.json
+++ b/src/zjs_arduino_101.json
@@ -7,8 +7,6 @@
             "CONFIG_STDOUT_CONSOLE=y",
             "CONFIG_NEWLIB_LIBC=y",
             "CONFIG_FLOAT=y",
-            "CONFIG_NANO_TIMERS=y",
-            "CONFIG_NANO_TIMEOUTS=y",
             "CONFIG_RING_BUFFER=y"
         ]
     }

--- a/src/zjs_arduino_101.json
+++ b/src/zjs_arduino_101.json
@@ -3,11 +3,7 @@
     "targets": ["arduino_101"],
     "zephyr_conf": {
         "arduino_101": [
-            "CONFIG_MAIN_STACK_SIZE=2048",
-            "CONFIG_STDOUT_CONSOLE=y",
-            "CONFIG_NEWLIB_LIBC=y",
-            "CONFIG_FLOAT=y",
-            "CONFIG_RING_BUFFER=y"
+            "CONFIG_MAIN_STACK_SIZE=2048"
         ]
     }
 }

--- a/src/zjs_ashell.json
+++ b/src/zjs_ashell.json
@@ -1,14 +1,14 @@
 {
     "module": "ashell",
-    "depends": ["aio", "arduino101_pins", "ble", "console", "fs", "gpio",
-                "grove_lcd", "i2c", "performance", "pwm", "sensor_accel",
-                "sensor_gyro", "sensor_light", "sensor_temp", "spi" ],
+    "depends": ["aio", "arduino101_pins", "ble", "common", "console", "fs",
+                "gpio", "grove_lcd", "i2c", "performance", "pwm",
+                "sensor_accel", "sensor_gyro", "sensor_light", "sensor_temp",
+                "spi"],
     "targets": ["arduino_101"],
     "src": ["ashell/"],
     "zephyr_conf": {
         "arduino_101": [
             "CONFIG_EARLY_CONSOLE=y",
-            "CONFIG_STDOUT_CONSOLE=y",
             "CONFIG_CONSOLE_HANDLER=y",
             "CONFIG_CONSOLE_HANDLER_SHELL=y",
             "CONFIG_IHEX_UPLOADER_DEBUG=n",

--- a/src/zjs_common.json
+++ b/src/zjs_common.json
@@ -1,0 +1,11 @@
+{
+    "module": "common",
+    "zephyr_conf": {
+        "all": [
+            "CONFIG_STDOUT_CONSOLE=y",
+            "CONFIG_NEWLIB_LIBC=y",
+            "CONFIG_FLOAT=y",
+            "CONFIG_RING_BUFFER=y"
+        ]
+    }
+}

--- a/src/zjs_frdm_k64f.json
+++ b/src/zjs_frdm_k64f.json
@@ -6,10 +6,6 @@
     "zephyr_conf": {
         "frdm_k64f": [
             "CONFIG_MAIN_STACK_SIZE=2048",
-            "CONFIG_STDOUT_CONSOLE=y",
-            "CONFIG_NEWLIB_LIBC=y",
-            "CONFIG_FLOAT=y",
-            "CONFIG_RING_BUFFER=y",
             "CONFIG_PINMUX_MCUX_PORTD=y"
         ]
     }

--- a/src/zjs_frdm_k64f.json
+++ b/src/zjs_frdm_k64f.json
@@ -9,8 +9,6 @@
             "CONFIG_STDOUT_CONSOLE=y",
             "CONFIG_NEWLIB_LIBC=y",
             "CONFIG_FLOAT=y",
-            "CONFIG_NANO_TIMERS=y",
-            "CONFIG_NANO_TIMEOUTS=y",
             "CONFIG_RING_BUFFER=y",
             "CONFIG_PINMUX_MCUX_PORTD=y"
         ]

--- a/src/zjs_qemu_x86.json
+++ b/src/zjs_qemu_x86.json
@@ -4,10 +4,6 @@
     "zephyr_conf": {
         "qemu_x86": [
             "CONFIG_MAIN_STACK_SIZE=2048",
-            "CONFIG_STDOUT_CONSOLE=y",
-            "CONFIG_NEWLIB_LIBC=y",
-            "CONFIG_FLOAT=y",
-            "CONFIG_RING_BUFFER=y",
             "CONFIG_RAM_SIZE=80",
             "CONFIG_ROM_SIZE=256"
         ]

--- a/src/zjs_qemu_x86.json
+++ b/src/zjs_qemu_x86.json
@@ -7,8 +7,6 @@
             "CONFIG_STDOUT_CONSOLE=y",
             "CONFIG_NEWLIB_LIBC=y",
             "CONFIG_FLOAT=y",
-            "CONFIG_NANO_TIMERS=y",
-            "CONFIG_NANO_TIMEOUTS=y",
             "CONFIG_RING_BUFFER=y",
             "CONFIG_RAM_SIZE=80",
             "CONFIG_ROM_SIZE=256"


### PR DESCRIPTION
This includes base configuration common to all platforms.

Fixes #1260.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>