### PR TITLE
[ocf] Do not source contiki headers

### DIFF
--- a/src/zjs_iotivity_constrained.json
+++ b/src/zjs_iotivity_constrained.json
@@ -33,10 +33,7 @@
          "../deps/iotivity-constrained/port/zephyr/src/storage.c"
     ],
     "zjs_config": [
-        "-I${ZEPHYR_BASE}/net/ip",
-        "-I${ZEPHYR_BASE}/net/ip/contiki",
-        "-I${ZEPHYR_BASE}/net/ip/contiki/os/lib",
-        "-I${ZEPHYR_BASE}/net/ip/contiki/os",
+        "-I${ZEPHYR_BASE}/subsys/net/ip",
         "-I${ZEPHYR_BASE}/samples/bluetooth",
         "-I$(OCF_ROOT)/port/zephyr/src",
         "-I$(OCF_ROOT)/include -I$(OCF_ROOT)",
@@ -45,7 +42,7 @@
         "-DNDEBUG",
         "-include $(ZJS_BASE)/src/zjs_ocf_config.h",
         "-include $(ZJS_BASE)/$(OCF_ROOT)/port/zephyr/src/config.h",
-        "-I$(ZJS_BASE)/$(OCF_ROOT)/$(OCF_ROOT)/include",
+        "-I$(ZJS_BASE)/$(OCF_ROOT)/include",
         "-I$(ZJS_BASE)/$(OCF_ROOT)"
     ]
 }


### PR DESCRIPTION
Legacy Contiki based IP stack has been removed in
Zephyr, so removing obsolete include paths.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>