### PR TITLE
[utils] Do not include __FILE__ macro in non debug builds

### DIFF
--- a/src/zjs_common.h
+++ b/src/zjs_common.h
@@ -72,8 +72,7 @@ int zjs_get_ms(void);
 #else  // !DEBUG_BUILD
 #define DBG_PRINT(fmt...) do {} while (0)
 #define ERR_PRINT                                                        \
-    ZJS_PRINT("\n%s:%d %s():\n(ERROR) ", zjs_shorten_filepath(__FILE__), \
-              __LINE__, __func__);                                       \
+    ZJS_PRINT("\n%d:(ERROR) ", __LINE__);                                \
     ZJS_PRINT
 #endif  // DEBUG_BUILD
 


### PR DESCRIPTION
Using __FILE__ macro in non debug code is increasing the
image size depending on where the sources are built, so
this patch removes that macro from the non debug code.

Fixes #1550

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>