### PR TITLE
[timers] Make timers completely async/event driven

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -45,7 +45,7 @@ JERRY_LIBS += 		-l jerry-core -lm
 
 JERRY_LIB_PATH += 	-L $(JERRY_BASE)/build/lib/
 
-LINUX_LIBS +=		$(JERRY_LIBS)
+LINUX_LIBS +=		$(JERRY_LIBS) -lrt
 
 ifeq ($(shell uname -s), Linux)
 LINUX_LIBS +=		-pthread

--- a/src/main.c
+++ b/src/main.c
@@ -250,12 +250,7 @@ int main(int argc, char *argv[])
             // FIXME: need to consider the chicken and egg problems here
             serviced = 1;
         }
-        u64_t wait = zjs_timers_process_events();
-        if (wait != ZJS_TICKS_FOREVER) {
-            serviced = 1;
-            wait_time = (wait < wait_time) ? wait : wait_time;
-        }
-        wait = zjs_service_routines();
+        u64_t wait = zjs_service_routines();
         if (wait != ZJS_TICKS_FOREVER) {
             serviced = 1;
             wait_time = (wait < wait_time) ? wait : wait_time;

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -283,7 +283,7 @@ zjs_callback_id add_callback_priv(jerry_value_t js_func,
     cb_map[new_cb->id] = new_cb;
 
     DBG_PRINT("adding new callback id %d, js_func=%p, once=%u\n", new_cb->id,
-              (void *)new_cb->js_func, once);
+            (void *)(uintptr_t)new_cb->js_func, once);
 
 #ifdef INSTRUMENT_CALLBACKS
     set_info_string(cb_map[new_cb->id]->creator, file, func);
@@ -458,7 +458,8 @@ void print_callbacks(void)
                 ZJS_PRINT("[%u] JS Callback:\n\tType: ", i);
                 if (jerry_value_is_function(cb_map[i]->js_func)) {
                     ZJS_PRINT("Single Function\n");
-                    ZJS_PRINT("\tjs_func: %p\n", (void *)cb_map[i]->js_func);
+                    ZJS_PRINT("\tjs_func: %p\n",
+                            (void *)(uintptr_t)cb_map[i]->js_func);
                     ZJS_PRINT("\tonce: %u\n", GET_ONCE(cb_map[i]->flags));
                 } else {
                     ZJS_PRINT("js_func is not a function\n");

--- a/src/zjs_common.c
+++ b/src/zjs_common.c
@@ -28,82 +28,22 @@ char *zjs_shorten_filepath(char *filepath)
 
 #ifdef DEBUG_BUILD
 
-static u8_t init = 0;
-static int seconds = 0;
-
-#ifdef ZJS_LINUX_BUILD
-#include <time.h>
+static int start = 0;
 
 int zjs_get_sec(void)
 {
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    if (!init) {
-        seconds = now.tv_sec;
-        init = 1;
+    if (!start) {
+        start = zjs_port_timer_get_uptime() / 1000;
     }
-    return now.tv_sec - seconds;
+    return (zjs_port_timer_get_uptime() / 1000) - start;
 }
 
 int zjs_get_ms(void)
 {
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    if (!init) {
-        seconds = now.tv_sec;
-        init = 1;
+    if (!start) {
+        start = zjs_port_timer_get_uptime() / 1000;
     }
-    return (now.tv_nsec / 1000000);
+    return zjs_port_timer_get_uptime() - (zjs_get_sec() * 1000);
 }
 
-#else  // !ZJS_LINUX_BUILD
-
-#include "zjs_zephyr_port.h"
-
-static zjs_port_timer_t print_timer;
-// Millisecond counter to increment
-static u32_t milli = 0;
-
-void update_print_timer(void)
-{
-    if (!init) {
-        zjs_port_timer_init(&print_timer);
-        zjs_port_timer_start(&print_timer, 1);
-        init = 1;
-    }
-    if (zjs_port_timer_test(&print_timer)) {
-        if (milli >= 100) {
-            milli = 0;
-            seconds++;
-        } else {
-            // TODO: Find out why incrementing by 1 results in timer being
-            //       ~50% too slow. Increasing by 2 works as it did before the
-            //       unified kernel.
-            milli += 2;
-        }
-        zjs_port_timer_start(&print_timer, 1);
-    }
-}
-
-int zjs_get_sec(void)
-{
-    if (!init) {
-        zjs_port_timer_init(&print_timer);
-        zjs_port_timer_start(&print_timer, 1);
-        init = 1;
-    }
-    return seconds;
-}
-
-int zjs_get_ms(void)
-{
-    if (!init) {
-        zjs_port_timer_init(&print_timer);
-        zjs_port_timer_start(&print_timer, 1);
-        init = 1;
-    }
-    return milli;
-}
-
-#endif  // ZJS_LINUX_BUILD
 #endif  // DEBUG_BUILD

--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -16,6 +16,7 @@
 #include <misc/printk.h>
 #endif
 #include <zephyr/types.h>
+#include "zjs_zephyr_port.h"
 #endif
 
 #ifdef CONFIG_ARC

--- a/src/zjs_linux_port.h
+++ b/src/zjs_linux_port.h
@@ -6,6 +6,7 @@
 // C includes
 #include <stdint.h>
 #include <time.h>
+#include <signal.h>
 #include <unistd.h>
 
 // define Zephyr numeric types we use
@@ -18,20 +19,25 @@ typedef uint32_t u32_t;
 typedef int64_t s64_t;
 typedef uint64_t u64_t;
 
+struct zjs_port_timer;
+
+typedef void (*zjs_port_timer_cb)(struct zjs_port_timer *handle);
+
 typedef struct zjs_port_timer {
-    u32_t sec;
-    u32_t milli;
-    u32_t interval;
-    void *data;
+    void *user_data;
+    uint8_t repeat;
+    struct sigevent se;
+    struct itimerspec ti;
+    struct sigaction sa;
+    timer_t time;
+    zjs_port_timer_cb callback;
 } zjs_port_timer_t;
 
-#define zjs_port_timer_init(t) do {} while (0)
+void zjs_port_timer_init(zjs_port_timer_t *timer, zjs_port_timer_cb cb);
 
-void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval);
+void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval, u32_t repeat);
 
 void zjs_port_timer_stop(zjs_port_timer_t *timer);
-
-u8_t zjs_port_timer_test(zjs_port_timer_t *timer);
 
 u32_t zjs_port_timer_get_uptime(void);
 
@@ -63,5 +69,7 @@ int zjs_port_ring_buf_get(struct zjs_port_ring_buf *buf, u16_t *type,
 // INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or release prints!
 int zjs_port_ring_buf_put(struct zjs_port_ring_buf *buf, u16_t type,
                           u8_t value, u32_t *data, u8_t size32);
+
+#define zjs_port_get_thread_id() 0
 
 #endif /* ZJS_LINUX_PORT_H_ */

--- a/src/zjs_linux_time.c
+++ b/src/zjs_linux_time.c
@@ -2,40 +2,54 @@
 
 // C includes
 #include <time.h>
+#include <signal.h>
+#include <stdio.h>
 
 // ZJS includes
 #include "zjs_linux_port.h"
 
 #define ZEPHYR_TICKS_PER_SEC
 
-void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval)
+static void timer_signal(int signal, siginfo_t *info, void *oldaction)
 {
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    timer->sec = now.tv_sec;
-    timer->milli = now.tv_nsec / 1000000;
-    timer->interval = interval;
+    zjs_port_timer_t *timer = info->si_value.sival_ptr;
+    timer->callback(timer);
+}
+
+void zjs_port_timer_init(zjs_port_timer_t *timer, zjs_port_timer_cb cb)
+{
+    timer->sa.sa_sigaction = timer_signal;
+    timer->sa.sa_flags = SA_SIGINFO;
+    sigemptyset(&timer->sa.sa_mask);
+    sigaction(SIGRTMIN, &timer->sa, NULL);
+
+    timer->callback = cb;
+    timer->se.sigev_signo = SIGRTMIN;
+    timer->se.sigev_notify = SIGEV_SIGNAL;
+    timer->se.sigev_value.sival_ptr = timer;
+    timer_create(CLOCK_REALTIME, &timer->se, &timer->time);
+}
+
+void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval, u32_t repeat)
+{
+    uint32_t rsec = repeat / 1000;
+    uint32_t rms = repeat - (rsec * 1000);
+
+    timer->ti.it_interval.tv_sec = rsec;
+    timer->ti.it_interval.tv_nsec = rms * 1000000;
+    timer->ti.it_value.tv_sec = rsec;
+    timer->ti.it_value.tv_nsec = rms * 1000000;
+
+    timer_settime(timer->time, 0, &timer->ti, NULL);
 }
 
 void zjs_port_timer_stop(zjs_port_timer_t *timer)
 {
-    timer->interval = 0;
-}
-
-u8_t zjs_port_timer_test(zjs_port_timer_t *timer)
-{
-    u32_t elapsed;
-    struct timespec now;
-
-    clock_gettime(CLOCK_MONOTONIC, &now);
-
-    elapsed = (1000 * (now.tv_sec - timer->sec)) +
-              ((now.tv_nsec / 1000000) - timer->milli);
-
-    if (elapsed >= timer->interval) {
-        return elapsed;
-    }
-    return 0;
+    timer->ti.it_interval.tv_sec = 0;
+    timer->ti.it_interval.tv_nsec = 0;
+    timer->ti.it_value.tv_sec = 0;
+    timer->ti.it_value.tv_nsec = 0;
+    timer_settime(timer->time, 0, &timer->ti, NULL);
 }
 
 u32_t zjs_port_timer_get_uptime(void)

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -80,12 +80,13 @@ void zjs_pop_mem_stat(void *ptr);
 #endif  // ZJS_LINUX_BUILD
 
 #ifdef DEBUG_BUILD
-#define zjs_create_object()                                   \
-    ({                                                        \
-        jerry_value_t jval = jerry_create_object();           \
-        DBG_PRINT("trace: T:%p: create object: %p\n",         \
-                  k_current_get(), (void *)(uintptr_t)jval);  \
-        jval;                                                 \
+#define zjs_create_object()                                     \
+    ({                                                          \
+        jerry_value_t jval = jerry_create_object();             \
+        DBG_PRINT("trace: T:%p: create object: %p\n",           \
+                (void *)(uintptr_t)zjs_port_get_thread_id(),    \
+                (void *)(uintptr_t)jval);                       \
+        jval;                                                   \
     })
 #else
 #define zjs_create_object() jerry_create_object()

--- a/src/zjs_zephyr_port.h
+++ b/src/zjs_zephyr_port.h
@@ -5,13 +5,12 @@
 
 #include <zephyr.h>
 
+#define zjs_port_timer_cb               k_timer_expiry_t
 #define zjs_port_timer_t                struct k_timer
-#define zjs_port_timer_init(t)          k_timer_init(t, NULL, NULL)
-#define zjs_port_timer_start(t, i)      k_timer_start(t, i, i)
+#define zjs_port_timer_init(t, f)       k_timer_init(t, f, NULL)
+#define zjs_port_timer_start(t, i, r)   k_timer_start(t, r, r)
 #define zjs_port_timer_stop             k_timer_stop
-#define zjs_port_timer_test             k_timer_status_get
 #define zjs_port_timer_get_uptime       k_uptime_get_32
-#define zjs_port_timer_get_remaining    k_timer_remaining_get
 #define ZJS_TICKS_NONE                  TICKS_NONE
 #define ZJS_TICKS_FOREVER               K_FOREVER
 #define zjs_sleep                       k_sleep
@@ -25,5 +24,7 @@
 #define zjs_port_sem_take               k_sem_take
 #define zjs_port_sem_give               k_sem_give
 #define zjs_port_sem                    struct k_sem
+
+#define zjs_port_get_thread_id          k_current_get
 
 #endif /* ZJS_ZEPHYR_PORT_H_ */


### PR DESCRIPTION
Timers currently used the main event loop to check if
the timer had expired. This change uses Zephyr's timer
callbacks to signal the JS function. The linux port
uses signals to do the same thing.

Signed-off-by: James Prestwood <james.prestwood@intel.com>