### PR TITLE
[pme] Drop neuron context APIs as it's internal-only

### DIFF
--- a/arc/src/arc_pme.c
+++ b/arc/src/arc_pme.c
@@ -137,32 +137,6 @@ void arc_handle_pme(struct zjs_ipm_message *msg)
         msg->data.pme.g_context = curie_pme_get_global_context();
         DBG_PRINT("global context: %d\n", msg->data.pme.g_context);
         break;
-    case TYPE_PME_SET_GLOBAL_CONTEXT:
-        // valid range is 1-127
-        if (msg->data.pme.g_context < 1 || msg->data.pme.g_context > 127) {
-            ERR_PRINT("context range has to be 1-127\n");
-            ipm_send_error(msg, ERROR_IPM_INVALID_PARAMETER);
-            return;
-        }
-
-        curie_pme_set_global_context(msg->data.pme.g_context);
-        DBG_PRINT("global context: %d\n", msg->data.pme.g_context);
-        break;
-    case TYPE_PME_GET_NEURON_CONTEXT:
-        msg->data.pme.n_context = curie_pme_get_neuron_context();
-        DBG_PRINT("neuron context: %d\n", msg->data.pme.n_context);
-        break;
-    case TYPE_PME_SET_NEURON_CONTEXT:
-        // valid range is 1-127
-        if (msg->data.pme.n_context < 1 || msg->data.pme.n_context > 127) {
-            ERR_PRINT("context range has to be 1-127\n");
-            ipm_send_error(msg, ERROR_IPM_INVALID_PARAMETER);
-            return;
-        }
-
-        curie_pme_set_neuron_context(msg->data.pme.n_context);
-        DBG_PRINT("neuron context: %d\n", msg->data.pme.n_context);
-        break;
     case TYPE_PME_GET_CLASSIFIER_MODE:
         msg->data.pme.c_mode = curie_pme_get_classifier_mode();
         DBG_PRINT("classifier mode: %d\n", msg->data.pme.c_mode);

