### PR TITLE
[uart] Protect ring buffer access in ISRs w/ irq_lock not mutex

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -95,6 +95,9 @@ SYS_RING_BUF_DECLARE_POW2(ring_buffer, 5);
 static u8_t ring_buf_initialized = 1;
 
 #ifdef ZJS_LINUX_BUILD
+#define k_is_preempt_thread() 0
+#define irq_lock() 0
+#define irq_unlock(key) do {} while (0);
 #define RB_LOCK() do {} while (0)
 #define RB_UNLOCK() do {} while (0)
 #define CB_LOCK() do {} while (0)


### PR DESCRIPTION
It's not safe to be locking / unlocking mutexes from an ISR but we
were doing that because zjs_signal_callback is intended to be called
by ISRs. This was causing a hang in UART module after more careful
locking was added recently.

Fixes #1541

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>