### PR TITLE
[ocf] Update iotivity-constrained to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ cache:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install make gcc g++ python3-ply ncurses-dev uglifyjs libc6-dev-i386 python3-yaml -qq
+  # Workaround to install linux-libc-dev 4.4.X package. This is needed by iotivity-constrained.
+  - wget http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_4.4.0-93.116_amd64.deb
+  - sudo dpkg -i linux-libc-dev_4.4.0-93.116_amd64.deb
+
 
 install: >
   if [ "$TARGET" != "linux" -a "$(cat $ZEPHYR_SDK_INSTALL_DIR/sdk_version)" != "$ZEPHYR_SDK_VERSION" ]; then

--- a/src/zjs_iotivity_constrained.json
+++ b/src/zjs_iotivity_constrained.json
@@ -24,6 +24,7 @@
          "../deps/iotivity-constrained/api/oc_ri.c",
          "../deps/iotivity-constrained/api/oc_rep.c",
          "../deps/iotivity-constrained/api/oc_uuid.c",
+         "../deps/iotivity-constrained/api/oc_endpoint.c",
          "../deps/iotivity-constrained/api/oc_core_res.c",
          "../deps/iotivity-constrained/api/oc_network_events.c",
          "../deps/iotivity-constrained/port/zephyr/src/ipadapter.c",

--- a/src/zjs_ocf.json
+++ b/src/zjs_ocf.json
@@ -31,7 +31,10 @@
             "CONFIG_NET_BUF_DATA_SIZE=512",
             "CONFIG_NET_IF_UNICAST_IPV6_ADDR_COUNT=1",
             "CONFIG_NET_IF_MCAST_IPV6_ADDR_COUNT=1",
-            "CONFIG_NET_MAX_CONTEXTS=3"
+            "CONFIG_NET_MAX_CONTEXTS=3",
+            "CONFIG_NET_APP_SETTINGS=y",
+            "CONFIG_NET_APP_MY_IPV6_ADDR=\"2001:db8::1\"",
+            "CONFIG_NET_APP_PEER_IPV6_ADDR=\"2001:db8::2\""
         ],
         "arduino_101": [
             "CONFIG_BLUETOOTH_L2CAP_TX_BUF_COUNT=15",

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -42,7 +42,7 @@ struct client_resource {
     char *resource_type;
     jerry_value_t types_array;
     jerry_value_t iface_array;
-    oc_server_handle_t server;
+    oc_endpoint_t *endpoint;
     resource_state state;
     u32_t flags;
     u32_t error_code;
@@ -441,7 +441,7 @@ static oc_discovery_flags_t discovery(const char *di,
                                       const char *uri,
                                       oc_string_array_t types,
                                       oc_interface_mask_t interfaces,
-                                      oc_server_handle_t *server,
+                                      oc_endpoint_t *endpoint,
                                       void *user_handle)
 {
     struct ocf_handler *h = (struct ocf_handler *)user_handle;
@@ -486,7 +486,7 @@ NotFound:
 Found:
             cur->state = RES_STATE_FOUND;
 
-            memcpy(&cur->server, server, sizeof(oc_server_handle_t));
+            cur->endpoint = endpoint;
 
             if (!cur->device_id) {
                 cur->device_id = zjs_malloc(strlen(di) + 1);
@@ -566,6 +566,7 @@ Found:
             return OC_STOP_DISCOVERY;
         }
     }
+    oc_free_server_endpoints(endpoint);
     return OC_CONTINUE_DISCOVERY;
 }
 
@@ -735,7 +736,7 @@ static ZJS_DECL_FUNC(ocf_retrieve)
     }
 
     if (resource->flags & FLAG_OBSERVE) {
-        oc_do_observe(resource->resource_path, &resource->server, NULL,
+        oc_do_observe(resource->resource_path, resource->endpoint, NULL,
                       &observe_callback, LOW_QOS, resource);
     }
 
@@ -747,7 +748,7 @@ static ZJS_DECL_FUNC(ocf_retrieve)
     h->res = resource;
     h->promise_obj = jerry_acquire_value(promise);
 
-    if (!oc_do_get(resource->resource_path, &resource->server, NULL,
+    if (!oc_do_get(resource->resource_path, resource->endpoint, NULL,
                    ocf_get_handler, LOW_QOS, h)) {
 
         ZVAL err = make_ocf_error("NetworkError", "GET call failed", resource);
@@ -807,7 +808,7 @@ static ZJS_DECL_FUNC(ocf_update)
     h->res = resource;
     h->promise_obj = jerry_acquire_value(promise);
 
-    if (oc_init_put(resource->resource_path, &resource->server, NULL,
+    if (oc_init_put(resource->resource_path, resource->endpoint, NULL,
                     put_finished, LOW_QOS, h)) {
         ZVAL props = zjs_get_property(argv[0], "properties");
         void *ret;
@@ -947,7 +948,7 @@ static ZJS_DECL_FUNC(ocf_get_platform_info)
 
     DBG_PRINT("sending GET to /oic/p\n");
 
-    if (!oc_do_get("/oic/p", &resource->server, NULL,
+    if (!oc_do_get("/oic/p", resource->endpoint, NULL,
                    ocf_get_platform_info_handler, LOW_QOS, h)) {
         jerry_value_t err = make_ocf_error("NetworkError", "GET call failed",
                                            resource);
@@ -1060,7 +1061,7 @@ static ZJS_DECL_FUNC(ocf_get_device_info)
 
     DBG_PRINT("sending GET to /oic/d\n");
 
-    if (!oc_do_get("/oic/d", &resource->server, NULL,
+    if (!oc_do_get("/oic/d", resource->endpoint, NULL,
                    &ocf_get_device_info_handler, LOW_QOS, h)) {
         ZVAL err = make_ocf_error("NetworkError", "GET call failed", resource);
         jerry_resolve_or_reject_promise(promise, err, false);

--- a/src/zjs_ocf_common.h
+++ b/src/zjs_ocf_common.h
@@ -26,7 +26,7 @@ struct props_handle {
 #define TYPE_IS_INT    1
 #define TYPE_IS_UINT   2
 
-#define OCF_MAX_DEVICE_ID_LEN 36
+#define OCF_MAX_DEVICE_ID_LEN 42
 #define OCF_MAX_RES_TYPE_LEN  32
 #define OCF_MAX_RES_PATH_LEN  64
 #define OCF_MAX_URI_LEN       64

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -513,7 +513,7 @@ void zjs_ocf_register_resources(void)
         int i;
         struct server_resource *resource = cur->resource;
 
-        resource->res = oc_new_resource(resource->resource_path,
+        resource->res = oc_new_resource(NULL, resource->resource_path,
                                         resource->num_types, 0);
         if (!resource->res) {
             ERR_PRINT("failed to create new resource\n");


### PR DESCRIPTION
This updates iotivity-constrained to latest to support OCF 1.0 spec. I tested this and the communication between iotivity-constrained and iot-rest-api-server is working fine on Linux.

On Zephyr over BLE, we still need to adjust the TX, RX and DAT_BUF sizes since the /oic/res (resource discovery) response size has changed according to OCF 1.0 standard and it is too large with more information. 

I'm adding support for query-oriented resource discovery in REST API server so that we can do the resource discovery with specific 'rt' query option (e.g: /oic/res?rt=core-light) and that response size will fit into the buffers.

Fixes #1485

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>