### PR TITLE
[websockets] Fix "cannot acquire send_pkt" on Arduino 101

### DIFF
--- a/samples/websockets/WebSocketServer.js
+++ b/samples/websockets/WebSocketServer.js
@@ -36,6 +36,7 @@ wss.on('connection', function(ws) {
                 ws.ping(new Buffer("PING"));
             }
             count++;
+            clearTimeout(t);
         }, 1000);
     });
     ws.on('ping', function(data) {

--- a/samples/websockets/WebSocketServer4.js
+++ b/samples/websockets/WebSocketServer4.js
@@ -39,6 +39,7 @@ net_cfg.dhcp(function(address, subnet, gateway) {
                     ws.ping(new Buffer("PING"));
                 }
                 count++;
+                clearTimeout(t);
             }, 1000);
         });
         ws.on('ping', function(data) {

--- a/src/zjs_ws.json
+++ b/src/zjs_ws.json
@@ -15,7 +15,7 @@
             "CONFIG_NET_STATISTICS=y",
             "CONFIG_NET_BUF=y",
             "CONFIG_NET_PKT_RX_COUNT=5",
-            "CONFIG_NET_PKT_TX_COUNT=2",
+            "CONFIG_NET_PKT_TX_COUNT=3",
             "CONFIG_NET_BUF_RX_COUNT=10",
             "CONFIG_NET_BUF_TX_COUNT=6",
             "CONFIG_NET_IF_UNICAST_IPV6_ADDR_COUNT=3",


### PR DESCRIPTION
With limited memory, the A101 was running into two problems:

1. The number of net pkt's was set to 2, which, in the 'ping' case
   of the web socket server, was not enough.

2. The timer handle was not being cleared once the timeout expired.
   Normally this is ok but since it was being saved in the global
   scope it was never getting garbage collected.

Fixes #1386

Signed-off-by: James Prestwood <james.prestwood@intel.com>