### PR TITLE
[tools] TRACE=on will now print all memory left after cleanup

### DIFF
--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -214,6 +214,10 @@ void zjs_modules_cleanup()
     }
     // clean up fixed modules
     zjs_error_cleanup();
+
+#ifdef ZJS_TRACE_MALLOC
+    zjs_print_mem_stats();
+#endif //ZJS_TRACE_MALLOC
 }
 
 void zjs_register_service_routine(void *handle, zjs_service_routine func)

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -217,7 +217,7 @@ void zjs_modules_cleanup()
 
 #ifdef ZJS_TRACE_MALLOC
     zjs_print_mem_stats();
-#endif //ZJS_TRACE_MALLOC
+#endif  // ZJS_TRACE_MALLOC
 }
 
 void zjs_register_service_routine(void *handle, zjs_service_routine func)

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -217,7 +217,7 @@ void zjs_modules_cleanup()
 
 #ifdef ZJS_TRACE_MALLOC
     zjs_print_mem_stats();
-#endif  // ZJS_TRACE_MALLOC
+#endif
 }
 
 void zjs_register_service_routine(void *handle, zjs_service_routine func)

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -13,7 +13,7 @@
 #ifdef ZJS_TRACE_MALLOC
 #define MAX_LIST_SIZE 300
 mem_stats_t mem_array[MAX_LIST_SIZE];
-#endif //ZJS_TRACE_MALLOC
+#endif
 
 void *zjs_malloc_with_retry(size_t size)
 {
@@ -25,6 +25,7 @@ void *zjs_malloc_with_retry(size_t size)
     }
     return ptr;
 }
+
 #ifdef ZJS_TRACE_MALLOC
 void zjs_print_mem_stats()
 {
@@ -62,13 +63,13 @@ void zjs_pop_mem_stat(void *rm_ptr)
             if (mem_array[i].ptr == rm_ptr) {
                 mem_array[i].ptr = NULL;
                 mem_array[i].file = "";
-                //free(mem_array[i].func);
                 mem_array[i].line = 0;
             }
         }
     }
 }
