### PR TITLE
[util] Add strequal macro to replace strcmp for equality tests

### DIFF
--- a/src/ashell/comms-shell.c
+++ b/src/ashell/comms-shell.c
@@ -424,7 +424,7 @@ u32_t ashell_process_data(const char *buf, u32_t len)
     }
 
     /* Don't send back the 'echo off' command */
-    if (!strcmp(CMD_ECHO_OFF, buf)) {
+    if (strequal(CMD_ECHO_OFF, buf)) {
         echo_mode = false;
     }
 

--- a/src/ashell/jerry-code.c
+++ b/src/ashell/jerry-code.c
@@ -43,11 +43,10 @@ static bool list_contains(requires_list_t **list, const char *file_name)
 {
     requires_list_t *cur = *list;
     while (cur) {
-        if (strcmp(file_name, cur->file_name) != 0) {
-            cur = cur->next;
-        } else {
+        if (strequal(file_name, cur->file_name)) {
             return true;
         }
+        cur = cur->next;
     }
     return false;
 }
@@ -297,7 +296,7 @@ static bool add_requires(requires_list_t **list, char *filebuf)
         // Also check that the file hasn't already been loaded
 
         // FIXME: this always expects JS file to have .js lowercase extension
-        if (filelen >= 3 && !strcmp(&filestr[filelen - 3], ".js") &&
+        if (filelen >= 3 && strequal(&filestr[filelen - 3], ".js") &&
             !list_contains(list, filestr)) {
             if (fs_valid_filename(filestr)) {
                 add_to_list(list, filestr);

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -436,10 +436,10 @@ s32_t ashell_raw_capture(const char *buf, u32_t len)
 
 s32_t ashell_set_echo_mode(char *buf)
 {
-    if (!strcmp("on", buf)) {
+    if (strequal(buf, "on")) {
         comms_print("echo_on");
         comms_set_echo_mode(true);
-    } else if (!strcmp("off", buf)) {
+    } else if (strequal(buf, "off")) {
         comms_print("echo_off");
         comms_set_echo_mode(false);
     }
@@ -492,14 +492,14 @@ s32_t ashell_set_transfer_state(char *buf)
     next = ashell_get_token_arg(buf);
     comms_print(buf);
 
-    if (!strcmp("raw", buf)) {
+    if (strequal(buf, "raw")) {
         comms_set_prompt(NULL);
         shell.state_flags |= kShellTransferRaw;
         shell.state_flags &= ~kShellTransferIhex;
         return RET_OK;
     }
 
-    if (!strcmp("ihex", buf)) {
+    if (strequal(buf, "ihex")) {
         comms_set_prompt(hex_prompt);
         shell.state_flags |= kShellTransferIhex;
         shell.state_flags &= ~kShellTransferRaw;
@@ -516,7 +516,7 @@ s32_t ashell_set_state(char *buf)
     }
 
     char *next = ashell_get_token_arg(buf);
-    if (!strcmp(CMD_TRANSFER, buf)) {
+    if (strequal(buf, CMD_TRANSFER)) {
         return ashell_set_transfer_state(next);
     }
 
@@ -531,7 +531,7 @@ s32_t ashell_get_state(char *buf)
     }
 
     ashell_get_token_arg(buf);
-    if (!strcmp(CMD_TRANSFER, buf)) {
+    if (strequal(buf, CMD_TRANSFER)) {
         DBG("Flags %lu\n", shell.state_flags);
 
         if (shell.state_flags & kShellTransferRaw)
@@ -764,7 +764,7 @@ s32_t ashell_main_state(char *buf, u32_t len)
     }
 
     for (u8_t t = 0; t < ASHELL_COMMANDS_COUNT; t++) {
-        if (!strcmp(commands[t].cmd_name, buf)) {
+        if (strequal(commands[t].cmd_name, buf)) {
             s32_t res = commands[t].cb(next);
             /* End command */
             if (shell.state_flags & kShellTransferIhex) {

--- a/src/ashell/shell-state.c
+++ b/src/ashell/shell-state.c
@@ -26,8 +26,8 @@
 #include "comms-shell.h"
 #include "comms-uart.h"
 #include "shell-state.h"
-
 #include "ihex-handler.h"
+#include "../zjs_util.h"
 
 // JerryScript includes
 #include "jerry-code.h"

--- a/src/zjs_aio.c
+++ b/src/zjs_aio.c
@@ -210,7 +210,7 @@ static ZJS_DECL_FUNC(zjs_aio_pin_on)
     jerry_size_t size = MAX_TYPE_LEN;
     char event[size];
     zjs_copy_jstring(argv[0], event, &size);
-    if (strcmp(event, "change"))
+    if (!strequal(event, "change"))
         return zjs_error("unsupported event type");
 
     aio_handle_t *handle;

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -836,11 +836,11 @@ static bool zjs_ble_parse_characteristic(ble_characteristic_t *chrc)
         char name[MAX_NAME_LENGTH];
         zjs_copy_jstring(v_property, name, &size);
 
-        if (!strcmp(name, "read")) {
+        if (strequal(name, "read")) {
             chrc->flags |= BT_GATT_CHRC_READ;
-        } else if (!strcmp(name, "write")) {
+        } else if (strequal(name, "write")) {
             chrc->flags |= BT_GATT_CHRC_WRITE;
-        } else if (!strcmp(name, "notify")) {
+        } else if (strequal(name, "notify")) {
             chrc->flags |= BT_GATT_CHRC_NOTIFY;
         }
     }

--- a/src/zjs_board.c
+++ b/src/zjs_board.c
@@ -95,9 +95,9 @@ static const zjs_pin_t *zjs_find_pin(const char *name)
     int len = sizeof(pin_data) / sizeof(zjs_pin_t);
     for (int i = 0; i < len; ++i) {
         const zjs_pin_t *pin = &pin_data[i];
-        if (!strcmp(name, pin->name) ||
-            (pin->altname && !strcmp(name, pin->altname)) ||
-            (pin->altname2 && !strcmp(name, pin->altname2)))
+        if (strequal(name, pin->name) ||
+            (pin->altname && strequal(name, pin->altname)) ||
+            (pin->altname2 && strequal(name, pin->altname2)))
             return pin;
     }
     return NULL;

--- a/src/zjs_buffer.c
+++ b/src/zjs_buffer.c
@@ -221,7 +221,7 @@ static ZJS_DECL_FUNC(zjs_buffer_to_string)
         return zjs_error("encoding argument too long");
     }
 
-    if (!strcmp(encoding, "ascii")) {
+    if (strequal(encoding, "ascii")) {
         char *str = zjs_malloc(buf->bufsize);
         if (!str) {
             return zjs_error("out of memory");
@@ -241,7 +241,7 @@ static ZJS_DECL_FUNC(zjs_buffer_to_string)
                 strnlen((char *)buf->buffer, buf->bufsize));
         zjs_free(str);
         return jstr;
-    } else if (!strcmp(encoding, "hex")) {
+    } else if (strequal(encoding, "hex")) {
         if (buf && buf->bufsize > 0) {
             char hexbuf[buf->bufsize * 2 + 1];
             for (int i = 0; i < buf->bufsize; i++) {

--- a/src/zjs_dgram.c
+++ b/src/zjs_dgram.c
@@ -164,9 +164,9 @@ static ZJS_DECL_FUNC(zjs_dgram_createSocket)
     GET_STR(argv[0], type_str);
 
     sa_family_t family;
-    if (strcmp(type_str, "udp4") == 0)
+    if (strequal(type_str, "udp4"))
         family = AF_INET;
-    else if (strcmp(type_str, "udp6") == 0)
+    else if (strequal(type_str, "udp6"))
         family = AF_INET6;
     else
         return zjs_error("invalid argument");
@@ -204,9 +204,9 @@ static ZJS_DECL_FUNC(zjs_dgram_sock_on)
     zjs_copy_jstring(argv[0], event, &str_sz);
 
     zjs_callback_id *cb_slot;
-    if (!strcmp(event, "message"))
+    if (strequal(event, "message"))
         cb_slot = &handle->message_cb_id;
-    else if (!strcmp(event, "error"))
+    else if (strequal(event, "error"))
         cb_slot = &handle->error_cb_id;
     else
         return zjs_error("unsupported event type");

--- a/src/zjs_fs.c
+++ b/src/zjs_fs.c
@@ -114,17 +114,17 @@ static int file_exists(const char *path)
 static u16_t get_mode(char *str)
 {
     u16_t mode = 0;
-    if (strcmp(str, "r") == 0) {
+    if (strequal(str, "r")) {
         mode = MODE_R;
-    } else if (strcmp(str, "r+") == 0) {
+    } else if (strequal(str, "r+")) {
         mode = MODE_R_PLUS;
-    } else if (strcmp(str, "w") == 0) {
+    } else if (strequal(str, "w")) {
         mode = MODE_W;
-    } else if (strcmp(str, "w+") == 0) {
+    } else if (strequal(str, "w+")) {
         mode = MODE_W_PLUS;
-    } else if (strcmp(str, "a") == 0) {
+    } else if (strequal(str, "a")) {
         mode = MODE_A;
-    } else if (strcmp(str, "a+") == 0) {
+    } else if (strequal(str, "a+")) {
         mode = MODE_A_PLUS;
     }
     return mode;

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -47,7 +47,7 @@ static ZJS_DECL_FUNC(native_require_handler)
     int modcount = sizeof(zjs_modules_array) / sizeof(module_t);
     for (int i = 0; i < modcount; i++) {
         module_t *mod = &zjs_modules_array[i];
-        if (!strcmp(mod->name, module)) {
+        if (strequal(mod->name, module)) {
             // We only want one instance of each module at a time
             if (mod->instance == 0) {
                 mod->instance = mod->init();
@@ -197,7 +197,7 @@ void zjs_modules_init()
         module_t *mod = &zjs_modules_array[i];
 
         // DEV: if you add another module name here, remove the break below
-        if (!strcmp(mod->name, "events")) {
+        if (strequal(mod->name, "events")) {
             mod->instance = jerry_acquire_value(mod->init());
             break;
         }

--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -137,9 +137,9 @@ static int str2bt_addr_le(const char *str, const char *type, bt_addr_le_t *addr)
         addr->a.val[i] = tmp;
     }
 
-    if (!strcmp(type, "public") || !strcmp(type, "(public)")) {
+    if (strequal(type, "public") || strequal(type, "(public)")) {
         addr->type = BT_ADDR_LE_PUBLIC;
-    } else if (!strcmp(type, "random") || !strcmp(type, "(random)")) {
+    } else if (strequal(type, "random") || strequal(type, "(random)")) {
         addr->type = BT_ADDR_LE_RANDOM;
     } else {
         return -EINVAL;

--- a/src/zjs_ocf_client.c
+++ b/src/zjs_ocf_client.c
@@ -319,7 +319,7 @@ static struct client_resource *find_resource_by_id(const char *device_id)
         struct client_resource *cur = resource_list;
         while (cur) {
             if (cur->state != RES_STATE_SEARCHING) {
-                if (strcmp(cur->device_id, device_id) == 0) {
+                if (strequal(cur->device_id, device_id)) {
                     return cur;
                 }
             }
@@ -456,21 +456,21 @@ static oc_discovery_flags_t discovery(const char *di,
             if (cur->state == RES_STATE_SEARCHING) {
                 // check if resource has any filter constraints
                 if (cur->device_id) {
-                    if (strcmp(cur->device_id, di) == 0) {
+                    if (strequal(cur->device_id, di)) {
                         goto Found;
                     } else {
                         goto NotFound;
                     }
                 }
                 if (cur->resource_type) {
-                    if (strcmp(cur->resource_type, t) == 0) {
+                    if (strequal(cur->resource_type, t)) {
                         goto Found;
                     } else {
                         goto NotFound;
                     }
                 }
                 if (cur->resource_path) {
-                    if (strcmp(cur->resource_path, uri) == 0) {
+                    if (strequal(cur->resource_path, uri)) {
                         goto Found;
                     } else {
                         goto NotFound;
@@ -864,39 +864,39 @@ static void ocf_get_platform_info_handler(oc_client_response_t *data)
                 break;
             case BYTE_STRING:
             case STRING:
-                if (strcmp(oc_string(rep->name), "mnmn") == 0) {
+                if (strequal(oc_string(rep->name), "mnmn")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "manufacturerName");
-                } else if (strcmp(oc_string(rep->name), "pi") == 0) {
+                } else if (strequal(oc_string(rep->name), "pi")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "id");
-                } else if (strcmp(oc_string(rep->name), "mnmo") == 0) {
+                } else if (strequal(oc_string(rep->name), "mnmo")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "model");
-                } else if (strcmp(oc_string(rep->name), "mndt") == 0) {
+                } else if (strequal(oc_string(rep->name), "mndt")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "manufacturerDate");
-                } else if (strcmp(oc_string(rep->name), "mnpv") == 0) {
+                } else if (strequal(oc_string(rep->name), "mnpv")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "platformVersion");
-                } else if (strcmp(oc_string(rep->name), "mnos") == 0) {
+                } else if (strequal(oc_string(rep->name), "mnos")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "osVersion");
-                } else if (strcmp(oc_string(rep->name), "mnfv") == 0) {
+                } else if (strequal(oc_string(rep->name), "mnfv")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "firmwareVersion");
-                } else if (strcmp(oc_string(rep->name), "mnml") == 0) {
+                } else if (strequal(oc_string(rep->name), "mnml")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "manufacturerURL");
-                } else if (strcmp(oc_string(rep->name), "mnsl") == 0) {
+                } else if (strequal(oc_string(rep->name), "mnsl")) {
                     zjs_obj_add_readonly_string(platform_info,
                                                 oc_string(rep->value.string),
                                                 "supportURL");
@@ -988,7 +988,7 @@ static void ocf_get_device_info_handler(oc_client_response_t *data)
                 break;
             case BYTE_STRING:
             case STRING:
-                if (strcmp(oc_string(rep->name), "di") == 0) {
+                if (strequal(oc_string(rep->name), "di")) {
                     zjs_obj_add_string(device_info,
                                        oc_string(rep->value.string), "uuid");
                     /*
@@ -1001,14 +1001,14 @@ static void ocf_get_device_info_handler(oc_client_response_t *data)
                                        create_url(oc_string(rep->value.string),
                                                   resource->resource_path),
                                        "url");
-                } else if (strcmp(oc_string(rep->name), "n") == 0) {
+                } else if (strequal(oc_string(rep->name), "n")) {
                     zjs_obj_add_string(device_info,
                                        oc_string(rep->value.string), "name");
-                } else if (strcmp(oc_string(rep->name), "icv") == 0) {
+                } else if (strequal(oc_string(rep->name), "icv")) {
                     zjs_obj_add_string(device_info,
                                        oc_string(rep->value.string),
                                        "coreSpecVersion");
-                } else if (strcmp(oc_string(rep->name), "dmv") == 0) {
+                } else if (strequal(oc_string(rep->name), "dmv")) {
                     zjs_obj_add_string(device_info,
                                        oc_string(rep->value.string),
                                        "dataModels");

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -54,9 +54,9 @@ static bool ocf_foreach_prop(const jerry_value_t prop_name,
      */
     // Skip id/resourcePath/resourceType because that is not a resource property
     // that is sent out
-    if ((strcmp(name, "deviceId") != 0) &&
-        (strcmp(name, "resourcePath") != 0) &&
-        (strcmp(name, "resourceType") != 0)) {
+    if ((!strequal(name, "deviceId")) &&
+        (!strequal(name, "resourcePath")) &&
+        (!strequal(name, "resourceType"))) {
         handle->names_array[handle->size] =
             zjs_malloc(jerry_get_string_size(prop_name) + 1);
         memcpy(handle->names_array[handle->size], name, strlen(name));

--- a/src/zjs_ocf_server.c
+++ b/src/zjs_ocf_server.c
@@ -524,22 +524,22 @@ void zjs_ocf_register_resources(void)
                                            resource->resource_types[i]);
         }
         for (i = 0; i < resource->num_ifaces; ++i) {
-            if (strcmp(resource->resource_ifaces[i], "/oic/if/rw") == 0) {
+            if (strequal(resource->resource_ifaces[i], "/oic/if/rw")) {
                 oc_resource_bind_resource_interface(resource->res, OC_IF_RW);
                 oc_resource_set_default_interface(resource->res, OC_IF_RW);
-            } else if (strcmp(resource->resource_ifaces[0], "/oic/if/r") == 0) {
+            } else if (strequal(resource->resource_ifaces[0], "/oic/if/r")) {
                 oc_resource_bind_resource_interface(resource->res, OC_IF_R);
                 oc_resource_set_default_interface(resource->res, OC_IF_R);
-            } else if (strcmp(resource->resource_ifaces[0], "/oic/if/a") == 0) {
+            } else if (strequal(resource->resource_ifaces[0], "/oic/if/a")) {
                 oc_resource_bind_resource_interface(resource->res, OC_IF_A);
                 oc_resource_set_default_interface(resource->res, OC_IF_A);
-            } else if (strcmp(resource->resource_ifaces[0], "/oic/if/s") == 0) {
+            } else if (strequal(resource->resource_ifaces[0], "/oic/if/s")) {
                 oc_resource_bind_resource_interface(resource->res, OC_IF_S);
                 oc_resource_set_default_interface(resource->res, OC_IF_S);
-            } else if (strcmp(resource->resource_ifaces[0], "/oic/if/b") == 0) {
+            } else if (strequal(resource->resource_ifaces[0], "/oic/if/b")) {
                 oc_resource_bind_resource_interface(resource->res, OC_IF_B);
                 oc_resource_set_default_interface(resource->res, OC_IF_B);
-            } else if (strcmp(resource->resource_ifaces[0], "/oic/if/ll") == 0) {
+            } else if (strequal(resource->resource_ifaces[0], "/oic/if/ll")) {
                 oc_resource_bind_resource_interface(resource->res, OC_IF_LL);
                 oc_resource_set_default_interface(resource->res, OC_IF_LL);
             }

--- a/src/zjs_pwm.c
+++ b/src/zjs_pwm.c
@@ -170,7 +170,7 @@ static ZJS_DECL_FUNC(zjs_pwm_open)
     char buffer[BUFLEN];
     const char *polarity = ZJS_POLARITY_NORMAL;
     if (zjs_obj_get_string(data, "polarity", buffer, BUFLEN)) {
-        if (!strcmp(buffer, ZJS_POLARITY_REVERSE))
+        if (strequal(buffer, ZJS_POLARITY_REVERSE))
             polarity = ZJS_POLARITY_REVERSE;
     }
 

--- a/src/zjs_sensor.c
+++ b/src/zjs_sensor.c
@@ -98,15 +98,15 @@ sensor_state_t zjs_sensor_get_state(jerry_value_t obj)
     const int BUFLEN = 20;
     char buffer[BUFLEN];
     if (zjs_obj_get_string(obj, "state", buffer, BUFLEN)) {
-        if (!strcmp(buffer, "unconnected"))
+        if (strequal(buffer, "unconnected"))
             return SENSOR_STATE_UNCONNECTED;
-        if (!strcmp(buffer, "idle"))
+        if (strequal(buffer, "idle"))
             return SENSOR_STATE_IDLE;
-        if (!strcmp(buffer, "activating"))
+        if (strequal(buffer, "activating"))
             return SENSOR_STATE_ACTIVATING;
-        if (!strcmp(buffer, "activated"))
+        if (strequal(buffer, "activated"))
             return SENSOR_STATE_ACTIVATED;
-        if (!strcmp(buffer, "errored"))
+        if (strequal(buffer, "errored"))
             return SENSOR_STATE_ERRORED;
         else
             ERR_PRINT("invalid state set %s\n", buffer);

--- a/src/zjs_unit_tests.c
+++ b/src/zjs_unit_tests.c
@@ -43,7 +43,7 @@ static u8_t string_correct = 0;
 static void c_callback2(void *handle, const void *args)
 {
     char *s = (char *)handle;
-    if (strcmp(s, "pass string as handle") == 0) {
+    if (strequal(s, "pass string as handle")) {
         string_correct = 1;
     }
 }
@@ -53,8 +53,8 @@ static void c_callback3(void *handle, const void *args)
 {
     char *h = (char *)handle;
     char *a = (char *)args;
-    if (strcmp(h, "this is my handle") == 0) {
-        if (strcmp(a, "this is my args") == 0) {
+    if (strequal(h, "this is my handle")) {
+        if (strequal(a, "this is my args")) {
             handle_and_args = 1;
         }
     }

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -734,7 +734,7 @@ int zjs_require_string_if_prop_map(jerry_value_t obj, const char *prop,
     jerry_size_t size = maxlen;
     zjs_copy_jstring(value, str, &size);
     for (int i = 0; map[i].first != NULL; ++i) {
-        if (!strcmp(str, map[i].first)) {
+        if (strequal(str, map[i].first)) {
             *result = map[i].second;
             return 0;
         }

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -32,6 +32,9 @@ typedef struct mem_stats {
 #define ZJS_HIDDEN_PROP(n) "\377" n
 #endif
 
+// define more readable string equality "function"
+#define strequal(a, b) !strcmp(a, b)
+
 /**
  * Call malloc but if it fails, run JerryScript garbage collection and retry
  *

--- a/src/zjs_web_sockets.c
+++ b/src/zjs_web_sockets.c
@@ -701,13 +701,13 @@ static void tcp_received(struct net_context *context,
                 memcpy(value, tmp2 + 2, i - tmp2 - 2);
                 value[i - tmp2 - 3] = '\0';
 
-                if (strcmp(field, "Sec-WebSocket-Key") == 0) {
+                if (strequal(field, "Sec-WebSocket-Key")) {
                     // compute and return accept key
                     DBG_PRINT("new connection key: %s\n", value);
                     memset(con->accept_key, 0, 64);
                     generate_key(value, strlen(value), con->accept_key, 64);
                     DBG_PRINT("accept key: %s\n", con->accept_key);
-                } else if (strcmp(field, "Sec-WebSocket-Protocol") == 0) {
+                } else if (strequal(field, "Sec-WebSocket-Protocol")) {
                     int protocols = 1;
                     char *i = value;
                     while (*i != '\0') {


### PR DESCRIPTION
This is more readable and less vulnerable to logic inversion.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>