### PR TITLE
[build] Fix linux and QEMU build on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,8 @@ setup:
 ifeq ($(BOARD), qemu_x86)
 ifneq ($(OS), Darwin)
 	echo "CONFIG_XIP=y" >> prj.conf
+else
+	echo "CONFIG_RAM_SIZE=192" >> prj.conf
 endif
 else
 ifeq ($(ASHELL), ashell)

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -9,6 +9,8 @@ OCF_ROOT ?= deps/iotivity-constrained
 
 BUILD_DIR = $(ZJS_BASE)/outdir/linux/$(VARIANT)
 
+UNAME := $(shell uname)
+
 CORE_SRC +=	src/zjs_a101_pins.c \
 		src/zjs_board.c \
 		src/zjs_buffer.c \
@@ -97,18 +99,20 @@ BUILD_OBJ = $(CORE_OBJ:%.o=$(BUILD_DIR)/%.o)
 
 LINUX_MODULES="zjs_buffer.json,\
 zjs_console.json,\
-zjs_event.json,\
-zjs_iotivity_constrained.json,\
-zjs_ocf.json,\
-zjs_performance.json,\
+zjs_event.json,
+ifneq ($(UNAME),Darwin)
+LINUX_MODULES += zjs_iotivity_constrained.json,\
+zjs_ocf.json,
+endif
+LINUX_MODULES += zjs_performance.json,\
 zjs_promise.json,\
 zjs_test_callbacks.json,\
 zjs_test_promise.json,\
 zjs_gpio.json"
 
-UNAME := $(shell uname)
 ifneq ($(UNAME),Darwin)
 # Only build OCF on linux, until iotivity-constrained is fixed on Mac
+
 CORE_SRC +=	src/zjs_ocf_common.c \
 		src/zjs_ocf_client.c \
 		src/zjs_ocf_server.c

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -9,8 +9,8 @@
 #endif
 #include <string.h>
 
-#include "zjs_util.h"
 #include "zjs_callbacks.h"
+#include "zjs_util.h"
 
 #include "jerryscript.h"
 

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -11,14 +11,7 @@
 #endif
 
 #ifdef ZJS_LINUX_BUILD
-typedef int8_t s8_t;
-typedef uint8_t u8_t;
-typedef int16_t s16_t;
-typedef uint16_t u16_t;
-typedef int32_t s32_t;
-typedef uint32_t u32_t;
-typedef int64_t s64_t;
-typedef uint64_t u64_t;
+#include "zjs_linux_port.h"
 #else
 #include <zephyr/types.h>
 #endif

--- a/src/zjs_linux_port.h
+++ b/src/zjs_linux_port.h
@@ -3,12 +3,19 @@
 #ifndef ZJS_LINUX_PORT_H_
 #define ZJS_LINUX_PORT_H_
 
-#include "zjs_util.h"
-#include <unistd.h>
+#include <stdint.h>
 #include <time.h>
+#include <unistd.h>
 
 // define Zephyr numeric types we use
+typedef int8_t s8_t;
+typedef uint8_t u8_t;
+typedef int16_t s16_t;
+typedef uint16_t u16_t;
+typedef int32_t s32_t;
 typedef uint32_t u32_t;
+typedef int64_t s64_t;
+typedef uint64_t u64_t;
 
 typedef struct zjs_port_timer {
     u32_t sec;

--- a/src/zjs_linux_ring_buffer.c
+++ b/src/zjs_linux_ring_buffer.c
@@ -5,7 +5,7 @@
  * slightly modified to run on Linux.
  */
 
-#include "zjs_linux_port.h"
+#include "zjs_util.h"
 
 #ifndef likely
 #define likely(x)   __builtin_expect((long)!!(x), 1L)


### PR DESCRIPTION
Disable ocf build and fixed linux build on MacOS.

Fixes #1290

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>