### PR TITLE
[ocf] Fixed OCF random segfault on FRDM-K64F

### DIFF
--- a/src/zjs_iotivity_constrained.json
+++ b/src/zjs_iotivity_constrained.json
@@ -43,6 +43,7 @@
         "-I$(OCF_ROOT)/deps/tinydtls",
         "-DWITH_OCF",
         "-DNDEBUG",
+        "-include $(ZJS_BASE)/src/zjs_ocf_config.h",
         "-include $(ZJS_BASE)/$(OCF_ROOT)/port/zephyr/src/config.h",
         "-I$(ZJS_BASE)/$(OCF_ROOT)/$(OCF_ROOT)/include",
         "-I$(ZJS_BASE)/$(OCF_ROOT)"

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -515,6 +515,10 @@ void zjs_ocf_register_resources(void)
         struct server_resource *resource = cur->resource;
 
         resource->res = oc_new_resource(resource->resource_path, resource->num_types, 0);
+        if (!resource->res) {
+            ERR_PRINT("failed to create new resource\n");
+            return;
+        }
         for (i = 0; i < resource->num_types; ++i) {
             oc_resource_bind_resource_type(resource->res, resource->resource_types[i]);
         }


### PR DESCRIPTION
The problem is that iotivity-constrained didn't build with OC_DYNAMIC_ALLOCATION,
also added NULL checking to prevent segfault.

Fixes #1284

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>