### PR TITLE
[general] Use sizeof(args) as safer than manual calculation

### DIFF
--- a/src/zjs_fs.c
+++ b/src/zjs_fs.c
@@ -961,7 +961,7 @@ Finished:
         jerry_value_t args[] = { err, buffer };
 
         zjs_callback_id id = zjs_add_callback_once(argv[1], this, NULL, NULL);
-        zjs_signal_callback(id, args, sizeof(jerry_value_t) * 2);
+        zjs_signal_callback(id, args, sizeof(args));
     }
     return ZJS_UNDEFINED;
 #endif

--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -243,7 +243,7 @@ static void dhcp_callback(struct net_mgmt_event_callback *cb,
                       sizeof(buf));
         ZVAL gateway = jerry_create_string(buf);
 
-        jerry_value_t args[] = {addr, subnet, gateway};
+        jerry_value_t args[] = { addr, subnet, gateway };
         zjs_signal_callback(dhcp_id, args, sizeof(args));
         dhcp_id = -1;
 


### PR DESCRIPTION
Also, restore style of args declaration in another place where I had
just fixed the same issue; after reviewing all of them I see we use
spaces around the braces consistently.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>