### PR TITLE
[callbacks] Fix possible overflow of callback ID

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -449,7 +449,7 @@ void signal_callback_priv(zjs_callback_id id,
     LOCK();
     DBG_PRINT("pushing item to ring buffer. id=%d, args=%p, size=%u\n", id,
               args, size);
-    if (id < 0 || id > cb_size || !cb_map[id]) {
+    if (id < 0 || id >= cb_size || !cb_map[id]) {
         DBG_PRINT("callback ID %u does not exist\n", id);
         return;
     }
@@ -555,7 +555,7 @@ void print_callbacks(void)
 void zjs_call_callback(zjs_callback_id id, const void *data, u32_t sz)
 {
     LOCK();
-    if (id == -1 || id > cb_size || !cb_map[id]) {
+    if (id == -1 || id >= cb_size || !cb_map[id]) {
         ERR_PRINT("callback %d does not exist\n", id);
     } else if (GET_CB_REMOVED(cb_map[id]->flags)) {
         DBG_PRINT("callback %d has already been removed\n", id);


### PR DESCRIPTION
If someone callback id of exactly cb_size, this would cause an
invalid offset into cb_map, at least on the boundary of a new chunk
of callbacks.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>