### PR TITLE
[build] Fix for FORCE in analyze

### DIFF
--- a/scripts/analyze
+++ b/scripts/analyze
@@ -221,7 +221,7 @@ def parse_json_tree(file, dlist, zlist, zjslist, jrslist, srclist, tree, force=[
             with open(args['JSON_DIR'] + f) as file:
                 data = json.load(file)
                 parse_json_tree_helper(text, data['module'], dlist, zlist, zjslist, jrslist, srclist, tree)
-    
+
     # iterate the JSON tree
     for i in tree:
         # find any matching require lines

--- a/scripts/analyze
+++ b/scripts/analyze
@@ -217,7 +217,6 @@ def parse_json_tree(file, dlist, zlist, zjslist, jrslist, srclist, tree, force=[
         text = js.read()
 
     if force != []:
-        # parse only the forced JSON files
         for f in force:
             with open(args['JSON_DIR'] + f) as file:
                 data = json.load(file)

--- a/scripts/analyze
+++ b/scripts/analyze
@@ -222,27 +222,27 @@ def parse_json_tree(file, dlist, zlist, zjslist, jrslist, srclist, tree, force=[
             with open(args['JSON_DIR'] + f) as file:
                 data = json.load(file)
                 parse_json_tree_helper(text, data['module'], dlist, zlist, zjslist, jrslist, srclist, tree)
-    else:
-        # iterate the JSON tree
-        for i in tree:
-            # find any matching require lines
-            if 'require' in tree[i]:
-                if match_require(text, tree[i]['require']):
-                    if i not in dlist:
-                        dlist.append(i)
-                    parse_json_tree_helper(text, i, dlist, zlist, zjslist, jrslist, srclist, tree)
-            # find any matching constructor calls
-            elif 'constructor' in tree[i]:
-                if re.search(r"%s\(.*" % tree[i]['constructor'], text):
-                    if i not in dlist:
-                        dlist.append(i)
-                    parse_json_tree_helper(text, i, dlist, zlist, zjslist, jrslist, srclist, tree)
-            # find any matching uses of object
-            if 'object' in tree[i]:
-                if re.search(r"%s\." % tree[i]['object'], text):
-                    merge_lists(zjslist, tree[i]['zjs_config'])
-                    merge_lists(srclist, tree[i]['src'])
-                    dlist.append(tree[i]['object'])
+    
+    # iterate the JSON tree
+    for i in tree:
+        # find any matching require lines
+        if 'require' in tree[i]:
+            if match_require(text, tree[i]['require']):
+                if i not in dlist:
+                    dlist.append(i)
+                parse_json_tree_helper(text, i, dlist, zlist, zjslist, jrslist, srclist, tree)
+        # find any matching constructor calls
+        elif 'constructor' in tree[i]:
+            if re.search(r"%s\(.*" % tree[i]['constructor'], text):
+                if i not in dlist:
+                    dlist.append(i)
+                parse_json_tree_helper(text, i, dlist, zlist, zjslist, jrslist, srclist, tree)
+        # find any matching uses of object
+        if 'object' in tree[i]:
+            if re.search(r"%s\." % tree[i]['object'], text):
+                merge_lists(zjslist, tree[i]['zjs_config'])
+                merge_lists(srclist, tree[i]['src'])
+                dlist.append(tree[i]['object'])
 
     # Get any deps for the board
     parse_json_tree_helper(text, board, dlist, zlist, zjslist, jrslist, srclist, tree)


### PR DESCRIPTION
Currently if FORCE is provided, it analyze only looks at those
modules.  With the addition of FORCE=zjs_common.json this breaks
building with JS=samples/* as it only includes the common.json.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>