### PR TITLE
[tests] Fix PWM test to use actual time values

### DIFF
--- a/tests/test-pwm.js
+++ b/tests/test-pwm.js
@@ -46,8 +46,7 @@ msTimer = setInterval(function () {
     } else {
         msFalse = msFalse + 1;
     }
-    // set 50 ms but 60 ms actually and time precision 20 ms for zephyr 1.6
-}, 50);
+}, 60);
 
 setTimeout(function () {
     // 16 = 0.33 < 0.3333 < 0.34 = 17
@@ -104,8 +103,7 @@ setTimeout(function () {
                clearInterval(cycleTimer);
            }
        }
-    // set 10 ms but 20 ms actually
-    }, 10);
+    }, 20);
 }, 3000);
 
 assert.throws(function () {


### PR DESCRIPTION
The recent timer patch made JS timers much more accurate.
The PWM test was relying on the old slow timers. Changing
the interval values to what they should actually be fixes
the test.

Signed-off-by: James Prestwood <james.prestwood@intel.com>