### PR TITLE
[trlite] Add fs to k64f tests so we catch build regressions

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -319,7 +319,8 @@ if [ "$RUN" == "all" -o "$RUN" == "2" ]; then
     # k64f build tests
     try_command "k64f hello" make $VERBOSE BOARD=frdm_k64f
 
-    MODULES=(ble dgram events gpio grove_lcd i2c k64f_pins performance pwm uart)
+    MODULES=(ble dgram events fs gpio grove_lcd i2c k64f_pins performance pwm
+             uart)
     SENSORS=(Accelerometer)
     write_modules_test $TMPFILE $MODULES $SENSORS
 


### PR DESCRIPTION
Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>