### PR TITLE
[travis] Fix broken build by using deprecated setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: generic # setting language to C will override cross-compiler and fail
 
 sudo: required
 dist: trusty
+group: deprecated-2017Q3
 
 notifications:
   irc:


### PR DESCRIPTION
This is a temporary workaround until we figure out how to solve the
problem of "import yaml" no longer working in Python 3 scripts.

I'd prefer we not merge this and solve that instead; otherwise we'll
have masked over it and won't ever fix it until something worse goes
wrong.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>