### PR TITLE
[build] Work-around fix for Zephyr SDK bug on AIO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,11 @@ EXT_JERRY_FLAGS ?=	-DENABLE_ALL_IN_ONE=ON \
 			-DJERRY_LIBM=OFF \
 			-DJERRY_PORT_DEFAULT=OFF
 
+# Work-around for #2363 until Zephyr fixes the SDK
+ifeq ($(VARIANT), release)
+KBUILD_CFLAGS_OPTIMIZE = -O2
+endif
+
 # Generate and run snapshot as byte code instead of running JS directly
 ifneq (,$(filter $(MAKECMDGOALS),ide ashell linux))
 SNAPSHOT=off
@@ -423,7 +428,7 @@ arc: analyze
 		cd arc; make BOARD=arduino_101_sss CROSS_COMPILE=$(ARC_CROSS_COMPILE); \
 	else \
 		sed -i '/This is a generated file/r./zjs.conf.tmp' arc/src/Makefile; \
-		cd arc; make BOARD=arduino_101_sss -j4; \
+		cd arc; make BOARD=arduino_101_sss KBUILD_CFLAGS_OPTIMIZE=$(KBUILD_CFLAGS_OPTIMIZE) -j4; \
 	fi
 ifeq ($(BOARD), arduino_101)
 	@echo


### PR DESCRIPTION
The 0.9.1 SDK still has upstream bug #2363 not fixed, so
this work-around patches our build to build with -O2 on ARC
images so it fixes the bug with AIO not booting.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>