### PR TITLE
[buffer] Fixed bug in .toString() where a NULL terminator was ignored

### DIFF
--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -231,8 +231,14 @@ static ZJS_DECL_FUNC(zjs_buffer_to_string)
             // strip off high bit if present
             str[i] = buf->buffer[i] & 0x7f;
         }
+        /*
+         * If there is a NULL terminator before the end of the buffer we only
+         * want to create a string of that length, not including the extra
+         * bytes. And if there is no NULL terminator, we want to limit the size
+         * to the stored buffer size.
+         */
         jerry_value_t jstr = jerry_create_string_sz((jerry_char_t *)str,
-                                                    buf->bufsize);
+                strnlen((char *)buf->buffer, buf->bufsize));
         zjs_free(str);
         return jstr;
     } else if (!strcmp(encoding, "hex")) {

--- a/tests/test-fs.js
+++ b/tests/test-fs.js
@@ -212,6 +212,8 @@ fs.writeSync(fd1, new Buffer('over'));
 rbuf = new Buffer(8);
 rlen = fs.readSync(fd1, rbuf, 0, 8, 0);
 assert(rlen == 4, "length correct: " + rlen);
+// null terminate at index 4
+rbuf.writeUInt8(0x00, 4);
 assert(rbuf.toString('ascii') == 'over',
     "file was overwritten with 'w': " + rbuf.toString('ascii'));
 fs.closeSync(fd1);


### PR DESCRIPTION
Fixes #1439

Signed-off-by: James Prestwood <james.prestwood@intel.com>