### PR TITLE
[SPI] Adding an acquire when using provided buffer

### DIFF
--- a/src/zjs_spi.c
+++ b/src/zjs_spi.c
@@ -160,7 +160,7 @@ static ZJS_DECL_FUNC(zjs_spi_transceive)
         } else {
             // If we were passed a buffer just use it as is
             tx_buf = zjs_buffer_find(argv[1]);
-            tx_buf_obj = buffer;
+            tx_buf_obj = jerry_acquire_value(buffer);   // We don't own the buffer
         }
         // If this is a read / write
         if (dir_arg == ZJS_TOPOLOGY_FULL_DUPLEX) {

--- a/src/zjs_spi.c
+++ b/src/zjs_spi.c
@@ -159,7 +159,7 @@ static ZJS_DECL_FUNC(zjs_spi_transceive)
             zjs_free(tmpBuf);
         } else {
             // If we were passed a buffer just use it as is
-            tx_buf = zjs_buffer_find(argv[1]);            
+            tx_buf = zjs_buffer_find(argv[1]);
         }
         // If this is a read / write
         if (dir_arg == ZJS_TOPOLOGY_FULL_DUPLEX) {

--- a/src/zjs_spi.c
+++ b/src/zjs_spi.c
@@ -137,7 +137,7 @@ static ZJS_DECL_FUNC(zjs_spi_transceive)
         // Figure out if the buffer is an array or string, handle accordingly
         if (jerry_value_is_array(argv[1])) {
             len = jerry_get_array_length(buffer);
-            tx_buf_obj = zjs_buffer_create(len, &tx_buf);
+            ZVAL tx_buf_obj = zjs_buffer_create(len, &tx_buf);
             if (tx_buf) {
                 for (int i = 0; i < len; i++) {
                     ZVAL item = jerry_get_property_by_index(buffer, i);
@@ -150,7 +150,7 @@ static ZJS_DECL_FUNC(zjs_spi_transceive)
                 }
             }
         } else if (jerry_value_is_string(argv[1])) {
-            tx_buf_obj = zjs_buffer_create(jerry_get_string_size(buffer),
+            ZVAL tx_buf_obj = zjs_buffer_create(jerry_get_string_size(buffer),
                                            &tx_buf);
             // zjs_copy_jstring adds a null terminator, which we don't want
             // so make a new string instead and remove it.
@@ -159,8 +159,7 @@ static ZJS_DECL_FUNC(zjs_spi_transceive)
             zjs_free(tmpBuf);
         } else {
             // If we were passed a buffer just use it as is
-            tx_buf = zjs_buffer_find(argv[1]);
-            tx_buf_obj = jerry_acquire_value(buffer);   // We don't own the buffer
+            tx_buf = zjs_buffer_find(argv[1]);            
         }
         // If this is a read / write
         if (dir_arg == ZJS_TOPOLOGY_FULL_DUPLEX) {

--- a/src/zjs_spi.c
+++ b/src/zjs_spi.c
@@ -151,7 +151,7 @@ static ZJS_DECL_FUNC(zjs_spi_transceive)
             }
         } else if (jerry_value_is_string(argv[1])) {
             ZVAL tx_buf_obj = zjs_buffer_create(jerry_get_string_size(buffer),
-                                           &tx_buf);
+                                                &tx_buf);
             // zjs_copy_jstring adds a null terminator, which we don't want
             // so make a new string instead and remove it.
             char *tmpBuf = zjs_alloc_from_jstring(argv[1], NULL);


### PR DESCRIPTION
If the passed arg is a Buffer object, I don't want to have
ZVAL free the original reference when its done, because I don't
own it. Instead, create a local reference that gets freed.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>