### PR TITLE
[ocf] Much better way to do object encoding/decoding

### DIFF
--- a/src/zjs_gpio_mock.c
+++ b/src/zjs_gpio_mock.c
@@ -87,25 +87,6 @@ static jerry_value_t find_property_with_value(jerry_value_t obj,
     return match.name;
 }
 
-// donated by jprestwo from his pending websockets patch, should move to util
-static jerry_value_t push_array(jerry_value_t array, jerry_value_t val)
-{
-    jerry_value_t new;
-    if (!jerry_value_is_array(array)) {
-        new = jerry_create_array(1);
-        jerry_set_property_by_index(new, 0, val);
-    } else {
-        u32_t size = jerry_get_array_length(array);
-        new = jerry_create_array(size + 1);
-        for (int i = 0; i < size; i++) {
-            ZVAL v = jerry_get_property_by_index(array, i);
-            jerry_set_property_by_index(new, i, v);
-        }
-        jerry_set_property_by_index(new, size, val);
-    }
-    return new;
-}
-
 // mock control functions
 
 /**
@@ -142,11 +123,11 @@ static ZJS_DECL_FUNC(zjs_gpio_mock_wire)
     }
 
     ZVAL pin1_wired = zjs_get_property(pin1_obj, "wired");
-    ZVAL new1_wired = push_array(pin1_wired, pin2_obj);
+    ZVAL new1_wired = zjs_push_array(pin1_wired, pin2_obj);
     zjs_set_property(pin1_obj, "wired", new1_wired);
 
     ZVAL pin2_wired = zjs_get_property(pin2_obj, "wired");
-    ZVAL new2_wired = push_array(pin2_wired, pin1_obj);
+    ZVAL new2_wired = zjs_push_array(pin2_wired, pin1_obj);
     zjs_set_property(pin2_obj, "wired", new2_wired);
 
     return ZJS_UNDEFINED;

--- a/src/zjs_ocf_common.h
+++ b/src/zjs_ocf_common.h
@@ -16,16 +16,6 @@
 //#include "port/oc_signal_main_loop.h"
 #include "port/oc_clock.h"
 
-struct props_handle {
-    jerry_value_t props_array;
-    u32_t size;
-    char **names_array;
-};
-
-#define TYPE_IS_NUMBER 0
-#define TYPE_IS_INT    1
-#define TYPE_IS_UINT   2
-
 #define OCF_MAX_DEVICE_ID_LEN 42
 #define OCF_MAX_RES_TYPE_LEN  32
 #define OCF_MAX_RES_PATH_LEN  64
@@ -45,34 +35,20 @@ struct props_handle {
     return promise;
 
 /*
- * Test if value at index is a double or integer
+ * Encode all properties in 'object' into the global CborEncoder
  *
- * @param val           JerryScript value to test
- *
- * @return              0=number, 1=int, 2=uint
+ * @param object        JerryScript object containing properties to encode
  */
-int zjs_ocf_is_int(jerry_value_t val);
+void zjs_ocf_encode_value(jerry_value_t object);
 
 /*
- * Encode all properties in props_object into a CborEncoder for an
- * iotivity-constrained callback.
+ * Decode properties from an OCF response into a jerry_value_t
  *
- * @param props_object  JerryScript object containing properties to encode
- * @param encoder       CborEncoder to encode the properties into
- * @param root          Flag if this is the root object or a sub-object
+ * @param data          Data from OCF response
  *
- * @return              Handle to free the properties later
+ * @return              Jerry object matching 'data'
  */
-void *zjs_ocf_props_setup(jerry_value_t props_object,
-                          CborEncoder *encoder,
-                          bool root);
-
-/*
- * Free properties after a call to zjs_ocf_props_setup()
- *
- * @param h             Handler returned from zjs_ocf_props_setup()
- */
-void zjs_ocf_free_props(void *h);
+jerry_value_t zjs_ocf_decode_value(oc_rep_t *data);
 
 /**
  * Routine to call into iotivity-constrained

--- a/src/zjs_ocf_encoder.h
+++ b/src/zjs_ocf_encoder.h
@@ -48,8 +48,9 @@ extern CborError g_err;
  * @param key           Child object (CborEncoder *)
  * @param name          Name of object (char *)
  */
