### PR TITLE
[zephyr] Update to Zephyr 1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ cache:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install make gcc g++ python3-ply ncurses-dev uglifyjs libc6-dev-i386 python3-yaml -qq
+  - sudo apt-get install make gcc g++ python3-ply ncurses-dev uglifyjs libc6-dev-i386 python3-pip python3-yaml -qq
+  - sudo pip3 install pyelftools
 
 install: >
   if [ "$TARGET" != "linux" -a "$(cat $ZEPHYR_SDK_INSTALL_DIR/sdk_version)" != "$ZEPHYR_SDK_VERSION" ]; then

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ change in Zephyr, so it could be left out currently if you don't use k64f.
 Before that, for a while python-yaml was needed when the script was using
 Python 2.
 
+You may also need to install pip3 to get pyelftools:
+
+```bash
+$ sudo apt-get install python-pip3
+$ sudo pip3 install pyelftools
+```
+
 #### Clone the ZJS repo
 Next, clone this git repo:
 ```bash

--- a/scripts/analyze
+++ b/scripts/analyze
@@ -314,11 +314,25 @@ def write_makefile(src, zconf, file):
                 f.write("\t" + i + " \\\n")
             f.write("\n")
 
+def expand_match(match):
+    """Expand regexp match as a shell variable, if possible"""
+    # requires: match should be VARNAME from $(VARNAME) string
+    #  effects: tries to expand $VARNAME as a shell variable; if it fails,
+    #             returns the original $(VARNAME) string
+    varname = match.groups()[0]
+    ref = '$' + varname
+    expanded = os.path.expandvars(ref)
+    if ref == expanded:
+        return '$(' + varname + ')'
+    return expanded
+
 def write_zconf(list, file):
     """Write Zephyr config options to a file"""
     with open(file, "w") as f:
         for i in list:
-            f.write(i + '\n')
+            # expand any shell variables of the form $(VARNAME)
+            expanded = re.sub(r"\$\((\w+)\)", expand_match, i)
+            f.write(expanded + '\n')
 
 def write_modules(list, tree):
     """Write zjs_modules_gen.h file"""

--- a/scripts/checkheaders
+++ b/scripts/checkheaders
@@ -7,20 +7,29 @@
 
 cd $ZJS_BASE/src
 
-TEMPLATE=/tmp/zjs_template.c
+SRCDIR=/tmp/zjs_checkheaders
+
+# prepare directory
+rm -rf $SRCDIR
+mkdir $SRCDIR
+
+TEMPLATE=$SRCDIR/zjs_template.c
 
 echo                 > $TEMPLATE
 echo "int main() {" >> $TEMPLATE
 echo "return 0;"    >> $TEMPLATE
 echo "}"            >> $TEMPLATE
 
-SOURCE=/tmp/zjs_source.c
-BINARY=/tmp/zjs_source
+SOURCE=$SRCDIR/zjs_source.c
+BINARY=$SRCDIR/zjs_source
+
+# create a stub generated dts board header to work around errors
+touch $SRCDIR/generated_dts_board.h
 
 PASSCOUNT=0
 TOTAL=0
 
-CFLAGS="-m32 -DCONFIG_X86 -DCONFIG_PREEMPT_ENABLED -DCONFIG_NET_IPV4 -DCONFIG_NET_IF_UNICAST_IPV4_ADDR_COUNT=1 -DCONFIG_NET_IF_MCAST_IPV4_ADDR_COUNT=1 -DCONFIG_LOAPIC_BASE_ADDRESS=0xFEE00000 -I. -I../deps/jerryscript/jerry-core -I../deps/jerryscript/jerry-core/include -I../deps/zephyr/include -I../deps/zephyr/arch/x86/include -I../deps/iotivity-constrained/include -I../deps/iotivity-constrained -include ../deps/iotivity-constrained/port/zephyr/src/config.h"
+CFLAGS="-m32 -DCONFIG_X86 -DCONFIG_PREEMPT_ENABLED -DCONFIG_NET_IPV4 -DCONFIG_NET_IF_UNICAST_IPV4_ADDR_COUNT=1 -DCONFIG_NET_IF_MCAST_IPV4_ADDR_COUNT=1 -DCONFIG_LOAPIC_BASE_ADDRESS=0xFEE00000 -I. -I$SRCDIR -I../deps/jerryscript/jerry-core -I../deps/jerryscript/jerry-core/include -I../deps/zephyr/include -I../deps/zephyr/arch/x86/include -I../deps/iotivity-constrained/include -I../deps/iotivity-constrained -include../deps/iotivity-constrained/port/zephyr/src/config.h"
 FAILURES=
 
 function create_source()  # HEADER

--- a/scripts/trlite
+++ b/scripts/trlite
@@ -291,7 +291,7 @@ if [ "$RUN" == "all" -o "$RUN" == "1" ]; then
 
     # also, try printing a float w/o PRINT_FLOAT
     echo "console.log(3.14159);" >> $TMPFILE
-    try_command "modules" make $VERBOSE JS=$TMPFILE ROM=256
+    try_command "modules" make $VERBOSE JS=$TMPFILE ROM=255
 
     MODULES=(net pme ws)
     write_modules_test $TMPFILE $MODULES
@@ -460,10 +460,10 @@ if [ "$RUN" == "all" -o "$RUN" == "4" ]; then
     TESTNUM=0
 
     # ashell tests
-    try_command "ashell" make $VERBOSE ashell ROM=256
+    try_command "ashell" make $VERBOSE ashell ROM=255
 
     # build ide version
-    try_command "ide" make $VERBOSE ide ROM=256
+    try_command "ide" make $VERBOSE ide ROM=255
 
     # test key sample code
     try_command "btgrove" make $VERBOSE JS=samples/WebBluetoothGroveLcdDemo.js ROM=256

--- a/src/MODULES.md
+++ b/src/MODULES.md
@@ -99,7 +99,7 @@ targets. For example, a simplified version of the "net" module:
     ...
     "zephyr_conf": {
         "all": ["CONFIG_NETWORKING=y"],
-        "arduino_101": ["CONFIG_BLUETOOTH=y"],
+        "arduino_101": ["CONFIG_BT=y"],
         "qemu_x86": ["CONFIG_NET_SLIP_TAP=y"],
         "frdm_k64f": ["CONFIG_NET_L2_ETHERNET=y"]
     }

--- a/src/ashell/term-uart.c
+++ b/src/ashell/term-uart.c
@@ -28,7 +28,6 @@
 
 #include <atomic.h>
 #include <board.h>
-#include <sections.h>
 #include <toolchain.h>
 #include <uart.h>
 

--- a/src/zjs_ashell.json
+++ b/src/zjs_ashell.json
@@ -1,7 +1,7 @@
 {
     "module": "ashell",
-    "depends": ["aio", "arduino101_pins", "ble", "common", "console", "fs",
-                "gpio", "i2c", "pwm", "performance", "sensor_accel",
+    "depends": ["aio", "arduino101_pins", "ble", "common", "console",
+                "gpio", "i2c", "performance", "pwm", "sensor_accel",
                 "sensor_gyro", "sensor_light", "sensor_temp", "spi"],
     "targets": ["arduino_101"],
     "src": ["ashell/"],
@@ -29,11 +29,11 @@
             "CONFIG_FLASH=y",
             "CONFIG_SPI=y",
             "CONFIG_GPIO=y",
-            "CONFIG_BLUETOOTH=y",
-            "CONFIG_BLUETOOTH_LE=y",
-            "CONFIG_BLUETOOTH_SMP=y",
-            "CONFIG_BLUETOOTH_PERIPHERAL=y",
-            "CONFIG_BLUETOOTH_GATT_DYNAMIC_DB=y"
+            "CONFIG_BT=y",
+            "CONFIG_BT_LE=y",
+            "CONFIG_BT_SMP=y",
+            "CONFIG_BT_PERIPHERAL=y",
+            "CONFIG_BT_GATT_DYNAMIC_DB=y"
         ]
     },
     "zjs_config": ["-DZJS_ASHELL"]

--- a/src/zjs_ble.json
+++ b/src/zjs_ble.json
@@ -4,12 +4,12 @@
     "depends": ["events", "buffer"],
     "zephyr_conf": {
         "all": [
-            "CONFIG_BLUETOOTH=y",
+            "CONFIG_BT=y",
             "CONFIG_NBLE=y",
-            "CONFIG_BLUETOOTH_SMP=y",
-            "CONFIG_BLUETOOTH_PERIPHERAL=y",
-            "CONFIG_BLUETOOTH_GATT_DYNAMIC_DB=y",
-            "CONFIG_BLUETOOTH_MAX_CONN=4"
+            "CONFIG_BT_SMP=y",
+            "CONFIG_BT_PERIPHERAL=y",
+            "CONFIG_BT_GATT_DYNAMIC_DB=y",
+            "CONFIG_BT_MAX_CONN=4"
         ]
     },
     "zjs_config": ["-DBUILD_MODULE_BLE"],

--- a/src/zjs_dgram.c
+++ b/src/zjs_dgram.c
@@ -5,6 +5,7 @@
 // Zephyr includes
 #include <net/net_context.h>
 #include <net/net_pkt.h>
+#include <net/udp.h>
 #if defined(CONFIG_NET_L2_BLUETOOTH)
 #include <bluetooth/bluetooth.h>
 #endif
@@ -136,8 +137,9 @@ static void udp_received(struct net_context *context,
     ZVAL_MUTABLE buf_js = zjs_buffer_create(recv_len, &buf);
     ZVAL rinfo = zjs_create_object();
     if (buf) {
-        zjs_obj_add_number(rinfo, "port",
-                           ntohs(NET_UDP_HDR(net_pkt)->src_port));
+        struct net_udp_hdr placeholder;
+        struct net_udp_hdr *hdr = net_udp_get_hdr(net_pkt, &placeholder);
+        zjs_obj_add_number(rinfo, "port", ntohs(hdr->src_port));
         zjs_obj_add_string(rinfo, "family",
                            family == AF_INET ? "IPv4" : "IPv6");
         zjs_obj_add_string(rinfo, "address", addr_str);

--- a/src/zjs_net.c
+++ b/src/zjs_net.c
@@ -194,11 +194,13 @@ static void zjs_copy_sockaddr(struct sockaddr *dst, struct sockaddr *src,
     //             the underlying address family; if len is given, asserts
     //             that it matches the expected size
     if (src->sa_family == AF_INET) {
-        ZJS_ASSERT(!len || len == sizeof(sockaddr_in), "expected IPv4 length");
+        ZJS_ASSERT(!len || len == sizeof(struct sockaddr_in),
+                   "expected IPv4 length");
         *(struct sockaddr_in *)dst = *(struct sockaddr_in *)src;
     }
     else if (src->sa_family == AF_INET6) {
-        ZJS_ASSERT(!len || len == sizeof(sockaddr_in6), "expected IPv6 length");
+        ZJS_ASSERT(!len || len == sizeof(struct sockaddr_in6),
+                   "expected IPv6 length");
         *(struct sockaddr_in6 *)dst = *(struct sockaddr_in6 *)src;
     }
     else {

--- a/src/zjs_net.c
+++ b/src/zjs_net.c
@@ -16,7 +16,6 @@ static char FTRACE_PREFIX[] = "net";
 #include <errno.h>
 
 // Zephyr includes
-#include <sections.h>
 #include <zephyr.h>
 
 #include <net/net_context.h>

--- a/src/zjs_net.c
+++ b/src/zjs_net.c
@@ -193,11 +193,11 @@ static void zjs_copy_sockaddr(struct sockaddr *dst, struct sockaddr *src,
     //  effects: copies src to dest, but only the number of bytes required by
     //             the underlying address family; if len is given, asserts
     //             that it matches the expected size
-    if (src->family == AF_INET) {
+    if (src->sa_family == AF_INET) {
         ZJS_ASSERT(!len || len == sizeof(sockaddr_in), "expected IPv4 length");
         *(struct sockaddr_in *)dst = *(struct sockaddr_in *)src;
     }
-    else if (src->family == AF_INET6) {
+    else if (src->sa_family == AF_INET6) {
         ZJS_ASSERT(!len || len == sizeof(sockaddr_in6), "expected IPv6 length");
         *(struct sockaddr_in6 *)dst = *(struct sockaddr_in6 *)src;
     }
@@ -1054,13 +1054,13 @@ static ZJS_DECL_FUNC(server_listen)
 
     struct sockaddr addr;
     memset(&addr, 0, sizeof(struct sockaddr));
-    addr.family = (family == 6) ? AF_INET6 : AF_INET;  // default to IPv4
+    addr.sa_family = (family == 6) ? AF_INET6 : AF_INET;  // default to IPv4
 
-    CHECK(net_context_get(addr.family, SOCK_STREAM, IPPROTO_TCP,
+    CHECK(net_context_get(addr.sa_family, SOCK_STREAM, IPPROTO_TCP,
                           &server_h->server_ctx));
 
     u32_t addrlen;
-    if (addr.family == AF_INET) {
+    if (addr.sa_family == AF_INET) {
         struct sockaddr_in *addr4 = (struct sockaddr_in *)&addr;
         addr4->sin_port = htons((int)port);
         net_addr_pton(AF_INET, hostname, &addr4->sin_addr);

--- a/src/zjs_net_l2_bluetooth.json
+++ b/src/zjs_net_l2_bluetooth.json
@@ -5,11 +5,11 @@
     "targets": ["arduino_101"],
     "zephyr_conf": {
         "arduino_101": [
-            "CONFIG_BLUETOOTH=y",
-            "CONFIG_BLUETOOTH_SMP=y",
-            "CONFIG_BLUETOOTH_SIGNING=y",
-            "CONFIG_BLUETOOTH_PERIPHERAL=y",
-            "CONFIG_BLUETOOTH_L2CAP_DYNAMIC_CHANNEL=y",
+            "CONFIG_BT=y",
+            "CONFIG_BT_SMP=y",
+            "CONFIG_BT_SIGNING=y",
+            "CONFIG_BT_PERIPHERAL=y",
+            "CONFIG_BT_L2CAP_DYNAMIC_CHANNEL=y",
             "CONFIG_NETWORKING_WITH_6LOWPAN=y",
             "CONFIG_6LOWPAN_COMPRESSION_IPHC=y",
             "CONFIG_NET_L2_BLUETOOTH_ZEP1656=y",

--- a/src/zjs_ocf.json
+++ b/src/zjs_ocf.json
@@ -37,8 +37,8 @@
             "CONFIG_NET_APP_PEER_IPV6_ADDR=\"2001:db8::2\""
         ],
         "arduino_101": [
-            "CONFIG_BLUETOOTH_L2CAP_TX_BUF_COUNT=15",
-            "CONFIG_BLUETOOTH_RX_BUF_COUNT=15"
+            "CONFIG_BT_L2CAP_TX_BUF_COUNT=15",
+            "CONFIG_BT_RX_BUF_COUNT=15"
         ]
     },
     "header": ["zjs_ocf_server.h", "zjs_ocf_client.h", "zjs_ocf_common.h"],

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -279,7 +279,7 @@ static void issue_requests(void)
 #ifdef ZJS_LINUX_BUILD
 #define CONFIG_DEVICE_NAME "ZJS Device"
 #else
-#define CONFIG_DEVICE_NAME CONFIG_BLUETOOTH_DEVICE_NAME
+#define CONFIG_DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #endif
 
 void zjs_set_uuid(char *uuid)

--- a/src/zjs_web_sockets.c
+++ b/src/zjs_web_sockets.c
@@ -11,7 +11,6 @@ static char FTRACE_PREFIX[] = "net";
 #include <random.h>
 
 // Zephyr includes
-#include <sections.h>
 #include <zephyr.h>
 
 #include "mbedtls/base64.h"


### PR DESCRIPTION
Also, update iotivity-constrained to build with Zephyr 1.9.

In analyze, add expanding of shell variables used in zephyr_conf
JSON settings to work around an issue with the MBEDTLS_CFG_FILE.

Add a workaround to checkheaders to create a stub file for
generated_dts_board.h that is expected.

Decrease ROM size in trlite builds to allow for slight expansion
in ARC image build size. Also, drop 'fs' module from ashell/ide
builds so that they will fit in the new 255 KB allotted.

Follow rename of CONFIG_BLUETOOTH_* to CONFIG_BT_* in Zephyr.

Slightly reorganize Bluetooth service registration to match new
convention.

Work around some network macros that have gone away.

Fix references to sections.h that moved.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>