### PR TITLE
[ocf] Work-around to fix segfault when using promises

### DIFF
--- a/tests/test-ocfclient.js
+++ b/tests/test-ocfclient.js
@@ -143,9 +143,7 @@ function onfound2(resource) {
         });
 
         resource.properties.state = false;
-        client.update(resource).then(function(res) {
-        }).catch(function(error) {
-        });
+        client.update(resource);
 
         client.retrieve(resource.deviceId).then(function(res) {
             assert(res.properties.state === false,


### PR DESCRIPTION
This is a work-around patch to have the tests no segfault
when the function passed into the .then() is empty, which
causes a segfault executed.

Fixes #1316

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>