### PR TITLE
[net-config] Update docs to require setting IP address

### DIFF
--- a/docs/net-config.md
+++ b/docs/net-config.md
@@ -12,6 +12,10 @@ ZJS provides network configuration API's allowing the application to set the
 IP address, start DHCP, configure the Bluetooth MAC address, and be notified
 when the network interface has come up or gone down.
 
+If you include the net-config module, you *must* either set a static IP address
+or use DHCP. If you don't include the net-config module, you will get default
+static IP addresses of 192.0.2.1 and 2001:db8::1.
+
 Web IDL
 -------
 This IDL provides an overview of the interface; see below for documentation of

--- a/samples/TCPClient6.js
+++ b/samples/TCPClient6.js
@@ -19,6 +19,8 @@
 var net = require('net');
 var net_cfg = require('net-config');
 
+net_cfg.setStaticIP('2001:db8::1');
+
 net_cfg.on('netup', function() {
 	console.log("network up");
 	setTimeout(function() {

--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -300,9 +300,7 @@ static ZJS_DECL_FUNC(set_ip)
     struct sockaddr_in6 tmp = { 0 };
 
     // check if v6
-    if(net_addr_pton(AF_INET6,
-            str,
-            &tmp.sin6_addr) < 0) {
+    if (net_addr_pton(AF_INET6, str, &tmp.sin6_addr) < 0) {
         // check if v4
         struct sockaddr_in tmp1 = { 0 };
         if(net_addr_pton(AF_INET,
@@ -334,8 +332,8 @@ static ZJS_DECL_FUNC(set_ip)
 }
 
 static jerry_value_t config;
-
 static struct net_mgmt_event_callback cb;
+
 static void iface_event(struct net_mgmt_event_callback *cb,
         u32_t mgmt_event, struct net_if *iface)
 {

--- a/tests/test-tcp6-client.js
+++ b/tests/test-tcp6-client.js
@@ -2,7 +2,7 @@
 
 // Run this test case and run simple TCP server on linux
 //     TCP server: /tests/tools/test-tcp6-server.py
-// If on a101 using Bluetooth communication, please connect server with Bluetooth:
+// If on A101 using Bluetooth communication, connect server with Bluetooth:
 //     Add soft router on linux:
 //         ip -6 route add 2001:db8::/64 dev bt0
 //     Add IPv6 address on linux:
@@ -20,12 +20,15 @@ var board = require("board");
 var assert = require("Assert.js");
 var net_cfg = require("net-config");
 
+var my_addr = '2001:db8::1';
+net_cfg.setStaticIP(my_addr);
+
 var IPv6Address = "2001:db8::2";
 var IPv6Port = 9876;
 var addressOptions = {
     port: IPv6Port,
     host: IPv6Address,
-    localAddress: "2001:db8::1",
+    localAddress: my_addr,
     localPort: 8484,
     family: 6
 }

--- a/tests/tools/test-tcp6-server.py
+++ b/tests/tools/test-tcp6-server.py
@@ -6,10 +6,10 @@ import socket
 import SocketServer
 
 def main():
-    print "Socket server creat successful"
-
     host = "2001:db8::2"
     port = 9876
+    print "Creating socket server on " + host + " port " + str(port) + "..."
+
     addr = (host, port)
     Timeout = 80
     bufSize = 1024


### PR DESCRIPTION
If the net-config module is included, the user needs to either set a
static IP address or use DHCP; no default address will be set. We could
potentially change this, but this requirement makes for better example
code because it's more realistic.

Added setStaticIP call to a sample and a test that needed it.

Fixes #1413

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>