### PR TITLE
[spi] Fix incorrect spi speed bus set

### DIFF
--- a/docs/spi.md
+++ b/docs/spi.md
@@ -48,7 +48,7 @@ interface SPI {
 
 dictionary SPIOptions {
     octet bus;
-    long speed;
+    long speed;  // bus clock frequency in Hz
     bool msbFirst;
     long polarity;
     long phase;

--- a/samples/SPI.js
+++ b/samples/SPI.js
@@ -10,10 +10,12 @@ try {
     var busNum = board.name === "arduino_101" ? 1 : 0;
     // The deviceNumber is the slave device we want to send data to
     var deviceNum = 1;
+    // The busSpeed is the clock speed in Hz
+    var busSpeed = 2000000;
 
     console.log("BOARD NAME = " + board.name + " Device Number = " + deviceNum);
 
-    var spiBus = spi.open({speed:20000, bus:busNum, polarity:0, phase:0, bits:16});
+    var spiBus = spi.open({speed:busSpeed, bus:busNum, polarity:0, phase:0, bits:16});
     var buffer = spiBus.transceive(deviceNum, "Hello World\0");
     console.log("From SPI device " + deviceNum + ": " + buffer.toString('hex'));
 
@@ -34,7 +36,7 @@ try {
     buffer = spiBus.transceive(deviceNum, [1, 2, 3, 4]);
 
     // Open again
-    spiBus = spi.open({speed:20000, bus:busNum, polarity:0, phase:0, bits:8});
+    spiBus = spi.open({speed:busSpeed, bus:busNum, polarity:0, phase:0, bits:8});
     buffer = spiBus.transceive(deviceNum, [1, 2, 3, 4]);
     console.log("From SPI device " + deviceNum + ": " + buffer.toString('hex'));
 } catch (err) {

--- a/src/zjs_spi.json
+++ b/src/zjs_spi.json
@@ -4,19 +4,11 @@
     "depends": ["buffer"],
     "zephyr_conf": {
         "all": [
-            "CONFIG_SPI=y",
-            "CONFIG_SPI_0=y",
-            "CONFIG_SPI_0_NAME=\"SPI_0\"",
-            "CONFIG_SPI_0_IRQ_PRI=2",
-            "CONFIG_SPI_0_DEFAULT_CFG=0x80",
-            "SPI_0_DEFAULT_BAUD_RATE=500000",
-            "CONFIG_SPI_1=y",
-            "CONFIG_SPI_1_NAME=\"SPI_1\"",
-            "CONFIG_SPI_1_IRQ_PRI=2",
-            "CONFIG_SPI_1_DEFAULT_CFG=0x80",
-            "SPI_1_DEFAULT_BAUD_RATE=500000"
+            "CONFIG_SPI=y"
         ],
-        "frdm_k64f": ["CONFIG_SPI_MCUX_DSPI=y"]
+        "frdm_k64f": [
+            "CONFIG_SPI_MCUX_DSPI=y"
+        ]
     },
     "zjs_config": ["-DBUILD_MODULE_SPI"],
     "src": ["zjs_spi.c"],

--- a/tests/test-spi.js
+++ b/tests/test-spi.js
@@ -9,7 +9,7 @@ var board = require('board');
 
 var spiBus, spiBuffer, bufferData, busNum;
 var deviceNum = 1;
-var busSpeed = 20000;
+var busSpeed = 2000000;  // in Hz
 busNum = board.name === "arduino_101" ? 1 : 0;
 
 assert.throws(function() {


### PR DESCRIPTION
The SPI interface in Zephyr seems to accept a different
input for the max_sys_freq when configuring the bus, on
the Arduino 101, it is expecting it to be the clock divider
and on the FRDM-K64F, it is expecting it to be the baud rate.

Also removes configs that are not needed as it is automatically
set by Zephyr when you turn on SPI.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>