### PR TITLE
[websockets] Fix fault when closing websocket

### DIFF
--- a/samples/websockets/WebSocketServer.js
+++ b/samples/websockets/WebSocketServer.js
@@ -24,12 +24,13 @@ var wss = new WebSocket.Server({
 });
 
 var count = 0;
+var t = null;
 
 wss.on('connection', function(ws) {
     console.log("CONNECTION");
     ws.on('message', function(message) {
         console.log("MESSAGE: " + message.toString('ascii'));
-        setTimeout(function() {
+        t = setTimeout(function() {
             ws.send(new Buffer("A MESSAGE"), true);
             if (count % 10 == 0) {
                 ws.ping(new Buffer("PING"));
@@ -46,8 +47,10 @@ wss.on('connection', function(ws) {
     });
     ws.on('close', function(code, reason) {
         console.log("close event: " + reason);
+        clearTimeout(t);
     });
     ws.on('error', function(error) {
         console.log(error.name + " : " + error.message);
+        clearTimeout(t);
     });
 });

--- a/samples/websockets/WebSocketServer4.js
+++ b/samples/websockets/WebSocketServer4.js
@@ -27,12 +27,13 @@ net_cfg.dhcp(function(address, subnet, gateway) {
     });
 
     var count = 0;
+    var t = null;
 
     wss.on('connection', function(ws) {
         console.log("CONNECTION");
         ws.on('message', function(message) {
             console.log("MESSAGE: " + message.toString('ascii'));
-            setTimeout(function() {
+            t = setTimeout(function() {
                 ws.send(new Buffer("A MESSAGE"), true);
                 if (count % 10 == 0) {
                     ws.ping(new Buffer("PING"));
@@ -49,9 +50,11 @@ net_cfg.dhcp(function(address, subnet, gateway) {
         });
         ws.on('close', function(code, reason) {
             console.log("close event: " + reason);
+            clearTimeout(t);
         });
         ws.on('error', function(error) {
             console.log(error.name + " : " + error.message);
+            clearTimeout(t);
         });
     });
 });


### PR DESCRIPTION
After a websocket had been closed, there still was a pending
timeout to send more data. This clears that timeout if a
close event is triggered.

Fixes #1372

Signed-off-by: James Prestwood <james.prestwood@intel.com>