### PR TITLE
[net] Fix for #1507 - Default ble address

### DIFF
--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -33,9 +33,6 @@ void zjs_net_config_default(void)
 #ifdef CONFIG_NET_L2_BLUETOOTH
     if (!net_ble_enabled) {
         zjs_init_ble_address();
-        ipss_init();
-        ipss_advertise();
-        net_ble_enabled = 1;
     }
 #endif
     if (!net_enabled) {


### PR DESCRIPTION
The default address was actually being set, but there
were other methods being called that have been moved
to the main file, and needed to be removed otherwise it caused
havoc.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>