### PR TITLE
[callbacks] Fixing a memory leak for callbacks

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -369,6 +369,7 @@ void zjs_remove_all_callbacks()
         CB_LOCK();
         if (cb_map[i]) {
             zjs_remove_callback_priv(i, skip_flush);
+            zjs_free_callback(i);
         }
         CB_UNLOCK();
     }

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -327,6 +327,12 @@ static void zjs_remove_callback_priv(zjs_callback_id id, bool skip_flush)
     // effects: removes the callback associated with id; if skip_flush is true,
     //            assumes the callback will be "flushed" elsewhere, that is
     //            freed and the id reclaimed; otherwise, tries to do it here
+
+    // Don't free a callback after its been freed
+    if (GET_CB_REMOVED(cb_map[id]->flags)) {
+        return;
+    }
+
     CB_LOCK();
     if (id >= 0 && cb_map[id]) {
         if (GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_JS) {
@@ -369,7 +375,6 @@ void zjs_remove_all_callbacks()
         CB_LOCK();
         if (cb_map[i]) {
             zjs_remove_callback_priv(i, skip_flush);
-            zjs_free_callback(i);
         }
         CB_UNLOCK();
     }

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -250,6 +250,7 @@ static void free_timer(zjs_timer_t *tm)
         jerry_release_value(tm->argv[i]);
     }
     zjs_port_timer_stop(&tm->timer);
+    zjs_remove_callback(tm->callback_id);
     zjs_free(tm->argv);
     zjs_free(tm);
 }

--- a/src/zjs_timers.c
+++ b/src/zjs_timers.c
@@ -250,7 +250,6 @@ static void free_timer(zjs_timer_t *tm)
         jerry_release_value(tm->argv[i]);
     }
     zjs_port_timer_stop(&tm->timer);
-    zjs_remove_callback(tm->callback_id);
     zjs_free(tm->argv);
     zjs_free(tm);
 }


### PR DESCRIPTION
Currently when zjs_timers_cleanup gets called, not all of the memory
in the callbacks is getting freed.  The ring buffer isn't being
freed before the javascript ends.  This change forces all the
memory to be freed when zjs_remove_all_callbacks gets called.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>