-#endif // ZJS_TRACE_MALLOC
+#endif  // ZJS_TRACE_MALLOC
+
 void zjs_set_property(const jerry_value_t obj, const char *name,
                       const jerry_value_t prop)
 {

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -10,9 +10,10 @@
 #ifndef ZJS_LINUX_BUILD
 #include "zjs_zephyr_port.h"
 #endif
-
+#ifdef ZJS_TRACE_MALLOC
 #define max_list_size 300
 mem_stats_t mem_list[max_list_size];
+#endif //ZJS_TRACE_MALLOC
 
 void *zjs_malloc_with_retry(size_t size)
 {

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -11,6 +11,9 @@
 #include "zjs_zephyr_port.h"
 #endif
 
+#define max_list_size 300
+mem_stats_t mem_list[max_list_size];
+
 void *zjs_malloc_with_retry(size_t size)
 {
     void *ptr = malloc(size);
@@ -21,7 +24,53 @@ void *zjs_malloc_with_retry(size_t size)
     }
     return ptr;
 }
+#ifdef ZJS_TRACE_MALLOC
+void zjs_print_mem_stats()
+{
+    for (int i = 0; i < max_list_size; i++)
+    {
+        if (mem_list[i].ptr != NULL) {
+            ZJS_PRINT("index %i %s - %s:%d: %p\n", i, mem_list[i].file, mem_list[i].func, mem_list[i].line, mem_list[i].ptr);
+        }
+    }
+}
 
+void zjs_push_mem_stat(void *ptr, char *file, char *func, int line)
+{
+    int i = 0;
+    // Find an open spot
+    while (mem_list[i].ptr != NULL && i < max_list_size)
+    {
+        i++;
+    }
+
+    if (i > max_list_size) {
+        ZJS_PRINT("zjs_push_mem_stat no memory stat slots available\n");
+        return;
+    }
+
+    mem_list[i].ptr = ptr;
+    mem_list[i].file = file;
+    mem_list[i].func = func;
+    mem_list[i].line = line;
+}
+
+void zjs_pop_mem_stat(void *rm_ptr)
+{
+    if (rm_ptr != NULL) {
+        for (int i = 0; i < max_list_size; i++)
+        {
+            if (mem_list[i].ptr == rm_ptr) {
+                mem_list[i].ptr = NULL;
+                mem_list[i].file = "";
+                free(mem_list[i].func);
+                mem_list[i].line = 0;
+                mem_list[i].next = NULL;
+            }
+        }
+    }
+}
+#endif // ZJS_TRACE_MALLOC
 void zjs_set_property(const jerry_value_t obj, const char *name,
                       const jerry_value_t prop)
 {

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -11,8 +11,8 @@
 #include "zjs_zephyr_port.h"
 #endif
 #ifdef ZJS_TRACE_MALLOC
-#define max_list_size 300
-mem_stats_t mem_list[max_list_size];
+#define MAX_LIST_SIZE 300
+mem_stats_t mem_array[MAX_LIST_SIZE];
 #endif //ZJS_TRACE_MALLOC
 
 void *zjs_malloc_with_retry(size_t size)
@@ -28,42 +28,42 @@ void *zjs_malloc_with_retry(size_t size)
 #ifdef ZJS_TRACE_MALLOC
 void zjs_print_mem_stats()
 {
-    for (int i = 0; i < max_list_size; i++) {
-        if (mem_list[i].ptr != NULL) {
-            ZJS_PRINT("index %i %s - %s:%d: %p\n", i, mem_list[i].file, mem_list[i].func, mem_list[i].line, mem_list[i].ptr);
+    for (int i = 0; i < MAX_LIST_SIZE; i++) {
+        if (mem_array[i].ptr != NULL) {
+            ZJS_PRINT("index %i %s - %s:%d: %p\n", i, mem_array[i].file,
+                      mem_array[i].func, mem_array[i].line, mem_array[i].ptr);
         }
     }
 }
 
-void zjs_push_mem_stat(void *ptr, char *file, char *func, int line)
+void zjs_push_mem_stat(void *ptr, char *file, const char *func, int line)
 {
     int i = 0;
     // Find an open spot
-    while (mem_list[i].ptr != NULL && i < max_list_size) {
+    while (mem_array[i].ptr != NULL && i < MAX_LIST_SIZE) {
         i++;
     }
 
-    if (i > max_list_size) {
-        ZJS_PRINT("zjs_push_mem_stat no memory stat slots available\n");
+    if (i >= MAX_LIST_SIZE) {
+        ZJS_PRINT("No memory stat slots available\n");
         return;
     }
 
-    mem_list[i].ptr = ptr;
-    mem_list[i].file = file;
-    mem_list[i].func = func;
-    mem_list[i].line = line;
+    mem_array[i].ptr = ptr;
+    mem_array[i].file = file;
+    mem_array[i].func = func;
+    mem_array[i].line = line;
 }
 
 void zjs_pop_mem_stat(void *rm_ptr)
 {
     if (rm_ptr != NULL) {
-        for (int i = 0; i < max_list_size; i++) {
-            if (mem_list[i].ptr == rm_ptr) {
-                mem_list[i].ptr = NULL;
-                mem_list[i].file = "";
-                free(mem_list[i].func);
-                mem_list[i].line = 0;
-                mem_list[i].next = NULL;
+        for (int i = 0; i < MAX_LIST_SIZE; i++) {
+            if (mem_array[i].ptr == rm_ptr) {
+                mem_array[i].ptr = NULL;
+                mem_array[i].file = "";
+                //free(mem_array[i].func);
+                mem_array[i].line = 0;
             }
         }
     }

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -28,8 +28,7 @@ void *zjs_malloc_with_retry(size_t size)
 #ifdef ZJS_TRACE_MALLOC
 void zjs_print_mem_stats()
 {
-    for (int i = 0; i < max_list_size; i++)
-    {
+    for (int i = 0; i < max_list_size; i++) {
         if (mem_list[i].ptr != NULL) {
             ZJS_PRINT("index %i %s - %s:%d: %p\n", i, mem_list[i].file, mem_list[i].func, mem_list[i].line, mem_list[i].ptr);
         }
@@ -40,8 +39,7 @@ void zjs_push_mem_stat(void *ptr, char *file, char *func, int line)
 {
     int i = 0;
     // Find an open spot
-    while (mem_list[i].ptr != NULL && i < max_list_size)
-    {
+    while (mem_list[i].ptr != NULL && i < max_list_size) {
         i++;
     }
 
@@ -59,8 +57,7 @@ void zjs_push_mem_stat(void *ptr, char *file, char *func, int line)
 void zjs_pop_mem_stat(void *rm_ptr)
 {
     if (rm_ptr != NULL) {
-        for (int i = 0; i < max_list_size; i++)
-        {
+        for (int i = 0; i < max_list_size; i++) {
             if (mem_list[i].ptr == rm_ptr) {
                 mem_list[i].ptr = NULL;
                 mem_list[i].file = "";

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -23,7 +23,7 @@ typedef struct mem_stats {
     int line;
     struct mem_stats *next;
 } mem_stats_t;
-#endif //ZJS_TRACE_MALLOC
+#endif
 
 #define ZJS_UNDEFINED jerry_create_undefined()
 

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -54,7 +54,7 @@ void zjs_pop_mem_stat(void *ptr);
         void *zjs_ptr = zjs_malloc_with_retry(sz);                              \
         ZJS_PRINT("%s:%d: allocating %u bytes (%p)\n", __func__, __LINE__,      \
                   (u32_t)sz, zjs_ptr);                                          \
-        zjs_push_mem_stat(zjs_ptr, __FILE__, __func__, __LINE__);  \
+        zjs_push_mem_stat(zjs_ptr, __FILE__, __func__, __LINE__);               \
         zjs_ptr;                                                                \
     })
 #define zjs_free(ptr) \

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -15,6 +15,14 @@
 #include "zjs_common.h"
 #include "zjs_error.h"
 
+typedef struct mem_stats {
+    void *ptr;
+    char *file;
+    char *func;
+    int line;
+    struct mem_stats *next;
+} mem_stats_t;
+
 #define ZJS_UNDEFINED jerry_create_undefined()
 
 #ifdef DEBUG_BUILD
@@ -30,6 +38,10 @@
  */
 void *zjs_malloc_with_retry(size_t size);
 
+void zjs_print_mem_stats();
+void zjs_push_mem_stat(void *ptr, char *file, char *func, int line);
+void zjs_pop_mem_stat(void *ptr);
+
 #ifdef ZJS_LINUX_BUILD
 #define zjs_malloc(sz) malloc(sz)
 #define zjs_free(ptr) free(ptr)
@@ -39,12 +51,15 @@ void *zjs_malloc_with_retry(size_t size);
 #define zjs_malloc(sz)                                                      \
     ({                                                                      \
         void *zjs_ptr = zjs_malloc_with_retry(sz);                          \
-        ZJS_PRINT("%s:%d: allocating %lu bytes (%p)\n", __func__, __LINE__, \
+        ZJS_PRINT("%s:%d: allocating %u bytes (%p)\n", __func__, __LINE__,  \
                   (u32_t)sz, zjs_ptr);                                      \
+        char *func_copy = malloc(strlen(__func__) + 1);                     \
+        strcpy(func_copy, __func__);                                        \
+        zjs_push_mem_stat(zjs_ptr, __FILE__, func_copy, __LINE__);          \
         zjs_ptr;                                                            \
     })
 #define zjs_free(ptr) \
-    (ZJS_PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), free(ptr))
+    (ZJS_PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), zjs_pop_mem_stat(ptr), free(ptr))
 #else
 #define zjs_malloc(sz)                             \
     ({                                             \

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -54,7 +54,7 @@ void zjs_pop_mem_stat(void *ptr);
         void *zjs_ptr = zjs_malloc_with_retry(sz);                              \
         ZJS_PRINT("%s:%d: allocating %u bytes (%p)\n", __func__, __LINE__,      \
                   (u32_t)sz, zjs_ptr);                                          \
-        zjs_push_mem_stat(zjs_ptr, __FILE__, (const char*)__func__, __LINE__);  \
+        zjs_push_mem_stat(zjs_ptr, __FILE__, __func__, __LINE__);  \
         zjs_ptr;                                                                \
     })
 #define zjs_free(ptr) \

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -15,6 +15,7 @@
 #include "zjs_common.h"
 #include "zjs_error.h"
 
+#ifdef ZJS_TRACE_MALLOC
 typedef struct mem_stats {
     void *ptr;
     char *file;
@@ -22,6 +23,7 @@ typedef struct mem_stats {
     int line;
     struct mem_stats *next;
 } mem_stats_t;
+#endif //ZJS_TRACE_MALLOC
 
 #define ZJS_UNDEFINED jerry_create_undefined()
 

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -49,13 +49,13 @@ void zjs_pop_mem_stat(void *ptr);
 #else
 #include <zephyr.h>
 #ifdef ZJS_TRACE_MALLOC
-#define zjs_malloc(sz)                                                      \
-    ({                                                                      \
-        void *zjs_ptr = zjs_malloc_with_retry(sz);                          \
-        ZJS_PRINT("%s:%d: allocating %u bytes (%p)\n", __func__, __LINE__,  \
-                  (u32_t)sz, zjs_ptr);                                      \
-        zjs_push_mem_stat(zjs_ptr, __FILE__, (const char*)__func__, __LINE__);          \
-        zjs_ptr;                                                            \
+#define zjs_malloc(sz)                                                          \
+    ({                                                                          \
+        void *zjs_ptr = zjs_malloc_with_retry(sz);                              \
+        ZJS_PRINT("%s:%d: allocating %u bytes (%p)\n", __func__, __LINE__,      \
+                  (u32_t)sz, zjs_ptr);                                          \
+        zjs_push_mem_stat(zjs_ptr, __FILE__, (const char*)__func__, __LINE__);  \
+        zjs_ptr;                                                                \
     })
 #define zjs_free(ptr) \
     (ZJS_PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), zjs_pop_mem_stat(ptr), free(ptr))

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -19,9 +19,8 @@
 typedef struct mem_stats {
     void *ptr;
     char *file;
-    char *func;
+    const char *func;
     int line;
-    struct mem_stats *next;
 } mem_stats_t;
 #endif
 
@@ -41,7 +40,7 @@ typedef struct mem_stats {
 void *zjs_malloc_with_retry(size_t size);
 
 void zjs_print_mem_stats();
-void zjs_push_mem_stat(void *ptr, char *file, char *func, int line);
+void zjs_push_mem_stat(void *ptr, char *file, const char *func, int line);
 void zjs_pop_mem_stat(void *ptr);
 
 #ifdef ZJS_LINUX_BUILD
@@ -55,9 +54,7 @@ void zjs_pop_mem_stat(void *ptr);
         void *zjs_ptr = zjs_malloc_with_retry(sz);                          \
         ZJS_PRINT("%s:%d: allocating %u bytes (%p)\n", __func__, __LINE__,  \
                   (u32_t)sz, zjs_ptr);                                      \
-        char *func_copy = malloc(strlen(__func__) + 1);                     \
-        strcpy(func_copy, __func__);                                        \
-        zjs_push_mem_stat(zjs_ptr, __FILE__, func_copy, __LINE__);          \
+        zjs_push_mem_stat(zjs_ptr, __FILE__, (const char*)__func__, __LINE__);          \
         zjs_ptr;                                                            \
     })
 #define zjs_free(ptr) \


### PR DESCRIPTION
This provides a method to print all the memory left after the
module cleanup methods have been called.  It will provide an easy
way to spot memory leaks.  You can use this method to print at any
time, but currently it will only be called after module cleanup.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>