### PR TITLE
[events] Stop matching on event prefix

### DIFF
--- a/src/zjs_event.c
+++ b/src/zjs_event.c
@@ -61,7 +61,7 @@ static const jerry_object_native_info_t emitter_type_info = {
 
 static int compare_name(event_t *event, const char *name)
 {
-    return strncmp(event->name, name, event->namelen);
+    return strncmp(event->name, name, event->namelen + 1);
 }
 
 jerry_value_t zjs_add_event_listener(jerry_value_t obj, const char *event_name,


### PR DESCRIPTION
This compares the null terminator of the event name string so that it
will no longer match prefix but only exact string match.

Thanks to Cui Yan for finding the bug and another proposed solution.

Fixes #1432

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>