### PR TITLE
[ashell] Added command to erase flash file system

### DIFF
--- a/docs/ashell.md
+++ b/docs/ashell.md
@@ -86,7 +86,7 @@ Command list:
     rm     FILE    Remove file or directory
     mv     F1 F2   Move a file F1 to destination F2
     clear          Clear the terminal screen
-    erase          Erase flash file system
+    erase          Erase flash file system and reboot
     boot   FILE    Set the file that should run at boot
     reboot         Reboot the device
 ```
@@ -190,8 +190,8 @@ Clears the terminal screen.
 
 Erase flash file system.
 
-Note: this only works on the Arduino 101 and it will require rebooting the
-device to take affect.
+Note: this only works on the Arduino 101 and it will automatically rebooting the
+board after erase is finished.
 
 ### boot
 

--- a/docs/ashell.md
+++ b/docs/ashell.md
@@ -86,6 +86,7 @@ Command list:
     rm     FILE    Remove file or directory
     mv     F1 F2   Move a file F1 to destination F2
     clear          Clear the terminal screen
+    erase          Erase flash file system
     boot   FILE    Set the file that should run at boot
     reboot         Reboot the device
 ```
@@ -182,6 +183,15 @@ Renames filename1 to filename2.
 `clear`
 
 Clears the terminal screen.
+
+### erase
+
+`erase`
+
+Erase flash file system.
+
+Note: this only works on the Arduino 101 and it will require rebooting the
+device to take affect.
 
 ### boot
 

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -558,7 +558,7 @@ s32_t ashell_clear(char *buf)
 }
 
 #ifdef CONFIG_BOARD_ARDUINO_101
-s32_t ashell_erase_flash()
+s32_t ashell_erase_flash(char *buf)
 {
     struct device *flash_dev;
     flash_dev = device_get_binding(CONFIG_SPI_FLASH_W25QXXDV_DRV_NAME);
@@ -575,7 +575,8 @@ s32_t ashell_erase_flash()
     }
     flash_write_protection_set(flash_dev, true);
 
-    comms_print("Flash erase succeeded\n\r\n");
+    comms_print("Flash erase succeeded, rebooting...\n\r\n");
+    ashell_reboot(NULL);
     return RET_OK;
 }
 #endif
@@ -657,7 +658,8 @@ static const struct ashell_cmd commands[] = {
     {"mv",    "F1 F2",  "Move file F1 to destination F2", ashell_rename},
     {"clear", "",       "Clear the terminal screen", ashell_clear},
 #ifdef CONFIG_BOARD_ARDUINO_101
-    {"erase", "",       "Erase flash file system", ashell_erase_flash},
+    {"erase", "",       "Erase flash file system and reboot",
+                          ashell_erase_flash},
 #endif
     {"boot",  "FILE",   "Set the file that should run at boot",
                           ashell_set_bootcfg},

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -18,6 +18,9 @@
 #include <misc/printk.h>
 #include <misc/reboot.h>
 #include <zephyr/types.h>
+#ifdef CONFIG_BOARD_ARDUINO_101
+#include <flash.h>
+#endif
 
 // ZJS includes
 #include "comms-shell.h"
@@ -554,6 +557,29 @@ s32_t ashell_clear(char *buf)
     return RET_OK;
 }
 
+#ifdef CONFIG_BOARD_ARDUINO_101
+s32_t ashell_erase_flash()
+{
+    struct device *flash_dev;
+    flash_dev = device_get_binding(CONFIG_SPI_FLASH_W25QXXDV_DRV_NAME);
+
+    if (!flash_dev) {
+        comms_print("SPI flash driver was not found!\n\r\n");
+        return RET_ERROR;
+    }
+
+    flash_write_protection_set(flash_dev, false);
+    if (flash_erase(flash_dev, 0, CONFIG_SPI_FLASH_W25QXXDV_FLASH_SIZE) != 0) {
+        comms_print("Flash erase failed\n\r\n");
+        return RET_ERROR;
+    }
+    flash_write_protection_set(flash_dev, true);
+
+    comms_print("Flash erase succeeded\n\r\n");
+    return RET_OK;
+}
+#endif
+
 s32_t ashell_stop_javascript(char *buf)
 {
     javascript_stop();
@@ -630,6 +656,9 @@ static const struct ashell_cmd commands[] = {
     {"rm",    "FILE",   "Remove file or directory", ashell_remove_file},
     {"mv",    "F1 F2",  "Move file F1 to destination F2", ashell_rename},
     {"clear", "",       "Clear the terminal screen", ashell_clear},
+#ifdef CONFIG_BOARD_ARDUINO_101
+    {"erase", "",       "Erase flash file system", ashell_erase_flash},
+#endif
     {"boot",  "FILE",   "Set the file that should run at boot",
                           ashell_set_bootcfg},
     {"reboot", "",      "Reboot the device", ashell_reboot},


### PR DESCRIPTION
Added ability to erase the flash in Ashell/IDE, this
will help fix corrupted files created on the file system.

Fixes #1193

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>