### PR TITLE
[sensor] Fixed polling frequency not updated

### DIFF
--- a/arc/src/arc_sensor.c
+++ b/arc/src/arc_sensor.c
@@ -20,6 +20,8 @@
 #define BMI160_NAME BMI160_DEVICE_NAME
 #endif
 
+u32_t sensor_poll_freq = 20;        // default polling frequency
+
 #ifdef BUILD_MODULE_SENSOR_LIGHT
 static atomic_t pin_values[ARC_AIO_LEN] = {};
 static atomic_t pin_last_values[ARC_AIO_LEN] = {};

--- a/arc/src/arc_sensor.h
+++ b/arc/src/arc_sensor.h
@@ -3,7 +3,7 @@
 #ifndef __arc_sensor_h__
 #define __arc_sensor_h__
 
-static u32_t sensor_poll_freq = 20;  // default poll frequency
+extern u32_t sensor_poll_freq;
 
 void arc_handle_sensor(struct zjs_ipm_message *msg);
 


### PR DESCRIPTION
The poll frequency was declared as a static variable and
couldn't be set from a different src file, making it extern
so it could be set.

Fixes #1451

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>