### PR TITLE
[debugger] Enable Jerry debugger support for Linux

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -95,6 +95,10 @@ ifeq ($(V), 1)
 VERBOSE=-v
 endif
 
+ifeq ($(DEBUGGER), on)
+LINUX_DEFINES += -DZJS_DEBUGGER
+endif
+
 BUILD_OBJ = $(CORE_OBJ:%.o=$(BUILD_DIR)/%.o)
 
 # define the modules that will be pulled into the linux build
@@ -157,8 +161,9 @@ linux: setup $(BUILD_OBJ)
 		--mem-heap 16 \
 		--profile=es2015-subset \
 		--jerry-port-default=OFF \
-		--jerry-cmdline OFF \
-		--jerry-libc OFF;
+		--jerry-cmdline=OFF \
+		--jerry-libc=OFF \
+		--jerry-debugger=$(DEBUGGER)
 
 	@echo [LD] $(BUILD_DIR)/jslinux
 	@gcc $(LINUX_INCLUDES) $(JERRY_LIB_PATH) -o $(BUILD_DIR)/jslinux $(BUILD_OBJ) $(LINUX_FLAGS) $(CFLAGS) $(LINUX_DEFINES) $(LINUX_LIBS)

--- a/README.md
+++ b/README.md
@@ -231,9 +231,32 @@ Then Esc again to get back to the latest output (out of "Copy Mode").
 
 #### Debugging
 
+##### Debugging native C code
 You can use the commands `make debug` and `make gdb` in two separate terminals
 to connect to the device with a debugger. Then you can set breakpoints such as
 `b main` and `run` to start debugging as usual with gdb.
+
+##### Debugging JavaScript code
+JerryScript has a built-in remote debugger which allows debugging JavaScript programs.
+At the moment only a Websocket-based implementation is provided by JerryScript which
+transmits messages over TCP/IP networks. This implementation requires a socket API which
+currently only work when running on Linux.  The socket API is not yet supported
+with NewLib when building with Zephyr natively.
+
+To enable the remote debugger for a particular JS application:
+```bash
+make BOARD=linux DEBUGGER=on
+outdir/linux/release/jslinux app.js --debugger
+```
+
+It will then be run on debugger mode waiting for client connection, you can then
+in another terminal, you can connect to it by running the python client in JerryScript:
+```bash
+jerry-debugger/jerry-client-ws.py
+```
+
+In the client, type 'help' to get a list of debugger commands, such as
+adding breakpoints, stepping through JS sources, etc.
 
 #### Additional details
 

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -10,8 +10,10 @@ ccflags-y += -Wall -Werror $(ZJS_FLAGS)
 #       into warnings
 ccflags-y += -Wno-error=format
 
+ifneq ($(BOARD), linux)
 # Select extended ANSI C/POSIX function set in recent Newlib versions
 ccflags-y += -D_XOPEN_SOURCE=700
+endif
 
 ccflags-y += -I$(JERRY_BASE)/jerry-core/include
 ccflags-y += -I$(JERRY_BASE)/jerry-core/jrt

--- a/src/ashell/Makefile
+++ b/src/ashell/Makefile
@@ -27,7 +27,9 @@ obj-y += shell-state.o
 
 obj-y += ../../deps/ihex/kk_ihex_read.o
 
+ifneq ($(BOARD), linux)
 # Select extended ANSI C/POSIX function set in recent Newlib versions
 ccflags-y += -D_XOPEN_SOURCE=700
+endif
 
 ccflags-y += -DZJS_ASHELL -Wall -Werror


### PR DESCRIPTION
This adds to ability to enable debugger mode for linux builds running
on the same host system, you can then connect a remote client to it
to debug JavaScript applications.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>