### PR TITLE
[promise] Added promise API

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -26,6 +26,7 @@ CORE_SRC +=	src/zjs_a101_pins.c \
 		src/main.c \
 		src/zjs_modules.c \
 		src/zjs_performance.c \
+		src/zjs_promise.c \
 		src/zjs_script.c \
 		src/zjs_timers.c \
 		src/zjs_test_promise.c \

--- a/src/zjs_ocf_common.h
+++ b/src/zjs_ocf_common.h
@@ -38,9 +38,14 @@ struct props_handle {
     char name[name##_size];                \
     zjs_copy_jstring(jval, name, &name##_size);
 
-#define REJECT(err_name, err_msg)                           \
+#define RESOLVE(arg)                                     \
+    jerry_value_t promise = jerry_create_promise();      \
+    jerry_resolve_or_reject_promise(promise, arg, true); \
+    return promise;
+
+#define REJECT(err_name, err_msg, arg)                      \
     jerry_value_t promise = jerry_create_promise();         \
-    ZVAL error = make_ocf_error(err_name, err_msg, NULL);   \
+    ZVAL error = make_ocf_error(err_name, err_msg, arg);    \
     jerry_resolve_or_reject_promise(promise, error, false); \
     return promise;
 

--- a/src/zjs_promise.c
+++ b/src/zjs_promise.c
@@ -1,0 +1,104 @@
+// Copyright (c) 2016-2017, Intel Corporation.
+
+// C includes
+#include <string.h>
+
+#ifndef ZJS_LINUX_BUILD
+// Zephyr includes
+#include <zephyr.h>
+#endif
+
+// ZJS includes
+#include "zjs_promise.h"
+#include "zjs_util.h"
+
+// JerryScript includes
+#include "jerryscript.h"
+
+static zjs_promise_t *zjs_promises = NULL;
+
+zjs_promise_t *zjs_create_promise(const jerry_value_t argv[], u32_t argc)
+{
+    zjs_promise_t *p = zjs_malloc(sizeof(zjs_promise_t));
+
+    if (!p) {
+        ERR_PRINT("out of memory allocating promise struct\n");
+        return NULL;
+    }
+    memset(p, 0, sizeof(zjs_promise_t));
+
+    p->argc = argc;
+    p->promise_obj = jerry_create_promise();
+
+    if (p->argc > 0) {
+        p->argv = zjs_malloc(sizeof(jerry_value_t) * argc);
+
+        if (!p->argv) {
+            jerry_release_value(p->promise_obj);
+            zjs_free(p);
+            ERR_PRINT("out of memory allocating promise args\n");
+            return NULL;
+        }
+        for (int i = 0; i < argc; ++i) {
+            p->argv[i] = jerry_acquire_value(argv[i]);
+        }
+    } else {
+        p->argv = NULL;
+    }
+
+    ZJS_LIST_APPEND(zjs_promise_t, zjs_promises, p);
+    DBG_PRINT("added promise, p=%p, argv=%p, argc=%u\n",
+              p, argv, argc);
+    return p;
+}
+
+static bool delete_promise(zjs_promise_t *p)
+{
+    if (p) {
+        DBG_PRINT("deleted promise, p=%p, argv=%p, argc=%u\n",
+                   p, p->argv, p->argc);
+        for (int i = 0; i < p->argc; ++i) {
+            jerry_release_value(p->argv[i]);
+        }
+        jerry_release_value(p->promise_obj);
+        ZJS_LIST_REMOVE(zjs_promise_t, zjs_promises, p);
+        zjs_free(p->argv);
+        zjs_free(p);
+        return true;
+    }
+    return false;
+}
+
+void zjs_resolve_promise(zjs_promise_t *p, jerry_value_t arg)
+{
+    DBG_PRINT("resolve promise %p\n", p);
+    jerry_resolve_or_reject_promise(p->promise_obj, arg, true);
+    delete_promise(p);
+}
+
+void zjs_reject_promise(zjs_promise_t *p, jerry_value_t error)
+{
+    DBG_PRINT("reject promise %p\n", p);
+    jerry_resolve_or_reject_promise(p->promise_obj, error, false);
+    delete_promise(p);
+}
+
+jerry_value_t zjs_promise_init()
+{
+    return ZJS_UNDEFINED;
+}
+
+static void free_promise(zjs_promise_t *p)
+{
+    for (int i = 0; i < p->argc; ++i) {
+        jerry_release_value(p->argv[i]);
+    }
+    jerry_release_value(p->promise_obj);
+    zjs_free(p->argv);
+    zjs_free(p);
+}
+
+void zjs_promise_cleanup()
+{
+    ZJS_LIST_FREE(zjs_promise_t, zjs_promises, free_promise);
+}

--- a/src/zjs_promise.h
+++ b/src/zjs_promise.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2017, Intel Corporation.
+
+#ifndef __zjs_promise_h__
+#define __zjs_promise_h__
+
+#include "jerryscript.h"
+
+// ZJS includes
+#include "zjs_common.h"
+
+typedef struct zjs_promise {
+    jerry_value_t promise_obj;
+    jerry_value_t *argv;
+    u32_t argc;
+    struct zjs_promise *next;
+} zjs_promise_t;
+
+/*
+* Creates a Promise and add references to the arguments
+*
+* @param argv          Arguments of the Promise being called
+* @param argc          Number of arguments
+*
+* @return              Pointer to the struct associated with the Promise
+*                        use this to resolve or reject the Promise
+*/
+zjs_promise_t *zjs_create_promise(const jerry_value_t argv[], u32_t argc);
+
+/*
+* Resolve a Promise
+*
+* @param p             Pointer to the struct associated with the Promise
+* @param arg           Argument passed to the resolve function
+* @param release       Promise will be released if it is set to true
+*/
+void zjs_resolve_promise(zjs_promise_t *p, jerry_value_t arg);
+
+/*
+* Rejects a Promise
+*
+* @param p             Pointer to the struct associated with the Promise
+* @param error         Error passed to the reject function
+* @param release       Promise will be released if it is set to true
+*/
+void zjs_reject_promise(zjs_promise_t *p, jerry_value_t error);
+
+/** Initialize the promise module, or reinitialize after cleanup */
+jerry_value_t zjs_promise_init();
+
+/** Release resources held by the promise module */
+void zjs_promise_cleanup();
+
+#endif

--- a/src/zjs_promise.json
+++ b/src/zjs_promise.json
@@ -1,12 +1,20 @@
 {
     "module": "promise",
     "constructor": "Promise",
-    "zjs_config": ["-DBUILD_MODULE_PROMISE"],
-    "src": ["jerry-port/zjs_jerry_port.c"],
-    "zjs_config": ["-DJERRY_PORT_ENABLE_JOBQUEUE"],
+    "zjs_config": [
+        "-DBUILD_MODULE_PROMISE",
+        "-DJERRY_PORT_ENABLE_JOBQUEUE"
+    ],
     "jrs_config": [
         "CONFIG_DISABLE_ES2015_PROMISE_BUILTIN",
         "CONFIG_DISABLE_ES2015_BUILTIN",
         "CONFIG_DISABLE_ES2015_TYPEDARRAY_BUILTIN"
-    ]
+    ],
+    "src":[
+        "jerry-port/zjs_jerry_port.c",
+        "zjs_promise.c"
+    ],
+    "header": ["zjs_promise.h"],
+    "init": ["zjs_promise_init"],
+    "cleanup": ["zjs_promise_cleanup"]
 }


### PR DESCRIPTION
Added new zjs_promise module that helps make the promise
API to help fix an issue that the promise API do not
acquire the arguments passed in, this fixes an issue
where the argunent passed in the promise could be GCed
before it's resolved or rejected.

To create a promise, simply call zjs_create_promise and
pass in the argv and argc of the current JS func,
the API simply add references to the argv list and returns
a struct that contains the promise obj as well as the
args, and then automatically release them when you
call zjs_resolve_promise() or zjs_reject_promise();

Fixes #1407

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>