### PR TITLE
[ble] Fixed not able to set BLE address

### DIFF
--- a/docs/net-config.md
+++ b/docs/net-config.md
@@ -81,7 +81,7 @@ The `address` parameter should be a MAC address string in the format
 `XX:XX:XX:XX:XX:XX` where each character is in HEX format (0-9, A-F).
 
 Note: This function has be called when the JS is initially run when
-loaded, this means no calling from within any callback functions like
-setTimeout(), setInterval() and promise.  Also, If the image was built
+loaded. This means no calling from within any callback functions like
+setTimeout(), setInterval() and promises.  Also, If the image was built
 with the `BLE_ADDR` flag, this API has no effect. Using the `BLE_ADDR`
 hard codes the supplied address into the image which cannot be changed.

--- a/docs/net-config.md
+++ b/docs/net-config.md
@@ -80,6 +80,8 @@ Zephyr boards with BLE capabilities (e.g. Arduino 101).
 The `address` parameter should be a MAC address string in the format
 `XX:XX:XX:XX:XX:XX` where each character is in HEX format (0-9, A-F).
 
-Note: If the image was built with the `BLE_ADDR` flag, this API has
-no effect. Using the `BLE_ADDR` hard codes the supplied address into
-the image which cannot be changed.
+Note: This function has be called when the JS is initially run when
+loaded, this means no calling from within any callback functions like
+setTimeout(), setInterval() and promise.  Also, If the image was built
+with the `BLE_ADDR` flag, this API has no effect. Using the `BLE_ADDR`
+hard codes the supplied address into the image which cannot be changed.

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -92,7 +92,6 @@ static struct bt_uuid *gatt_cud_uuid = BT_UUID_DECLARE_16(BT_UUID_GATT_CUD_VAL);
 static struct bt_uuid *gatt_ccc_uuid = BT_UUID_DECLARE_16(BT_UUID_GATT_CCC_VAL);
 
 static struct k_sem ble_sem;
-static bool bt_enabled = false;
 
 static ble_handle_t *ble_handle = NULL;
 
@@ -580,22 +579,11 @@ static struct bt_conn_auth_cb zjs_ble_auth_cb_display = {
     .cancel = zjs_ble_auth_cancel,
 };
 
-// INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or release prints!
-static void zjs_ble_bt_ready(int err)
+void zjs_ble_emit_powered_event()
 {
-    DBG_PRINT("bt_ready() is called [err %d]\n", err);
     const char state[] = "poweredOn";
     zjs_defer_emit_event(ble_handle->ble_obj, "stateChange", state,
                          sizeof(state), string_arg, zjs_release_args);
-}
-
-void zjs_ble_enable()
-{
-    DBG_PRINT("Enabling the bluetooth, wait for bt_ready()...\n");
-    bt_enable(zjs_ble_bt_ready);
-    // setup connection callbacks
-    bt_conn_cb_register(&zjs_ble_conn_callbacks);
-    bt_conn_auth_cb_register(&zjs_ble_auth_cb_display);
 }
 
 static ZJS_DECL_FUNC(zjs_ble_disconnect)
@@ -1324,10 +1312,9 @@ jerry_value_t zjs_ble_init()
 
     handle->ble_obj = jerry_acquire_value(ble_obj);
 
-    if (!bt_enabled) {
-        zjs_ble_enable();
-        bt_enabled = true;
-    }
+    // setup connection callbacks
+    bt_conn_cb_register(&zjs_ble_conn_callbacks);
+    bt_conn_auth_cb_register(&zjs_ble_auth_cb_display);
 
     ble_handle = handle;
     return ble_obj;

--- a/src/zjs_ble.h
+++ b/src/zjs_ble.h
@@ -15,6 +15,6 @@ jerry_value_t zjs_ble_init();
 /** Release resources held by the ble module */
 void zjs_ble_cleanup();
 
-void zjs_ble_enable();
+void zjs_ble_emit_powered_event();
 
 #endif  // __zjs_ble_h__

--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -161,9 +161,9 @@ static void ble_set_address(char *ble_addr)
         return;
     }
 
-    // set the top two bits since Zephyr always sets them anyway, for exaxmple,
-    //   if you try to set 00:F9:50:21:43:4A, Zephyr is only set it to
-    //   F1:F9:50:21:43:4A, so we will print the actual value the user will see
+    // set the top two bits since Zephyr always sets them anyway, so we will
+    //   print the actual value the user will see. For example,
+    //   11:22:33:44:55:66 will change to D1:22:33:44:55:66.
     // TODO: find out why this happens and whether it must; if so, warn the
     //   user at compile-time instead of just here
     char hex[3];

--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -6,7 +6,7 @@
 #include <net/net_context.h>
 #endif
 
-#if defined(CONFIG_NET_L2_BLUETOOTH)
+#ifdef CONFIG_NET_L2_BLUETOOTH
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/storage.h>
 #include <gatt/ipss.h>
@@ -20,8 +20,8 @@
 #ifndef BUILD_MODULE_NET_CONFIG
 static u8_t net_enabled = 0;
 #endif
