### PR TITLE
[net] Fix socket_connect to support IPv4 connections

### DIFF
--- a/samples/TCPClient6.js
+++ b/samples/TCPClient6.js
@@ -60,7 +60,7 @@ net_cfg.on('netup', function() {
 			console.log("Socket has closed");
 		});
 		client.on("error", function(err) {
-			if (err.name == "NotFoundError") {
+			if (err.name == "Error") {
 				console.log("Server not found, retrying in 2 seconds");
 				setTimeout(function() {
 					if (!is_connected) {

--- a/src/zjs_net.c
+++ b/src/zjs_net.c
@@ -534,14 +534,14 @@ static jerry_value_t create_socket(u8_t client, sock_handle_t **handle_out)
 {
     sock_handle_t *sock_handle = zjs_malloc(sizeof(sock_handle_t));
     if (!sock_handle) {
-        return zjs_error_context("could not alloc socket handle", 0, 0);
+        return ZJS_UNDEFINED;
     }
     memset(sock_handle, 0, sizeof(sock_handle_t));
 
     sock_handle->rbuf = zjs_malloc(SOCK_READ_BUF_SIZE);
     if (!sock_handle->rbuf) {
         zjs_free(sock_handle);
-        return zjs_error_context("out of memory", 0, 0);
+        return ZJS_UNDEFINED;
     }
 
     jerry_value_t socket = zjs_create_object();
@@ -978,14 +978,14 @@ static ZJS_DECL_FUNC(socket_connect)
     }
     // TODO: get: .hints, .lookup
 
-    DBG_PRINT("port=%u, host=%s, localPort=%u, localAddress=%s, socket=%u\n",
-              (u32_t)port, host, (u32_t)localPort, localAddress, this);
+    DBG_PRINT("port=%u, host=%s, localPort=%u, localAddress=%s, socket=%p\n",
+              (u32_t)port, host, (u32_t)localPort, localAddress, (void *)this);
 
     int ret;
     if (!handle->tcp_sock) {
         sa_family_t inet = (fam == 6) ? AF_INET6 : AF_INET;
         CHECK(net_context_get(inet, SOCK_STREAM, IPPROTO_TCP,
-                              &handle->tcp_sock))
+                              &handle->tcp_sock));
     }
     if (!handle->tcp_sock) {
         DBG_PRINT("connect failed\n");

--- a/src/zjs_net.c
+++ b/src/zjs_net.c
@@ -1032,6 +1032,8 @@ static ZJS_DECL_FUNC(socket_connect)
                                                   function_obj);
             zjs_defer_emit_event(this, "error", &desc, sizeof(desc),
                                  handle_error_arg, zjs_release_args);
+            net_context_put(handle->tcp_sock);
+            handle->tcp_sock = NULL;
             return ZJS_UNDEFINED;
         }
     } else {
@@ -1064,6 +1066,8 @@ static ZJS_DECL_FUNC(socket_connect)
                                                   function_obj);
             zjs_defer_emit_event(this, "error", &desc, sizeof(desc),
                                  handle_error_arg, zjs_release_args);
+            net_context_put(handle->tcp_sock);
+            handle->tcp_sock = NULL;
             return ZJS_UNDEFINED;
         }
     }

--- a/src/zjs_net.c
+++ b/src/zjs_net.c
@@ -272,14 +272,12 @@ static void handle_wbuf_arg(void *h, jerry_value_t argv[], u32_t *argc,
 }
 
 enum {
-    ERROR_READ_SOCKET_CLOSED,
     ERROR_WRITE_SOCKET,
     ERROR_ACCEPT_SERVER,
     ERROR_CONNECT_SOCKET,
 };
 
 static const char *error_messages[] = {
-    "socket has been closed",
     "error writing to socket",
     "error listening to accepted connection",
     "failed to make connection",
@@ -335,9 +333,6 @@ static void tcp_received(struct net_context *context,
         // this means the socket closed properly
         DBG_PRINT("closing socket, context=%p, socket=%u\n", context,
                   handle->socket);
-        error_desc_t desc = create_error_desc(ERROR_READ_SOCKET_CLOSED, 0, 0);
-        zjs_defer_emit_event(handle->socket, "error", &desc, sizeof(desc),
-                             handle_error_arg, zjs_release_args);
 
         // note: we're not really releasing anything but release_close will
         //   just ignore the 0 args and this way we don't need a new function

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -420,16 +420,20 @@ void zjs_loop_init(void);
 // } list_item_t;
 // list_item_t *my_list = NULL;
 
-// Looks for and returns a node found in a list.
-// @param type          Struct type of list
-// @param list          Pointer to list head
-// @param cmp_element   Name of element in node struct to compare
-// @param cmp_to        Value to compare node element to
-
-// Example:
-//    list_item_t *item = ZJS_LIST_FIND(list_item_t, my_list, value, 42);
-
-// The above will return a list item whose `value` parameter == 42
+/**
+ *
+ * Looks for and returns a node found in a list.
+ * @param type          Struct type of list
+ * @param list          Pointer to list head
+ * @param cmp_element   Name of element in node struct to compare
+ * @param cmp_to        Value to compare node element to
+ *
+ * @return The matching list item, or NULL
+ *
+ * Example:
+ *    list_item_t *item = ZJS_LIST_FIND(list_item_t, my_list, value, 42);
+ *    // item will now be a list item whose `value` element == 42, or NULL
+ */
 #define ZJS_LIST_FIND(type, list, cmp_element, cmp_to) \
     ({                                                 \
         type *found = NULL;                            \
@@ -444,7 +448,24 @@ void zjs_loop_init(void);
         found;                                         \
     })
 
-// Version that takes a function used to compare with a value
+/**
+ * Runs cmp_func on each list item until it finds a match with cmp_to
+ *
+ * @param type       Struct type of list
+ * @param list       Pointer to list head
+ * @param cmp_func   int (type *item, valtype v) returns 0 if v matches in item
+ * @param cmp_to     Value of valtype to be passed to cmp_func
+ *
+ * @return The matching list item, or NULL
+ *
+ * Example:
+ *     int match_client(list_item_t *item, const char *client) {
+ *         return strcmp(item->client, client);
+ *     }
+ *     list_item_t *item = ZJS_LIST_FIND_COMP(list_item_t, my_list,
+ *                                            match_client, "Frodo");
+ *     // item will now be a list item with client "Frodo", or NULL
+ */
 #define ZJS_LIST_FIND_CMP(type, list, cmp_func, cmp_to) \
     ({                                                  \
         type *found = NULL;                             \


### PR DESCRIPTION
The function was returning an error immediately in the IPv4 case, if no
network context was set in the socket handle.

Fixes #1483, but then reveals another bus fault error on K64F.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>