### PR TITLE
[grove_lcd] Fix Grove LCD not working in IDE

### DIFF
--- a/arc/src/zjs_ashell_arc.json
+++ b/arc/src/zjs_ashell_arc.json
@@ -1,8 +1,8 @@
 {
     "module": "ashell_arc",
-    "depends": ["i2c",
+    "depends": ["aio_arc",
+                "grove_lcd_arc",
                 "i2c_arc",
-                "aio_arc",
                 "sensor_accel_arc",
                 "sensor_gyro_arc",
                 "sensor_light_arc",

--- a/arc/src/zjs_grove_lcd_arc.json
+++ b/arc/src/zjs_grove_lcd_arc.json
@@ -1,10 +1,10 @@
 {
     "module": "grove_lcd_arc",
     "require": "grove_lcd",
-    "depends": ["ipm_arc", "i2c_arc"],
+    "depends": ["ipm_arc"],
     "targets": ["arc"],
     "zephyr_conf": {
-        "all": [
+        "arc": [
             "CONFIG_I2C=y",
             "CONFIG_GROVE=y",
             "CONFIG_GROVE_LCD_RGB=y",


### PR DESCRIPTION
This patch fixes the bug where Ashell/IDE didn't include
the ARC build for Grove LCD.

Fixes #1357

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>