### PR TITLE
[fs] Fixed invalid FSstat object when file is deleted

### DIFF
--- a/arc/src/arc_sensor.c
+++ b/arc/src/arc_sensor.c
@@ -613,7 +613,7 @@ void arc_fetch_light()
 
 void arc_fetch_sensor()
 {
-    // ToDo: currently only supports BMI160 temperature
+    // TODO: currently only supports BMI160 temperature
     // add support for other types of sensors
     if (bmi160 && (
 #ifndef CONFIG_BMI160_TRIGGER

--- a/docs/fs.md
+++ b/docs/fs.md
@@ -159,7 +159,7 @@ Get stats about a file or directory.
 
 `path` name of file or directory.
 
-Returns a `Stat` object for that file or directory.
+Returns a `Stat` object for that file or directory or undefined if file or directory does not exist.
 
 ### FS.writeFileSync
 `void writeFileSync(string file, [string|buffer] data);`

--- a/samples/FsAsync.js
+++ b/samples/FsAsync.js
@@ -7,9 +7,9 @@ console.log('File System sample');
 fs.open('testfile.txt', 'w+', function(err, fd) {
     console.log('opened file error=' + err);
     fs.stat('testfile.txt', function(err, stats) {
-        if (stats.isFile()) {
+        if (stats && stats.isFile()) {
             console.log('fd is file');
-        } else if (stats.isDirectory()) {
+        } else if (stats && stats.isDirectory()) {
             console.log('fd is directory');
         } else {
             console.log('fd has unknown type');

--- a/samples/FsSync.js
+++ b/samples/FsSync.js
@@ -8,9 +8,9 @@ var fd = fs.openSync('testfile.txt', 'w+');
 
 var stats = fs.statSync('testfile.txt');
 
-if (stats.isFile()) {
+if (stats && stats.isFile()) {
     console.log('fd is file');
-} else if (stats.isDirectory()) {
+} else if (stats && stats.isDirectory()) {
     console.log('fd is directory');
 } else {
     console.log('fd has unknown type');

--- a/src/zjs_fs.c
+++ b/src/zjs_fs.c
@@ -327,7 +327,7 @@ static ZJS_DECL_FUNC_ARGS(zjs_fs_unlink, u8_t async)
 
     ret = fs_unlink(path);
     if (ret != 0) {
-        ERR_PRINT("failed to unlink %s with error [%d]\n", path, ret);
+        DBG_PRINT("failed to unlink %s with error [%d]\n", path, ret);
         return ZJS_UNDEFINED;
     }
 
@@ -788,7 +788,7 @@ static ZJS_DECL_FUNC_ARGS(zjs_fs_stat, u8_t async)
 
     ret = fs_stat(path, &entry);
     if (ret != 0) {
-        // ToDo: Decide what to do with FStat if the file doesn't exists,
+        // TODO: Decide what to do with FStat if the file doesn't exists,
         // the current work-around is to return undefined value.
         return ZJS_UNDEFINED;
     }

--- a/tests/test-fs.js
+++ b/tests/test-fs.js
@@ -5,7 +5,7 @@ var assert = require("Assert.js");
 
 // Clean up any test files left from previous tests
 var stats = fs.statSync('testfile.txt');
-if (stats.isFile() || stats.isDirectory()) {
+if (stats && (stats.isFile() || stats.isDirectory())) {
     fs.unlinkSync('testfile.txt');
     console.log('removing testfile.txt');
 }
@@ -15,7 +15,7 @@ var fd = fs.openSync('testfile.txt', 'a');
 fs.closeSync(fd);
 var fd_stats = fs.statSync('testfile.txt');
 var success = false;
-if (fd_stats.isFile()) {
+if (fd_stats && fd_stats.isFile()) {
 	success = true;
 }
 assert(success, "create file");
@@ -24,7 +24,7 @@ assert(success, "create file");
 fs.unlinkSync('testfile.txt');
 fd_stats = fs.statSync('testfile.txt');
 success = false;
-if (!fd_stats.isFile()) {
+if (!fd_stats || !fd_stats.isFile()) {
 	success = true;
 }
 assert(success, "remove file");


### PR DESCRIPTION
We are not currently checking if the file exists when
calling FS.statSync() to create the Stats object, in which
case if the file doesn't exists, we should return a undefined
value, and the unit tests should also check if the value
is undefined.  Added a ToDo to properly fix this with adding
a FS.exist() api that can be used to check if the file exists,
and then return a valid FSStat object when the file is invalid
according the NodeJS spec.

Fixes #1205

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>