### PR TITLE
[SPI] Changing the SPI example to print with hex instead of ascii

### DIFF
--- a/samples/SPI.js
+++ b/samples/SPI.js
@@ -8,7 +8,7 @@ try {
     var spiBus1 = spi.open({speed:20, bus:1, polarity:0, phase:0, bits:16});
 
     var buffer = spiBus1.transceive(1, "Hello World\0");
-    console.log("From SPI device 1: " + buffer.toString('ascii'));
+    console.log("From SPI device 1: " + buffer.toString('hex'));
 
     buffer = spiBus1.transceive(1, [1,2,3,4]);
     console.log("From SPI device 1: " + buffer.toString('hex'));


### PR DESCRIPTION
If the MOSI / MISO pins are not connected, the print will fail
with the message SPI error: buffer has invalid ascii. To avoid
this, I'm changing it to print using HEX.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>