### PR TITLE
[build] Fix the make gdb command to use updated path to gdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,7 +451,7 @@ debug:
 # Run gdb to connect to debug server for x86
 .PHONY: gdb
 gdb:
-	$$ZEPHYR_SDK_INSTALL_DIR/sysroots/i686-pokysdk-linux/usr/bin/iamcu-poky-elfiamcu/i586-poky-elfiamcu-gdb outdir/arduino_101/zephyr.elf -ex "target remote :3333"
+	$$ZEPHYR_SDK_INSTALL_DIR/sysroots/x86_64-pokysdk-linux/usr/bin/i586-zephyr-elfiamcu/i586-zephyr-elfiamcu-gdb outdir/arduino_101/zephyr.elf -ex "target remote :3333"
 
 # Run gdb to connect to debug server for ARC
 .PHONY: arcgdb


### PR DESCRIPTION
Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>