### PR TITLE
[ble] Fixed ble in Ashell

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -108,13 +108,8 @@ u8_t process_cmd_line(int argc, char *argv[])
 }
 #else
 #ifdef BUILD_MODULE_BLE
-#ifndef ZJS_ASHELL
-// INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or release prints!
-static void ble_bt_ready(int err)
-{
-    DBG_PRINT("bt_ready() is called [err %d]\n", err);
-    zjs_ble_emit_powered_event();
-}
+#ifndef BUILD_MODULE_OCF  // OCF will call bt_enable() itself
+extern void ble_bt_ready(int err);
 #endif
 #endif
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -108,14 +108,14 @@ u8_t process_cmd_line(int argc, char *argv[])
 }
 #else
 #ifdef BUILD_MODULE_BLE
+#ifndef ZJS_ASHELL
 // INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or release prints!
 static void ble_bt_ready(int err)
 {
     DBG_PRINT("bt_ready() is called [err %d]\n", err);
-#ifdef BUILD_MODULE_BLE
     zjs_ble_emit_powered_event();
-#endif
 }
+#endif
 #endif
 #endif
 
@@ -233,6 +233,7 @@ if (start_debug_server) {
     }
 
 #ifndef ZJS_LINUX_BUILD
+#ifndef ZJS_ASHELL  // Ashell will call bt_enable when module is loaded
 #ifndef BUILD_MODULE_OCF  // OCF will call bt_enable() itself
 #ifdef BUILD_MODULE_BLE
     if (bt_enable(ble_bt_ready)) {
@@ -248,6 +249,7 @@ if (start_debug_server) {
     ipss_init();
     ipss_advertise();
     net_ble_enabled = 1;
+#endif
 #endif
 #endif
 #endif

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -1288,14 +1288,12 @@ static ZJS_DECL_FUNC(zjs_ble_descriptor)
     return jerry_acquire_value(argv[0]);
 }
 
-#ifdef ZJS_ASHELL
 // INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or release prints!
-static void ble_bt_ready(int err)
+void ble_bt_ready(int err)
 {
     DBG_PRINT("bt_ready() is called [err %d]\n", err);
     zjs_ble_emit_powered_event();
 }
-#endif
 
 jerry_value_t zjs_ble_init()
 {

--- a/src/zjs_ble.c
+++ b/src/zjs_ble.c
@@ -582,6 +582,7 @@ static struct bt_conn_auth_cb zjs_ble_auth_cb_display = {
 void zjs_ble_emit_powered_event()
 {
     const char state[] = "poweredOn";
+    ZJS_ASSERT(ble_handle, "ble_handle not set");
     zjs_defer_emit_event(ble_handle->ble_obj, "stateChange", state,
                          sizeof(state), string_arg, zjs_release_args);
 }
@@ -1287,6 +1288,15 @@ static ZJS_DECL_FUNC(zjs_ble_descriptor)
     return jerry_acquire_value(argv[0]);
 }
 
+#ifdef ZJS_ASHELL
+// INTERRUPT SAFE FUNCTION: No JerryScript VM, allocs, or release prints!
+static void ble_bt_ready(int err)
+{
+    DBG_PRINT("bt_ready() is called [err %d]\n", err);
+    zjs_ble_emit_powered_event();
+}
+#endif
+
 jerry_value_t zjs_ble_init()
 {
     k_sem_init(&ble_sem, 0, 1);
@@ -1321,6 +1331,12 @@ jerry_value_t zjs_ble_init()
     bt_conn_auth_cb_register(&zjs_ble_auth_cb_display);
 
     ble_handle = handle;
+
+#ifdef ZJS_ASHELL
+    if (bt_enable(ble_bt_ready)) {
+        ERR_PRINT("Failed to enable Bluetooth and may not be enabled again, please reboot\n");
+    }
+#endif
     return ble_obj;
 }
 


### PR DESCRIPTION
This fixes the issue where bluetooth doesn't work in Ashell,
since when running in Ashell, bt_enable() cannot be called until
the Bluetooth module is initialized.  This also fixes the error message
showing up when IDE is launched.

Fixes #1502

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>