### PR TITLE
[net] Allow DHCP to work on A101 w/ ENC28J60

### DIFF
--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -231,8 +231,8 @@ static void dhcp_callback(struct net_mgmt_event_callback *cb,
                       sizeof(buf));
         ZVAL gateway = jerry_create_string(buf);
 
-        jerry_value_t args[] = { addr, subnet, gateway };
-        zjs_signal_callback(dhcp_id, args, sizeof(jerry_value_t) * 3);
+        jerry_value_t args[] = {addr, subnet, gateway};
+        zjs_signal_callback(dhcp_id, args, sizeof(args));
         dhcp_id = -1;
 
         return;

--- a/src/zjs_net_config.json
+++ b/src/zjs_net_config.json
@@ -7,9 +7,7 @@
         "all": [
             "CONFIG_NETWORKING=y",
             "CONFIG_NET_MGMT=y",
-            "CONFIG_NET_MGMT_EVENT=y"
-        ],
-        "frdm_k64f": [
+            "CONFIG_NET_MGMT_EVENT=y",
             "CONFIG_NET_DHCPV4=y"
         ]
     },


### PR DESCRIPTION
A bug in Zephyr prevents this from working currently, but it has been
fixed in zephyrproject-rtos/zephyr#1284. This just enables DHCP for
platforms other than K64F. Also, a minor style/convention tweak.

Fixes #1488

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>