### PR TITLE
[utils] Switch to the use the new UTF8 JrS string functions

### DIFF
--- a/samples/WebBluetoothGroveLcdDemo.js
+++ b/samples/WebBluetoothGroveLcdDemo.js
@@ -26,9 +26,14 @@ var aio = require("aio");
 var ble = require("ble");
 var grove_lcd = require("grove_lcd");
 var pins = require("arduino101_pins");
-var perf = require("performance");
 
-console.log("Boot timestamp:", perf.now(), "\n");
+try {
+    var perf = require("performance");
+    console.log("Boot timestamp:", perf.now(), "\n");
+}
+catch (e) {
+    // ignore errors, perf is just included for QA performance tracking
+}
 
 var DEVICE_NAME = 'Arduino101';
 

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -460,10 +460,10 @@ if [ "$RUN" == "all" -o "$RUN" == "4" ]; then
     TESTNUM=0
 
     # ashell tests
-    try_command "ashell" make $VERBOSE ashell ROM=257
+    try_command "ashell" make $VERBOSE ashell ROM=256
 
     # build ide version
-    try_command "ide" make $VERBOSE ide ROM=257
+    try_command "ide" make $VERBOSE ide ROM=256
 
     # test key sample code
     try_command "btgrove" make $VERBOSE JS=samples/WebBluetoothGroveLcdDemo.js ROM=256

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -460,10 +460,10 @@ if [ "$RUN" == "all" -o "$RUN" == "4" ]; then
     TESTNUM=0
 
     # ashell tests
-    try_command "ashell" make $VERBOSE ashell ROM=256
+    try_command "ashell" make $VERBOSE ashell ROM=257
 
     # build ide version
-    try_command "ide" make $VERBOSE ide ROM=256
+    try_command "ide" make $VERBOSE ide ROM=257
 
     # test key sample code
     try_command "btgrove" make $VERBOSE JS=samples/WebBluetoothGroveLcdDemo.js ROM=256

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -348,13 +348,13 @@ fi
 #
 
 function check_jstring_util() {
-    CALLCOUNT=$(grep jerry_string_to_char_buffer src/zjs_util.c | wc -l)
+    CALLCOUNT=$(grep "jerry_string_to\(_utf8\)\?_char_buffer" src/zjs_util.c | wc -l)
 
     # make sure there are exactly two calls to the function
     # note: the return value of running wc -l on Mac will have some blank space
     # in front of it, thus no double quoting $CALLCOUNT as the comparison will fail
     if [ $CALLCOUNT != "2" ]; then
-        echo "Error: Expected two calls to jerry_string_to_char_buffer in zjs_util.c!"
+        echo "Error: Expected two calls to jerry_string_to[_utf8]_char_buffer in zjs_util.c!"
         echo "Use zjs_copy_jstring and zjs_alloc_from_jstring instead."
         return 1;
     fi
@@ -364,9 +364,9 @@ function check_jstring_others() {
     SRCFILES=$(find src -name "*.[ch]" | grep -v zjs_util.c)
 
     # make sure there are no other calls to the function
-    if grep jerry_string_to_char_buffer $SRCFILES; then
+    if grep "jerry_string_to\(_utf8\)\?_char_buffer" $SRCFILES; then
         echo
-        echo "Error: Found calls to jerry_string_to_char_buffer outside zjs_util.c!"
+        echo "Error: Found calls to jerry_string_to[_utf8]_char_buffer outside zjs_util.c!"
         echo "Use zjs_copy_jstring and zjs_alloc_from_jstring instead."
         return 1;
     fi
@@ -426,10 +426,10 @@ if [ "$RUN" == "all" -o "$RUN" == "3" ]; then
     # git check
     try_command "git check" git --no-pager diff --check $(git rev-list HEAD | tail -1)
 
-    # ensure only two uses of jerry_string_to_char_buffer in zjs_util.c
+    # ensure only two uses of jerry_string_to[_utf8]_char_buffer in zjs_util.c
     try_command "jstring1" check_jstring_util
 
-    # ensure no other source file uses jerry-string_to_char_buffer
+    # ensure no other source file uses jerry_string_to[_utf8]_char_buffer
     try_command "jstring2" check_jstring_others
 
     # check that updated files have updated copyrights

--- a/src/zjs_ashell.json
+++ b/src/zjs_ashell.json
@@ -1,7 +1,7 @@
 {
     "module": "ashell",
     "depends": ["aio", "arduino101_pins", "ble", "common", "console", "fs",
-                "gpio", "grove_lcd", "i2c", "performance", "pwm", "sensor_accel",
+                "gpio", "grove_lcd", "i2c", "pwm", "sensor_accel",
                 "sensor_gyro", "sensor_light", "sensor_temp", "spi"],
     "targets": ["arduino_101"],
     "src": ["ashell/"],

--- a/src/zjs_ashell.json
+++ b/src/zjs_ashell.json
@@ -1,7 +1,7 @@
 {
     "module": "ashell",
     "depends": ["aio", "arduino101_pins", "ble", "common", "console", "fs",
-                "gpio", "grove_lcd", "i2c", "pwm", "sensor_accel",
+                "gpio", "i2c", "pwm", "performance", "sensor_accel",
                 "sensor_gyro", "sensor_light", "sensor_temp", "spi"],
     "targets": ["arduino_101"],
     "src": ["ashell/"],

--- a/src/zjs_util.c
+++ b/src/zjs_util.c
@@ -297,7 +297,8 @@ void zjs_copy_jstring(jerry_value_t jstr, char *buffer, jerry_size_t *maxlen)
     jerry_size_t size = jerry_get_string_size(jstr);
     jerry_size_t len = 0;
     if (*maxlen > size)
-        len = jerry_string_to_char_buffer(jstr, (jerry_char_t *)buffer, size);
+        len = jerry_string_to_utf8_char_buffer(jstr, (jerry_char_t *)buffer,
+                                               size);
     buffer[len] = '\0';
     *maxlen = len;
 }
@@ -312,7 +313,7 @@ char *zjs_alloc_from_jstring(jerry_value_t jstr, jerry_size_t *maxlen)
     }
 
     jerry_size_t len;
-    len = jerry_string_to_char_buffer(jstr, (jerry_char_t *)buffer, size);
+    len = jerry_string_to_utf8_char_buffer(jstr, (jerry_char_t *)buffer, size);
     buffer[len] = '\0';
 
     if (maxlen) {


### PR DESCRIPTION
I'm afraid we've been concerned only with ASCII to date but getting
strings as UTF-8 should get us a lot closer to correct behavior in the
face of extended characters.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>