--- a/docs/pme.md
+++ b/docs/pme.md
@@ -51,9 +51,6 @@ interface PME {
     writeVector(number[] pattern);
     unsigned short getCommittedCount();
     unsigned short getGlobalContext();
-    setGlobalContext(unsigned short context);
-    unsigned short getNeuronContext();
-    setNeuronContext(unsigned short context);
     unsigned short getClassifierMode();
     setClassifierMode(unsigned short mode);
     unsigned short getDistanceMode();
@@ -173,30 +170,6 @@ Returns the number of comitted neurons in the network (a value between 0-128).
 Reads the Global Context Register.
 
 Returns the contents of the Global Context Register (a value between 0-127).
-
-### PME.setGlobalContext
-
-`void setGlobalContext(unsigned short context);`
-
-Writes a value to the Global Context Register.
-
-The `context` is valid context value range between 1-127. A context value of 0 enables all neurons, with no regard to their context.
-
-### PME.getNeuronContext
-
-`unsigned short getNeuronContext();`
-
-Reads the Neuron Context Register.
-
-Returns the contents of the Neuron Context Register (a value between 0-127).
-
-### PME.setNeuronContext
-
-`void setNeuronContext(unsigned short context);`
-
-Writes a value to the Neuron Context Register.
-
-The `context` is valid context value range between 1-127. A context value of 0 enables all neurons, with no regard to their context.
 
 ### PME.getClassifierMode
 

--- a/samples/PME.js
+++ b/samples/PME.js
@@ -50,7 +50,6 @@ console.log("Learned [ 10, 10, 10, 10 ] with category 100");
 pme.learn(training2, 200);
 console.log("Learned [ 20, 20, 20, 20 ] with category 200");
 console.log("Global context: " + pme.getGlobalContext());
-console.log("Neuron context: " + pme.getNeuronContext());
 console.log("Neuron count: " + pme.getCommittedCount());
 
 var category = pme.classify(classify1);

--- a/src/zjs_ipm.h
+++ b/src/zjs_ipm.h
@@ -83,13 +83,10 @@ enum {
 #define TYPE_PME_WRITE_VECTOR                              0x0046
 #define TYPE_PME_GET_COMMITED_COUNT                        0x0047
 #define TYPE_PME_GET_GLOBAL_CONTEXT                        0x0048
-#define TYPE_PME_SET_GLOBAL_CONTEXT                        0x0049
-#define TYPE_PME_GET_NEURON_CONTEXT                        0x004A
-#define TYPE_PME_SET_NEURON_CONTEXT                        0x004B
-#define TYPE_PME_GET_CLASSIFIER_MODE                       0x004C
-#define TYPE_PME_SET_CLASSIFIER_MODE                       0x004D
-#define TYPE_PME_GET_DISTANCE_MODE                         0x004E
-#define TYPE_PME_SET_DISTANCE_MODE                         0x004F
+#define TYPE_PME_GET_CLASSIFIER_MODE                       0x0049
+#define TYPE_PME_SET_CLASSIFIER_MODE                       0x004A
+#define TYPE_PME_GET_DISTANCE_MODE                         0x004B
+#define TYPE_PME_SET_DISTANCE_MODE                         0x004C
 // PME save and restore
 #define TYPE_PME_BEGIN_SAVE_MODE                           0x0050
 #define TYPE_PME_ITERATE_TO_SAVE                           0x0051

--- a/src/zjs_pme.c
+++ b/src/zjs_pme.c
@@ -263,41 +263,6 @@ static ZJS_DECL_FUNC(zjs_pme_get_global_context)
     return jerry_create_number(reply.data.pme.g_context);
 }
 
-static ZJS_DECL_FUNC(zjs_pme_set_global_context)
-{
-    // args: global context
-    ZJS_VALIDATE_ARGS(Z_NUMBER);
-
-    zjs_ipm_message_t send;
-    send.type = TYPE_PME_SET_GLOBAL_CONTEXT;
-    send.data.pme.g_context = jerry_get_number_value(argv[0]);
-
-    CALL_REMOTE_FUNCTION_NO_REPLY(send);
-    return ZJS_UNDEFINED;
-}
-
-static ZJS_DECL_FUNC(zjs_pme_get_neuron_context)
-{
-    zjs_ipm_message_t send, reply;
-    send.type = TYPE_PME_GET_NEURON_CONTEXT;
-
-    CALL_REMOTE_FUNCTION(send, reply);
-    return jerry_create_number(reply.data.pme.n_context);
-}
-
-static ZJS_DECL_FUNC(zjs_pme_set_neuron_context)
-{
-    // args: neuron context
-    ZJS_VALIDATE_ARGS(Z_NUMBER);
-
-    zjs_ipm_message_t send;
-    send.type = TYPE_PME_SET_NEURON_CONTEXT;
-    send.data.pme.n_context = jerry_get_number_value(argv[0]);
-
-    CALL_REMOTE_FUNCTION_NO_REPLY(send);
-    return ZJS_UNDEFINED;
-}
-
 static ZJS_DECL_FUNC(zjs_pme_get_classifier_mode)
 {
     zjs_ipm_message_t send, reply;
@@ -499,9 +464,6 @@ jerry_value_t zjs_pme_init()
         { zjs_pme_write_vector, "writeVector" },
         { zjs_pme_get_committed_count, "getCommittedCount" },
         { zjs_pme_get_global_context, "getGlobalContext" },
-        { zjs_pme_set_global_context, "setGlobalContext" },
-        { zjs_pme_get_neuron_context, "getNeuronContext" },
-        { zjs_pme_set_neuron_context, "setNeuronContext" },
         { zjs_pme_get_classifier_mode, "getClassifierMode" },
         { zjs_pme_set_classifier_mode, "setClassifierMode" },
         { zjs_pme_get_distance_mode, "getDistanceMode" },

--- a/tests/test-pme.js
+++ b/tests/test-pme.js
@@ -123,36 +123,6 @@ assert(globalContext === 1,
        "PMEContext: get default value for global context as '" +
        globalContext + "'");
 
-var neuronContext = pme.getNeuronContext();
-assert(neuronContext === 127,
-       "PMEContext: get default value for neuron context as '" +
-       neuronContext + "'");
-
-var contextValues = [ 1, 10, 100, 127, 200, 0, "string", true ];
-for (var i = 0; i < contextValues.length; i++) {
-    if (i <= 3) {
-        pme.setGlobalContext(contextValues[i]);
-        globalContext = pme.getGlobalContext();
-        assert(globalContext === contextValues[i],
-               "PMEContext: set and get global context as '" +
-               contextValues[i] + "'");
-
-        pme.setNeuronContext(contextValues[i]);
-        neuronContext = pme.getNeuronContext();
-        assert(neuronContext === contextValues[i],
-               "PMEContext: set and get neuron context as '" +
-               contextValues[i] + "'");
-    } else {
-        assert.throws(function() {
-            pme.setGlobalContext(contextValues[i]);
-        }, "PMEContext: set global context as '" + contextValues[i] + "'\n");
-
-        assert.throws(function() {
-            pme.setNeuronContext(contextValues[i]);
-        }, "PMEContext: set neuron context as '" + contextValues[i] + "'\n");
-    }
-}
-
 var defaultCommittedCount = pme.getCommittedCount();
 assert(defaultCommittedCount === 0,
        "PMEObject: get default value for committed neurons as '" +


### PR DESCRIPTION
The setNeuronContext() and getNeuronContext() APIs are internal APIs
that should only be called in save/restore modes, applications
should not be calling this function directly, but instead
use the saveNeurons() and restoreNeurons() instead.

Fixes #1245, #1246

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>