-#if defined(CONFIG_NET_L2_BLUETOOTH)
-static u8_t ble_enabled = 0;
+#ifdef CONFIG_NET_L2_BLUETOOTH
+u8_t net_ble_enabled = 0;
 #endif
 
 void zjs_net_config_default(void)
@@ -30,16 +30,12 @@ void zjs_net_config_default(void)
      * if net-config was not included, just do the default configuration
      */
 #ifndef BUILD_MODULE_NET_CONFIG
-#if defined(CONFIG_NET_L2_BLUETOOTH)
-    if (!ble_enabled) {
+#ifdef CONFIG_NET_L2_BLUETOOTH
+    if (!net_ble_enabled) {
         zjs_init_ble_address();
-        if (bt_enable(NULL)) {
-            ERR_PRINT("Bluetooth init failed\n");
-            return;
-        }
         ipss_init();
         ipss_advertise();
-        ble_enabled = 1;
+        net_ble_enabled = 1;
     }
 #endif
     if (!net_enabled) {
@@ -152,7 +148,7 @@ static int str2bt_addr_le(const char *str, const char *type, bt_addr_le_t *addr)
     return 0;
 }
 
-void zjs_init_ble_address()
+static void ble_set_address(char *ble_addr)
 {
     static const struct bt_storage storage = {
         .read = zjs_ble_storage_read,
@@ -160,17 +156,18 @@ void zjs_init_ble_address()
         .clear = NULL,
     };
 
-    if (str2bt_addr_le(default_ble, "random", &id_addr) < 0) {
+    if (str2bt_addr_le(ble_addr, "random", &id_addr) < 0) {
         ERR_PRINT("bad BLE address string\n");
         return;
     }
 
-    // set the top two bits since Zephyr always sets them anyway, so we will
-    //   print the actual value the user will see
+    // set the top two bits since Zephyr always sets them anyway, for exaxmple,
+    //   if you try to set 00:F9:50:21:43:4A, Zephyr is only set it to
+    //   F1:F9:50:21:43:4A, so we will print the actual value the user will see
     // TODO: find out why this happens and whether it must; if so, warn the
     //   user at compile-time instead of just here
     char hex[3];
-    hex[0] = default_ble[0];
+    hex[0] = ble_addr[0];
     hex[1] = '0';
     hex[2] = '\0';
     u8_t byte;
@@ -178,13 +175,18 @@ void zjs_init_ble_address()
     u8_t newbyte = byte | 0xC0;
     if (byte != newbyte) {
         ZJS_PRINT("Warning: Requested BLE address %s had to be modified!\n",
-                  default_ble);
+                  ble_addr);
     }
     default_ble[0] = 'C' + (newbyte >> 4) - 12;
 
-    DBG_PRINT("BLE addr is set to: %s\n", default_ble);
+    DBG_PRINT("set BLE address to: %s\n", default_ble);
     BT_ADDR_SET_STATIC(&id_addr.a);
     bt_storage_register(&storage);
+}
+
+void zjs_init_ble_address()
+{
+    ble_set_address(default_ble);
 }
 #endif
 
@@ -267,19 +269,7 @@ static ZJS_DECL_FUNC(set_ble_address)
     jerry_size_t size = 18;
     char addr[size];
     zjs_copy_jstring(argv[0], addr, &size);
-
-    static const struct bt_storage storage = {
-        .read = zjs_ble_storage_read,
-        .write = NULL,
-        .clear = NULL,
-    };
-
-    if (str2bt_addr_le(addr, "random", &id_addr) < 0) {
-        return zjs_error("bad BLE address string");
-    }
-    DBG_PRINT("BLE addr is set to: %s\n", addr);
-    BT_ADDR_SET_STATIC(&id_addr.a);
-    bt_storage_register(&storage);
+    ble_set_address(addr);
 #endif
     return ZJS_UNDEFINED;
 }
@@ -367,15 +357,9 @@ jerry_value_t zjs_net_config_init(void)
             NET_EVENT_IF_UP | NET_EVENT_IF_DOWN);
     net_mgmt_add_event_callback(&cb);
 
-#if defined(CONFIG_NET_L2_BLUETOOTH)
-    if (!ble_enabled) {
+#ifdef CONFIG_NET_L2_BLUETOOTH
+    if (!net_ble_enabled) {
         zjs_init_ble_address();
-        if (bt_enable(NULL)) {
-            return zjs_error_context("could not initialize BLE", 0, 0);
-        }
-        ipss_init();
-        ipss_advertise();
-        ble_enabled = 1;
     }
 #endif
 

--- a/src/zjs_net_config.h
+++ b/src/zjs_net_config.h
@@ -4,6 +4,10 @@
 
 #ifndef ZJS_LINUX_BUILD
 #include <net/net_context.h>
+
+#ifdef CONFIG_NET_L2_BLUETOOTH
+extern u8_t net_ble_enabled;
+#endif
 #endif
 /*
  * Returns the net-config object from require.


### PR DESCRIPTION
The bug is that once bt_enable() is called, it's impossible to set
the BLE address, so we have to move bt_enable() to be called after
all modules and the JS is loaded, this guarantees that any API call to
setBleAddress will be called before bt_enable().

Also update documentation to reflect this change.

Fixes #1400

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>