### PR TITLE
[uart] Fix for 1279 UART not working

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -465,7 +465,11 @@ void signal_callback_priv(zjs_callback_id id,
             0,  // we use value for CB_FLUSH_ONE/ALL
             (u32_t *)args,
             (u8_t)((size + 3) / 4));
+    // Need to unlock here or callback may be blocked when it gets called.
     UNLOCK();
+#ifndef ZJS_LINUX_BUILD
+    zjs_loop_unblock();
+#endif
     if (ret != 0) {
         if (GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_JS) {
             // for JS, acquire values and release them after servicing callback
@@ -479,9 +483,6 @@ void signal_callback_priv(zjs_callback_id id,
         zjs_ringbuf_error_count++;
         zjs_ringbuf_last_error = ret;
     }
-#ifndef ZJS_LINUX_BUILD
-    zjs_loop_unblock();
-#endif
 }
 
 zjs_callback_id zjs_add_c_callback(void *handle, zjs_c_callback_func callback)

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -465,6 +465,7 @@ void signal_callback_priv(zjs_callback_id id,
             0,  // we use value for CB_FLUSH_ONE/ALL
             (u32_t *)args,
             (u8_t)((size + 3) / 4));
+    UNLOCK();
     if (ret != 0) {
         if (GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_JS) {
             // for JS, acquire values and release them after servicing callback
@@ -481,7 +482,6 @@ void signal_callback_priv(zjs_callback_id id,
 #ifndef ZJS_LINUX_BUILD
     zjs_loop_unblock();
 #endif
-    UNLOCK();
 }
 
 zjs_callback_id zjs_add_c_callback(void *handle, zjs_c_callback_func callback)

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -466,6 +466,9 @@ void signal_callback_priv(zjs_callback_id id,
             (u32_t *)args,
             (u8_t)((size + 3) / 4));
     // Need to unlock here or callback may be blocked when it gets called.
+    // NOTE: this is a temporary fix, we should implement a lock ID system
+    // rather than locking everything, as we are only trying to prevent a callback
+    // from being edited and called at the same time.
     UNLOCK();
 #ifndef ZJS_LINUX_BUILD
     zjs_loop_unblock();

--- a/src/zjs_uart.json
+++ b/src/zjs_uart.json
@@ -11,6 +11,7 @@
             "CONFIG_USB_DEVICE_STACK=y",
             "CONFIG_SYS_LOG_USB_DW_LEVEL=0",
             "CONFIG_SYS_LOG_USB_LEVEL=0",
+            "CONFIG_USB_CDC_ACM=y",
             "CONFIG_SERIAL=y",
             "CONFIG_UART_LINE_CTRL=y"
         ],


### PR DESCRIPTION
The lock in signal_callback is not freeing before UART is
triggered.  This is causing UART to be locked out when it tries
to write.  Moving the unlock up fixes the issue.  Also adding a
needed item to the zjs_uart.json file.

Signed-off-by: Brian Jones <brian.j.jones@intel.com>