-#define zjs_rep_set_object(object, key, name)                     \
-    g_err |= cbor_encode_text_string(object, name, strlen(name)); \
+#define zjs_rep_set_object(object, key, name)                           \
+    if (name)                                                           \
+        g_err |= cbor_encode_text_string(object, name, strlen(name));   \
     zjs_rep_start_object(object, key)
 
 /*
@@ -117,59 +118,15 @@ extern CborError g_err;
 /*
  * Encode a boolean value
  *
- * @param parent        Parent object
- * @param value         Value
- */
-#define zjs_rep_encode_boolean(parent, value) \
-    g_err |= cbor_encode_boolean(parent, value);
-
-/*
- * Encode a double value
- *
- * @param parent        Parent object
- * @param value         Value
- */
-#define zjs_rep_encode_double(parent, value) \
-    g_err |= cbor_encode_double(parent, value);
-
-/*
- * Encode a integer value
- *
- * @param parent        Parent object
- * @param value         Value
- */
-#define zjs_rep_encode_int(parent, value) \
-    g_err |= cbor_encode_int(parent, value);
-
-/*
- * Encode a unsigned integer value
- *
- * @param parent        Parent object
- * @param value         Value
- */
-#define zjs_rep_encode_uint(parent, value) \
-    g_err |= cbor_encode_uint(parent, value);
-
-/*
- * Encode a string value in an array
- *
- * @param parent        Parent object
- * @param value         Value
- */
-#define zjs_rep_encode_string(parent, value) \
-    g_err |= cbor_encode_text_string(parent, value, strlen(value));
-
-/*
- * Encode a boolean value
- *
  * @param object        Parent object
  * @param key           Name of boolean property
  * @param value         Value
  */
