### PR TITLE
[promise] Use built-in JobQueue implementation

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -38,7 +38,7 @@ CORE_OBJ =	$(CORE_SRC:%.c=%.o)
 
 LINUX_INCLUDES += 	-Isrc/ \
 			-I$(ZJS_BASE)/outdir/include \
-			-I$(JERRY_BASE)/jerry-core \
+			-I$(JERRY_BASE)/jerry-core/include \
 			-I$(JERRY_BASE)/jerry-core/jrt
 
 JERRY_LIBS += 		-l jerry-core -lm

--- a/scripts/checkheaders
+++ b/scripts/checkheaders
@@ -20,7 +20,7 @@ BINARY=/tmp/zjs_source
 PASSCOUNT=0
 TOTAL=0
 
-CFLAGS="-m32 -DCONFIG_X86 -DCONFIG_PREEMPT_ENABLED -DCONFIG_NET_IPV4 -DCONFIG_NET_IF_UNICAST_IPV4_ADDR_COUNT=1 -DCONFIG_NET_IF_MCAST_IPV4_ADDR_COUNT=1 -DCONFIG_LOAPIC_BASE_ADDRESS=0xFEE00000 -I. -I../deps/jerryscript/jerry-core -I../deps/zephyr/include -I../deps/zephyr/arch/x86/include -I../deps/iotivity-constrained/include -I../deps/iotivity-constrained -include ../deps/iotivity-constrained/port/zephyr/src/config.h"
+CFLAGS="-m32 -DCONFIG_X86 -DCONFIG_PREEMPT_ENABLED -DCONFIG_NET_IPV4 -DCONFIG_NET_IF_UNICAST_IPV4_ADDR_COUNT=1 -DCONFIG_NET_IF_MCAST_IPV4_ADDR_COUNT=1 -DCONFIG_LOAPIC_BASE_ADDRESS=0xFEE00000 -I. -I../deps/jerryscript/jerry-core -I../deps/jerryscript/jerry-core/include -I../deps/zephyr/include -I../deps/zephyr/arch/x86/include -I../deps/iotivity-constrained/include -I../deps/iotivity-constrained -include ../deps/iotivity-constrained/port/zephyr/src/config.h"
 FAILURES=
 
 function create_source()  # HEADER

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -13,7 +13,7 @@ ccflags-y += -Wno-error=format
 # Select extended ANSI C/POSIX function set in recent Newlib versions
 ccflags-y += -D_XOPEN_SOURCE=700
 
-ccflags-y += -I$(JERRY_BASE)/jerry-core
+ccflags-y += -I$(JERRY_BASE)/jerry-core/include
 ccflags-y += -I$(JERRY_BASE)/jerry-core/jrt
 ccflags-y += -I$(ZEPHYR_BASE)/drivers
 ccflags-y += -I$(ZJS_BASE)/outdir/include
@@ -52,5 +52,5 @@ obj-y += main.o \
 
 ifneq (,$(findstring zjs_ashell,$(ASHELL)))
 $(info Insecure Mode (development))
-export JERRY_INCLUDE = $(JERRY_BASE)/jerry-core/
+export JERRY_INCLUDE = $(JERRY_BASE)/jerry-core/include
 endif

--- a/src/jerry-port/zjs_jerry_port.c
+++ b/src/jerry-port/zjs_jerry_port.c
@@ -21,6 +21,7 @@ double jerry_port_get_current_time(void)
 void jerry_port_fatal(jerry_fatal_code_t code)
 {
     printf("[FATAL]: %u\n", code);
+    while (1) {};
 }
 
 void jerry_port_console(const char *fmat, ...)
@@ -39,34 +40,3 @@ void jerry_port_log(jerry_log_level_t level, const char *fmat, ...)
     vprintf(fmat, va);
     va_end(va);
 }
-
-#ifdef JERRY_PORT_ENABLE_JOBQUEUE
-#include "../zjs_common.h"
-#include "../zjs_callbacks.h"
-#include "../zjs_util.h"
-// The job queue is essentially C callbacks, this is a simple wrapper
-
-typedef struct job_wrapper {
-    jerry_job_handler_t handler;
-    void *job;
-    zjs_callback_id id;
-} job_wrapper_t;
-
-static void job_callback(void *h, const void *args)
-{
-    (void)(args);
-    job_wrapper_t *wrapper = (job_wrapper_t *)h;
-    wrapper->handler(wrapper->job);
-    zjs_remove_callback(wrapper->id);
-    zjs_free(wrapper);
-}
-
-void jerry_port_jobqueue_enqueue(jerry_job_handler_t handler, void *job_p)
-{
-    job_wrapper_t *wrapper = zjs_malloc(sizeof(job_wrapper_t));
-    wrapper->handler = handler;
-    wrapper->job = job_p;
-    wrapper->id = zjs_add_c_callback(wrapper, job_callback);
-    zjs_signal_callback(wrapper->id, NULL, 0);
-}
-#endif

--- a/src/main.c
+++ b/src/main.c
@@ -224,6 +224,18 @@ int main(int argc, char *argv[])
         if (zjs_service_callbacks()) {
             serviced = 1;
         }
+
+#ifdef BUILD_MODULE_PROMISE
+        // run queued jobs for promises
+        result = jerry_run_all_enqueued_jobs();
+        if (jerry_value_has_error_flag(result))
+        {
+            DBG_PRINT("Error running JS in promise jobqueue\n");
+            zjs_print_error_message(result, ZJS_UNDEFINED);
+            goto error;
+        }
+#endif
+
 #ifndef ZJS_LINUX_BUILD
         zjs_loop_block(wait_time);
 #endif

--- a/src/zjs_promise.json
+++ b/src/zjs_promise.json
@@ -3,7 +3,6 @@
     "constructor": "Promise",
     "zjs_config": ["-DBUILD_MODULE_PROMISE"],
     "src": ["jerry-port/zjs_jerry_port.c"],
-    "zjs_config": ["-DJERRY_PORT_ENABLE_JOBQUEUE"],
     "jrs_config": [
         "CONFIG_DISABLE_ES2015_PROMISE_BUILTIN",
         "CONFIG_DISABLE_ES2015_BUILTIN",

--- a/tools/Makefile.snapshot
+++ b/tools/Makefile.snapshot
@@ -32,7 +32,7 @@ CORE_SRC +=		tools/snapshot.c \
 CORE_OBJ =		$(CORE_SRC:%.c=%.o)
 
 SNAPSHOT_INCLUDES += 	-Isrc/ \
-			-I$(JERRY_BASE)/jerry-core
+			-I$(JERRY_BASE)/jerry-core/include
 
 JERRY_LIBS += 		-l jerry-core -lm
 


### PR DESCRIPTION
Update JerryScript and use the new Promise jobqueue implementation
as it is now built-in to JerryScript, thus no longer need to
provide our own job queue, which hopefully fix some of the bugs.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>