### PR TITLE
[ashell] Allow setting IDE_GPIO_PIN to enter IDE mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,14 @@ endif
 ifeq ($(shell test $(ROM) -gt 296; echo $$?), 0)
 $(error ROM must be no higher than 296)
 endif
+
+# IDE_GPIO_PIN has to be between 0 to 20
+ifeq ($(shell test $(IDE_GPIO_PIN) -lt 0; echo $$?), 0)
+$(error IDE_GPIO_PIN must be no lower than 0)
+endif
+ifeq ($(shell test $(IDE_GPIO_PIN) -gt 20; echo $$?), 0)
+$(error IDE_GPIO_PIN must be no higher than 20)
+endif
 endif  # BOARD = arduino_101
 
 ifeq ($(filter $(MAKECMDGOALS),linux), linux)
@@ -119,7 +127,7 @@ endif
 endif
 
 ifeq ($(FUNC_NAME), on)
-ZJS_FLAGS := "$(ZJS_FLAGS) -DZJS_FIND_FUNC_NAME"
+ZJS_FLAGS := $(ZJS_FLAGS) -DZJS_FIND_FUNC_NAME
 endif
 
 ifeq ($(FORCE),)
@@ -133,7 +141,10 @@ ifneq (,$(filter $(MAKECMDGOALS),ide ashell))
 ASHELL=zjs_ashell_$(ASHELL_TYPE).json
 FORCED := $(ASHELL),$(FORCED)
 ASHELL_ARC=zjs_ashell_arc.json
-ZJS_FLAGS := "$(ZJS_FLAGS) -DZJS_FIND_FUNC_NAME"
+ZJS_FLAGS += -DZJS_FIND_FUNC_NAME
+ifneq ($(IDE_GPIO_PIN),)
+ZJS_FLAGS += -DIDE_GPIO_PIN=$(IDE_GPIO_PIN)
+endif
 endif
 
 ifeq ($(BOARD), arduino_101)
@@ -194,7 +205,7 @@ ram_report: zephyr
 					CB_STATS=$(CB_STATS) \
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT) \
-					ZJS_FLAGS=$(ZJS_FLAGS) \
+					ZJS_FLAGS="$(ZJS_FLAGS)" \
 					ram_report
 
 .PHONY: rom_report
@@ -204,7 +215,7 @@ rom_report: zephyr
 					CB_STATS=$(CB_STATS) \
 					PRINT_FLOAT=$(PRINT_FLOAT) \
 					SNAPSHOT=$(SNAPSHOT) \
-					ZJS_FLAGS=$(ZJS_FLAGS) \
+					ZJS_FLAGS="$(ZJS_FLAGS)" \
 					rom_report
 
 # choose name of jerryscript library based on snapshot feature
@@ -238,7 +249,7 @@ zephyr: analyze generate $(JERRYLIB) $(ARC)
 					BLE_ADDR=$(BLE_ADDR) \
 					ASHELL=$(ASHELL) \
 					NETWORK_BUILD=$(NET_BUILD) \
-					ZJS_FLAGS=$(ZJS_FLAGS)
+					ZJS_FLAGS="$(ZJS_FLAGS)"
 ifeq ($(BOARD), arduino_101)
 	@echo
 	@echo -n Creating dfu images...
@@ -425,7 +436,7 @@ qemu: zephyr
 		CB_STATS=$(CB_STATS) \
 		SNAPSHOT=$(SNAPSHOT) \
 		NETWORK_BUILD=$(NET_BUILD) \
-		ZJS_FLAGS=$(ZJS_FLAGS)
+		ZJS_FLAGS="$(ZJS_FLAGS)"
 
 ARC_RESTRICT="zjs_ipm_arc.json,\
 		zjs_i2c_arc.json,\

--- a/src/ashell/file-utils.h
+++ b/src/ashell/file-utils.h
@@ -16,4 +16,5 @@ int fs_close_alloc(fs_file_t *fp);
 int fs_exist(const char *path);
 ssize_t fs_size(fs_file_t *file);
 bool fs_valid_filename(char *filename);
+int fs_get_boot_cfg_filename(const char *timestamp, char *filename);
 #endif  // __file_wrapper_h__