-#define zjs_rep_set_boolean(object, key, value)                     \
-    do {                                                            \
-        g_err |= cbor_encode_text_string(object, key, strlen(key)); \
-        g_err |= cbor_encode_boolean(object, value);                \
+#define zjs_rep_set_boolean(object, key, value)                         \
+    do {                                                                \
+        if (key)                                                        \
+            g_err |= cbor_encode_text_string(object, key, strlen(key)); \
+        g_err |= cbor_encode_boolean(object, value);                    \
     } while (0)
 
 /*
@@ -179,10 +136,11 @@ extern CborError g_err;
  * @param key           Name of boolean property
  * @param value         Value
  */
-#define zjs_rep_set_double(object, key, value)                      \
-    do {                                                            \
-        g_err |= cbor_encode_text_string(object, key, strlen(key)); \
-        g_err |= cbor_encode_double(object, value);                 \
+#define zjs_rep_set_double(object, key, value)                          \
+    do {                                                                \
+        if (key)                                                        \
+            g_err |= cbor_encode_text_string(object, key, strlen(key)); \
+        g_err |= cbor_encode_double(object, value);                     \
     } while (0)
 
 /*
@@ -192,10 +150,11 @@ extern CborError g_err;
  * @param key           Name of boolean property
  * @param value         Value
  */
-#define zjs_rep_set_int(object, key, value)                         \
-    do {                                                            \
-        g_err |= cbor_encode_text_string(object, key, strlen(key)); \
-        g_err |= cbor_encode_int(object, value);                    \
+#define zjs_rep_set_int(object, key, value)                             \
+    do {                                                                \
+        if (key)                                                        \
+            g_err |= cbor_encode_text_string(object, key, strlen(key)); \
+        g_err |= cbor_encode_int(object, value);                        \
     } while (0)
 
 /*
@@ -205,10 +164,11 @@ extern CborError g_err;
  * @param key           Name of boolean property
  * @param value         Value
  */
-#define zjs_rep_set_uint(object, key, value)                        \
-    do {                                                            \
-        g_err |= cbor_encode_text_string(object, key, strlen(key)); \
-        g_err |= cbor_encode_uint(object, value);                   \
+#define zjs_rep_set_uint(object, key, value)                            \
+    do {                                                                \
+        if (key)                                                        \
+            g_err |= cbor_encode_text_string(object, key, strlen(key)); \
+        g_err |= cbor_encode_uint(object, value);                       \
     } while (0)
 
 /*
@@ -218,10 +178,11 @@ extern CborError g_err;
  * @param key           Name of boolean property
  * @param value         Value
  */
-#define zjs_rep_set_text_string(object, key, value)                     \
-    do {                                                                \
-        g_err |= cbor_encode_text_string(object, key, strlen(key));     \
-        g_err |= cbor_encode_text_string(object, value, strlen(value)); \
+#define zjs_rep_set_text_string(object, key, value)                         \
+    do {                                                                    \
+        if (key)                                                            \
+            g_err |= cbor_encode_text_string(object, key, strlen(key));     \
+        g_err |= cbor_encode_text_string(object, value, strlen(value));     \
     } while (0)
 
 /*
@@ -231,10 +192,11 @@ extern CborError g_err;
  * @param key           Name of boolean property
  * @param value         Value
  */
-#define zjs_rep_set_byte_string(object, key, value)                     \
-    do {                                                                \
-        g_err |= cbor_encode_text_string(object, key, strlen(key));     \
-        g_err |= cbor_encode_byte_string(object, value, strlen(value)); \
+#define zjs_rep_set_byte_string(object, key, value)                         \
+    do {                                                                    \
+        if (key)                                                            \
+            g_err |= cbor_encode_text_string(object, key, strlen(key));     \
+        g_err |= cbor_encode_byte_string(object, value, strlen(value));     \
     } while (0)
 
 #endif

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -237,14 +237,7 @@ static ZJS_DECL_FUNC(ocf_respond)
 
     ZJS_GET_HANDLE(this, struct ocf_handler, h, ocf_type_info);
 
-    void *ret;
-    // Start the root encoding object
-    zjs_rep_start_root_object();
-    // Encode all properties from resource (argv[0])
-    ret = zjs_ocf_props_setup(data, &g_encoder, true);
-    zjs_rep_end_root_object();
-    // Free property return handle
-    zjs_ocf_free_props(ret);
+    zjs_ocf_encode_value(data);
 
     /*
      * TODO: Better error handling here. We need to implement a respond

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -292,6 +292,25 @@ bool zjs_obj_get_int32(jerry_value_t obj, const char *name, s32_t *num)
     return rval;
 }
 
+jerry_value_t zjs_push_array(jerry_value_t array, jerry_value_t val)
+{
+    if (!jerry_value_is_array(array)) {
+        jerry_value_t new = jerry_create_array(1);
+        jerry_set_property_by_index(new, 0, val);
+        return new;
+    } else {
+        u32_t size = jerry_get_array_length(array);
+        jerry_value_t new = jerry_create_array(size + 1);
+        for (int i = 0; i < size; i++) {
+            ZVAL v = jerry_get_property_by_index(array, i);
+            jerry_set_property_by_index(new, i, v);
+        }
+        jerry_set_property_by_index(new, size, val);
+        return new;
+    }
+}
+
+
 void zjs_copy_jstring(jerry_value_t jstr, char *buffer, jerry_size_t *maxlen)
 {
     jerry_size_t size = jerry_get_string_size(jstr);

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -145,6 +145,17 @@ bool zjs_obj_get_double(jerry_value_t obj, const char *name, double *num);
 bool zjs_obj_get_uint32(jerry_value_t obj, const char *name, u32_t *num);
 bool zjs_obj_get_int32(jerry_value_t obj, const char *name, s32_t *num);
 
+/*
+ * Push a new element into a JS array.
+ *
+ * @param array     Array to push into (can also be ZJS_UNDEFINED)
+ * @param val       Value to put into the array.
+ *
+ * @return          A NEW JS array containing the new element.
+ *
+ */
+jerry_value_t zjs_push_array(jerry_value_t array, jerry_value_t val);
+
 /**
  * Copy a JerryScript string into a supplied char * buffer.
  *

--- a/src/zjs_web_sockets.c
+++ b/src/zjs_web_sockets.c
@@ -210,28 +210,6 @@ static void free_server(void *native)
     }
 }
 
-/*
- * TODO: could probably move this to zjs_util
- */
-static jerry_value_t push_array(jerry_value_t array, jerry_value_t val)
-{
-    FTRACE("array = %p, val = %p\n", (void *)array, (void *)val);
-    if (!jerry_value_is_array(array)) {
-        jerry_value_t new = jerry_create_array(1);
-        jerry_set_property_by_index(new, 0, val);
-        return new;
-    } else {
-        u32_t size = jerry_get_array_length(array);
-        jerry_value_t new = jerry_create_array(size + 1);
-        for (int i = 0; i < size; i++) {
-            ZVAL v = jerry_get_property_by_index(array, i);
-            jerry_set_property_by_index(new, i, v);
-        }
-        jerry_set_property_by_index(new, size, val);
-        return new;
-    }
-}
-
 #ifdef DEBUG_BUILD
 static inline void pkt_sent(struct net_context *context, int status,
                             void *token, void *user_data)
@@ -671,7 +649,7 @@ static jerry_value_t create_ws_connection(ws_connection_t *con)
     zjs_make_emitter(conn, ZJS_UNDEFINED, con, NULL);
     if (con->server_h->track) {
         ZVAL clients = zjs_get_property(con->server_h->server, "clients");
-        ZVAL new = push_array(clients, conn);
+        ZVAL new = zjs_push_array(clients, conn);
         zjs_set_property(con->server_h->server, "clients", new);
     }
     con->conn = jerry_acquire_value(conn);


### PR DESCRIPTION
Using some code from #1497, this further improves the object
encoding/decoding. Instead of doing 2 passes on the object
to encode, this just does one. Also added support for arrays
of objects.

Signed-off-by: James Prestwood <james.prestwood@intel.com>