### PR TITLE
[event] Add event-name length comparison for fix #1432

### DIFF
--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -61,7 +61,8 @@ static const jerry_object_native_info_t emitter_type_info = {
 
 static int compare_name(event_t *event, const char *name)
 {
-    return strncmp(event->name, name, event->namelen);
+    int len = (event->namelen > strlen(name)) ? event->namelen : strlen(name);
+    return strncmp(event->name, name, len);
 }
 
 jerry_value_t zjs_add_event_listener(jerry_value_t obj, const char *event_name,


### PR DESCRIPTION
Fixed #1432 

Test Code: [/samples/tests/Events.js](https://github.com/01org/zephyr.js/blob/master/samples/tests/Events.js)

Log:
```
EventName[0]: test_event
EventName[1]: test_event1
testListenerNames.length = 2
testListenerCount.length = 2
test_event: handler 1: arg1=1234 arg2=4567
test_event: handler 2: arg1=1234 arg2=4567
test_event1: arg1=1000 arg2=1111
test_event: handler 2: arg1=1234 arg2=4567
Listeners for test_event = 1
Listeners for test_event after removeAllListeners = 0
Event test passed
```

Rename to `test_eve`:
Log:
```
EventName[0]: test_event
EventName[1]: test_eve
testListenerNames.length = 2
testListenerCount.length = 2
test_event: handler 1: arg1=1234 arg2=4567
test_event: handler 2: arg1=1234 arg2=4567
test_eve: arg1=1000 arg2=1111
test_event: handler 2: arg1=1234 arg2=4567
Listeners for test_event = 1
Listeners for test_event after removeAllListeners = 0
Event test passed
```






Signed-off-by: Cui Yan <yanx.cui@intel.com>