--- a/src/ashell/term-cmd.c
+++ b/src/ashell/term-cmd.c
@@ -941,38 +941,11 @@ s32_t ashell_help(char *buf)
 
 void ashell_run_boot_cfg()
 {
-    fs_file_t *file;
-    size_t count;
-    file = fs_open_alloc("boot.cfg", "r");
-    // Failed to open boot.cfg
-    if (!file) {
-        return;
-    }
+    char filename[MAX_FILENAME_SIZE];
 
-    size_t tssize = strlen(BUILD_TIMESTAMP);
-    ssize_t size = fs_size(file);
-    // Check that there is something after the timestamp
-    if (size > tssize) {
-        char ts[tssize];
-        count = fs_read(file, ts, tssize);
-        if (count == tssize && strncmp(ts, BUILD_TIMESTAMP, tssize) == 0) {
-            size_t filenamesize = size - tssize;
-            char filename[filenamesize + 1];
-            count = fs_read(file, filename, filenamesize);
-
-            if (count > 0) {
-                filename[filenamesize] = '\0';
-                ashell_run_javascript(filename);
-            }
-        } else {
-            // This is a newly flashed board, delete boot.cfg
-            ashell_remove_file("boot.cfg");
-        }
-    } else {
-        // boot.cfg is invalid, remove it
-        ashell_remove_file("boot.cfg");
+    if (fs_get_boot_cfg_filename(BUILD_TIMESTAMP, filename) == 0) {
+        ashell_run_javascript(filename);
     }
-    fs_close_alloc(file);
 }
 
 s32_t ashell_main_state(char *buf, u32_t len)

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,10 @@
 #include "zjs_script.h"
 #include "zjs_util.h"
 #ifdef ZJS_ASHELL
+#include <gpio.h>
+#include "zjs_board.h"
 #include "ashell/ashell.h"
+#include "ashell/file-utils.h"
 #endif
 
 // JerryScript includes
@@ -59,6 +62,11 @@ const size_t snapshot_len = sizeof(snapshot_bytecode);
 const char script_jscode[] = {
 #include "zjs_script_gen.h"
 };
+#endif
+
+#ifdef ZJS_ASHELL
+const char *BUILD_TIME_STAMP = __DATE__ " " __TIME__ "\n";
+static bool ashell_mode = false;
 #endif
 
 #ifdef ZJS_DEBUGGER
@@ -114,6 +122,51 @@ extern void ble_bt_ready(int err);
 #endif
 #endif
 
+#ifdef ZJS_ASHELL
+static bool config_mode_detected()
+{
+    // connect a button to GPIO pin IO8
+#ifdef IDE_GPIO_PIN
+    char devname[20];
+    int pin;
+
+    ZVAL pin_val = jerry_create_number(IDE_GPIO_PIN);
+    int rval = zjs_board_find_pin(pin_val, devname, &pin);
+    if (rval == FIND_PIN_INVALID) {
+        ERR_PRINT("bad pin argument");
+        return false;
+    }
+
+    struct device *gpiodev = device_get_binding(devname);
+    if (!gpiodev) {
+        ERR_PRINT("GPIO device not found\n");
+        return false;
+    }
+
+    int flags = 0;
+    flags |= GPIO_POL_INV | GPIO_DIR_IN;
+    rval = gpio_pin_configure(gpiodev, pin, flags);
+    if (rval) {
+        ERR_PRINT("invalid GPIO pin %d\n", pin);
+        return false;
+    }
+
+    u32_t value;
+    rval = gpio_pin_read(gpiodev, pin, &value);
+    if (rval) {
+        ERR_PRINT("gpio read failed\n");
+        return false;
+    }
+
+    return (value == 1);
+#else
+    // always enter IDE mode when IDE_GPIO_PIN is not specified
+    DBG_PRINT("IDE_GPIO_PIN not set\n");
+    return true;
+#endif
+}
+#endif
+
 #ifndef ZJS_LINUX_BUILD
 void main(void)
 #else
@@ -127,11 +180,13 @@ int main(int argc, char *argv[])
     char *script = NULL;
     file_name = argv[1];
     file_name_len = strlen(argv[1]);
+#elif defined ZJS_ASHELL
+    char *script = NULL;
 #else
     const char *script = NULL;
 #endif
     jerry_value_t code_eval;
-    u32_t script_len;
+    u32_t script_len = 0;
 #endif
 #ifndef ZJS_LINUX_BUILD
     DBG_PRINT("Main Thread ID: %p\n", (void *)k_current_get());
@@ -158,6 +213,59 @@ int main(int argc, char *argv[])
     zjs_register_service_routine(NULL, main_poll_routine);
 #endif
 
+#ifdef ZJS_ASHELL
+if (config_mode_detected()) {
+    // go into IDE mode if connected GPIO button is pressed
+    ashell_mode = true;
+} else {
+    // boot to cfg file if found
+    fs_file_t *file;
+    size_t count;
+    file = fs_open_alloc("boot.cfg", "r");
+
+    if (file) {
+        DBG_PRINT("JS boot config found, booting JS...\n\n\n");
+        size_t ts_len = strlen(BUILD_TIME_STAMP);
+        ssize_t size = fs_size(file);
+        // Check that there is something after the timestamp
+        if (size > ts_len) {
+            file_name_len = size - ts_len;
+            char ts[ts_len];
+            char filename[file_name_len + 1];
+            count = fs_read(file, ts, ts_len); // skip the timestamp
+            count = fs_read(file, filename, file_name_len);
+            if (count > 0) {
+                filename[file_name_len] = '\0';
+                DBG_PRINT("running JS %s\n", filename);
+                // read JS stored in filesystem
+                fs_file_t *js_file = fs_open_alloc(filename, "r");
+                if (!js_file) {
+                    ZJS_PRINT("\nFile %s not found on filesystem, exiting!\n",
+                              filename);
+                    fs_close_alloc(file);
+                    goto error;
+                }
+                script_len = fs_size(js_file);
+                script = zjs_malloc(script_len + 1);
+                count = fs_read(js_file, script, script_len);
+                if (script_len != count) {
+                    ZJS_PRINT("\nfailed to read JS file\n");
+                    zjs_free(script);
+                    fs_close_alloc(file);
+                    goto error;
+                }
+                script[script_len] = '\0';
+            }
+        }
+        fs_close_alloc(file);
+    } else {
+        // boot cfg file not found
+        ZJS_PRINT("\nNo JS found, please boot into IDE mode, exiting!\n");
+        goto error;
+    }
+}
+#endif
+
 #ifndef ZJS_SNAPSHOT_BUILD
 #ifdef ZJS_LINUX_BUILD
     if (argc > 1) {
@@ -173,13 +281,15 @@ int main(int argc, char *argv[])
     // slightly tricky: reuse next section as else clause
 #endif
     {
-        script_len = strnlen(script_jscode, MAX_SCRIPT_SIZE);
 #ifdef ZJS_LINUX_BUILD
         script = zjs_malloc(script_len + 1);
         memcpy(script, script_jscode, script_len);
         script[script_len] = '\0';
 #else
+#ifndef ZJS_ASHELL
+        script_len = strnlen(script_jscode, MAX_SCRIPT_SIZE);
         script = script_jscode;
+#endif
 #endif
         if (script_len == MAX_SCRIPT_SIZE) {
             ERR_PRINT("Script size too large! Increase MAX_SCRIPT_SIZE.\n");
@@ -261,11 +371,16 @@ if (start_debug_server) {
     u8_t last_serviced = 1;
 #endif
 #ifdef ZJS_ASHELL
-    zjs_ashell_init();
+    if (ashell_mode) {
+        DBG_PRINT("Config mode detected, booting into the IDE...\n\n\n");
+        zjs_ashell_init();
+    }
 #endif
     while (1) {
 #ifdef ZJS_ASHELL
-        zjs_ashell_process();
+        if (ashell_mode) {
+            zjs_ashell_process();
+        }
 #endif
         s32_t wait_time = ZJS_TICKS_FOREVER;
         u8_t serviced = 0;


### PR DESCRIPTION
If you building the IDE by passing IDE_GPIO_PIN to configure
the board to only boot into IDE mode only if a button press is detected

For example:
make ide IDE_GPIO_PIN=8

This will build the IDE so that if a button is connected to IO8
on the board using GPIO and it's holded down when the Arduino 101
is booting, it will then boot into ASHELL/IDE mode, otherwise
it will look for the boot.cfg file and boots the file.

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>