### PR TITLE
[general] Increase call stack size to improve BLE stability

### DIFF
--- a/src/zjs_arduino_101.json
+++ b/src/zjs_arduino_101.json
@@ -3,7 +3,7 @@
     "targets": ["arduino_101"],
     "zephyr_conf": {
         "arduino_101": [
-            "CONFIG_MAIN_STACK_SIZE=2048"
+            "CONFIG_MAIN_STACK_SIZE=4096"
         ]
     }
 }

--- a/src/zjs_ble.json
+++ b/src/zjs_ble.json
@@ -5,7 +5,6 @@
     "zephyr_conf": {
         "all": [
             "CONFIG_BLUETOOTH=y",
-            "CONFIG_BLUETOOTH_STACK_NBLE=y",
             "CONFIG_NBLE=y",
             "CONFIG_BLUETOOTH_SMP=y",
             "CONFIG_BLUETOOTH_PERIPHERAL=y",


### PR DESCRIPTION
The callstack of 2k is causing segfault in BLE
when it starts physical web advertisting, increasing
it to 4k fixes the segfault.

Fixes #1421

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>