### PR TITLE
[events] Don't emit poweredon signal unless Bluetooth has been initialized.

### DIFF
--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -581,9 +581,12 @@ static struct bt_conn_auth_cb zjs_ble_auth_cb_display = {
 
 void zjs_ble_emit_powered_event()
 {
-    const char state[] = "poweredOn";
-    zjs_defer_emit_event(ble_handle->ble_obj, "stateChange", state,
-                         sizeof(state), string_arg, zjs_release_args);
+    // Don't emit if bluetooth hasn't had init called yet
+    if (ble_handle) {
+        const char state[] = "poweredOn";
+        zjs_defer_emit_event(ble_handle->ble_obj, "stateChange", state,
+                             sizeof(state), string_arg, zjs_release_args);
+    }
 }
 
 static ZJS_DECL_FUNC(zjs_ble_disconnect)


### PR DESCRIPTION
Fix for #1502 
main.c emits the signal that BT is powered.  However,
In the case of ashell the BT module might not have been
initialized yet, causing the "error no handle found".
So I'm adding a check that the handle has been created.

Signed-off-by: Brian Jones <brian.j.jones@intel.com>