### PR TITLE
[uart] Fix for issue #1345, only 4 bytes sent to UART

### DIFF
--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -160,7 +160,7 @@ static int write_data(struct device *dev, const char *buf, int len)
         while (tx == false) {
             ;
         }
-        
+
         len -= sent;
         buf += sent;
         sent_total += sent;

--- a/src/zjs_uart.c
+++ b/src/zjs_uart.c
@@ -157,8 +157,10 @@ static int write_data(struct device *dev, const char *buf, int len)
             return sent_total;
         }
 
-        while (tx == false);
-
+        while (tx == false) {
+            ;
+        }
+        
         len -= sent;
         buf += sent;
         sent_total += sent;


### PR DESCRIPTION
Due to ZEP-2074, the Arduino 101 is limited to sending 4 bytes of data at a time via CDC_ACM.  This fix addresses that limitation.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>