### PR TITLE
[linux] Fix linux port to allow for a zero timeout

### DIFF
--- a/src/zjs_linux_time.c
+++ b/src/zjs_linux_time.c
@@ -32,6 +32,13 @@ void zjs_port_timer_init(zjs_port_timer_t *timer, zjs_port_timer_cb cb)
 
 void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval, u32_t repeat)
 {
+    /*
+     * Signals require > 0 timeout, so if a zero timeout is passed we have to
+     * just set it to 1.
+     */
+    if (repeat == 0)
+        repeat++;
+
     uint32_t rsec = repeat / 1000;
     uint32_t rms = repeat - (rsec * 1000);
 


### PR DESCRIPTION
The new linux timer port uses signals as callbacks for
timers. The signal API expects a greater than zero timeout
so in the zero timeout case we pass 1.

Signed-off-by: James Prestwood <james.prestwood@intel.com>