### PR TITLE
[ocf] Improved OCF stability over 6lowpan

### DIFF
--- a/src/zjs_ocf.json
+++ b/src/zjs_ocf.json
@@ -25,9 +25,10 @@
             "CONFIG_INIT_STACKS=y",
             "CONFIG_NET_BUF=y",
             "CONFIG_NET_PKT_RX_COUNT=5",
-            "CONFIG_NET_PKT_TX_COUNT=2",
+            "CONFIG_NET_PKT_TX_COUNT=5",
             "CONFIG_NET_BUF_RX_COUNT=10",
-            "CONFIG_NET_BUF_TX_COUNT=6",
+            "CONFIG_NET_BUF_TX_COUNT=10",
+            "CONFIG_NET_BUF_DATA_SIZE=256",
             "CONFIG_NET_IF_UNICAST_IPV6_ADDR_COUNT=1",
             "CONFIG_NET_IF_MCAST_IPV6_ADDR_COUNT=1",
             "CONFIG_NET_MAX_CONTEXTS=3"


### PR DESCRIPTION
The OCF was not able to send packets over BLE 6lowpan
consistently and segfaulting, this patch increase
the data size to help improve stability.

Fixes #1255, #1408, #1415

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>