### PR TITLE
[ocf] Fixed OCF encoding issues

### DIFF
--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -155,7 +155,7 @@ void *zjs_ocf_props_setup(jerry_value_t props_object, CborEncoder *encoder,
             DBG_PRINT("}\n");
         } else if (jerry_value_is_array(prop)) {
             /*
-             * TODO: need to start object?
+             * TODO: optimization can we recursively call zjs_ocf_props_setup()?
              */
             CborEncoder child;
             DBG_PRINT("Encoding array: %s [\n", h->names_array[i]);

--- a/src/zjs_ocf_encoder.h
+++ b/src/zjs_ocf_encoder.h
@@ -117,6 +117,51 @@ extern CborError g_err;
 /*
  * Encode a boolean value
  *
+ * @param parent        Parent object
+ * @param value         Value
+ */
+#define zjs_rep_encode_boolean(parent, value) \
+    g_err |= cbor_encode_boolean(parent, value);
+
+/*
+ * Encode a double value
+ *
+ * @param parent        Parent object
+ * @param value         Value
+ */
+#define zjs_rep_encode_double(parent, value) \
+    g_err |= cbor_encode_double(parent, value);
+
+/*
+ * Encode a integer value
+ *
+ * @param parent        Parent object
+ * @param value         Value
+ */
+#define zjs_rep_encode_int(parent, value) \
+    g_err |= cbor_encode_int(parent, value);
+
+/*
+ * Encode a unsigned integer value
+ *
+ * @param parent        Parent object
+ * @param value         Value
+ */
+#define zjs_rep_encode_uint(parent, value) \
+    g_err |= cbor_encode_uint(parent, value);
+
+/*
+ * Encode a string value in an array
+ *
+ * @param parent        Parent object
+ * @param value         Value
+ */
+#define zjs_rep_encode_string(parent, value) \
+    g_err |= cbor_encode_text_string(parent, value, strlen(value));
+
+/*
+ * Encode a boolean value
+ *
  * @param object        Parent object
  * @param key           Name of boolean property
  * @param value         Value


### PR DESCRIPTION
Added support for decimal values and arrays for property values in
OCF responses, this fixes a issue where different array types will
have wrong value when encoded or missing proper encoding.  Also
fixed the client to properly re-create the JS object from decoded
reponses.

Fixes #1489

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>