### PR TITLE
 [timers] Revert patch #1542 for linux timers

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -45,7 +45,7 @@ JERRY_LIBS += 		-l jerry-core -lm
 
 JERRY_LIB_PATH += 	-L $(JERRY_BASE)/build/lib/
 
-LINUX_LIBS +=		$(JERRY_LIBS) -lrt
+LINUX_LIBS +=		$(JERRY_LIBS)
 
 ifeq ($(shell uname -s), Linux)
 LINUX_LIBS +=		-pthread

--- a/src/main.c
+++ b/src/main.c
@@ -277,7 +277,17 @@ if (start_debug_server) {
             // FIXME: need to consider the chicken and egg problems here
             serviced = 1;
         }
+#ifdef ZJS_LINUX_BUILD
+	// FIXME - reverted patch #1542 to old timer implementation
+        u64_t wait = zjs_timers_process_events();
+        if (wait != ZJS_TICKS_FOREVER) {
+            serviced = 1;
+            wait_time = (wait < wait_time) ? wait : wait_time;
+        }
+        wait = zjs_service_routines();
+#else
         u64_t wait = zjs_service_routines();
+#endif
         if (wait != ZJS_TICKS_FOREVER) {
             serviced = 1;
             wait_time = (wait < wait_time) ? wait : wait_time;

--- a/src/zjs_common.c
+++ b/src/zjs_common.c
@@ -27,49 +27,22 @@ char *zjs_shorten_filepath(char *filepath)
 }
 
 #ifdef DEBUG_BUILD
-#ifdef ZJS_LINUX_BUILD
-#include <time.h>
-
-static u8_t init = 0;
-static int seconds = 0;
-#else
 static int start = 0;
-#endif
 
 int zjs_get_sec(void)
 {
-#ifdef ZJS_LINUX_BUILD
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    if (!init) {
-        seconds = now.tv_sec;
-        init = 1;
-    }
-    return now.tv_sec - seconds;
-#else
     if (!start) {
         start = zjs_port_timer_get_uptime() / 1000;
     }
     return (zjs_port_timer_get_uptime() / 1000) - start;
-#endif
 }
 
 int zjs_get_ms(void)
 {
-#ifdef ZJS_LINUX_BUILD
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    if (!init) {
-        seconds = now.tv_sec;
-        init = 1;
-    }
-    return (now.tv_nsec / 1000000);
-#else
     if (!start) {
         start = zjs_port_timer_get_uptime() / 1000;
     }
     return zjs_port_timer_get_uptime() - (zjs_get_sec() * 1000);
-#endif
 }
 
 #endif  // DEBUG_BUILD

--- a/src/zjs_common.c
+++ b/src/zjs_common.c
@@ -27,23 +27,49 @@ char *zjs_shorten_filepath(char *filepath)
 }
 
 #ifdef DEBUG_BUILD
+#ifdef ZJS_LINUX_BUILD
+#include <time.h>
 
+static u8_t init = 0;
+static int seconds = 0;
+#else
 static int start = 0;
+#endif
 
 int zjs_get_sec(void)
 {
+#ifdef ZJS_LINUX_BUILD
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    if (!init) {
+        seconds = now.tv_sec;
+        init = 1;
+    }
+    return now.tv_sec - seconds;
+#else
     if (!start) {
         start = zjs_port_timer_get_uptime() / 1000;
     }
     return (zjs_port_timer_get_uptime() / 1000) - start;
+#endif
 }
 
 int zjs_get_ms(void)
 {
+#ifdef ZJS_LINUX_BUILD
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    if (!init) {
+        seconds = now.tv_sec;
+        init = 1;
+    }
+    return (now.tv_nsec / 1000000);
+#else
     if (!start) {
         start = zjs_port_timer_get_uptime() / 1000;
     }
     return zjs_port_timer_get_uptime() - (zjs_get_sec() * 1000);
+#endif
 }
 
 #endif  // DEBUG_BUILD

--- a/src/zjs_linux_port.h
+++ b/src/zjs_linux_port.h
@@ -6,7 +6,6 @@
 // C includes
 #include <stdint.h>
 #include <time.h>
-#include <signal.h>
 #include <unistd.h>
 
 // define Zephyr numeric types we use
@@ -19,25 +18,21 @@ typedef uint32_t u32_t;
 typedef int64_t s64_t;
 typedef uint64_t u64_t;
 
-struct zjs_port_timer;
-
-typedef void (*zjs_port_timer_cb)(struct zjs_port_timer *handle);
-
+// FIXME - reverted patch #1542 to old timer implementation
 typedef struct zjs_port_timer {
-    void *user_data;
-    uint8_t repeat;
-    struct sigevent se;
-    struct itimerspec ti;
-    struct sigaction sa;
-    timer_t time;
-    zjs_port_timer_cb callback;
+    u32_t sec;
+    u32_t milli;
+    u32_t interval;
+    void *data;
 } zjs_port_timer_t;
 
-void zjs_port_timer_init(zjs_port_timer_t *timer, zjs_port_timer_cb cb);
+#define zjs_port_timer_init(t, cb) do {} while (0)
 
 void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval, u32_t repeat);
 
 void zjs_port_timer_stop(zjs_port_timer_t *timer);
+
+u8_t zjs_port_timer_test(zjs_port_timer_t *timer);
 
 u32_t zjs_port_timer_get_uptime(void);
 

--- a/src/zjs_linux_time.c
+++ b/src/zjs_linux_time.c
@@ -2,61 +2,40 @@
 
 // C includes
 #include <time.h>
-#include <signal.h>
-#include <stdio.h>
 
 // ZJS includes
 #include "zjs_linux_port.h"
 
 #define ZEPHYR_TICKS_PER_SEC
 
-static void timer_signal(int signal, siginfo_t *info, void *oldaction)
-{
-    zjs_port_timer_t *timer = info->si_value.sival_ptr;
-    timer->callback(timer);
-}
-
-void zjs_port_timer_init(zjs_port_timer_t *timer, zjs_port_timer_cb cb)
-{
-    timer->sa.sa_sigaction = timer_signal;
-    timer->sa.sa_flags = SA_SIGINFO;
-    sigemptyset(&timer->sa.sa_mask);
-    sigaction(SIGRTMIN, &timer->sa, NULL);
-
-    timer->callback = cb;
-    timer->se.sigev_signo = SIGRTMIN;
-    timer->se.sigev_notify = SIGEV_SIGNAL;
-    timer->se.sigev_value.sival_ptr = timer;
-    timer_create(CLOCK_REALTIME, &timer->se, &timer->time);
-}
-
 void zjs_port_timer_start(zjs_port_timer_t *timer, u32_t interval, u32_t repeat)
 {
-    /*
-     * Signals require > 0 timeout, so if a zero timeout is passed we have to
-     * just set it to 1.
-     */
-    if (repeat == 0)
-        repeat++;
-
-    uint32_t rsec = repeat / 1000;
-    uint32_t rms = repeat - (rsec * 1000);
-
-    timer->ti.it_interval.tv_sec = rsec;
-    timer->ti.it_interval.tv_nsec = rms * 1000000;
-    timer->ti.it_value.tv_sec = rsec;
-    timer->ti.it_value.tv_nsec = rms * 1000000;
-
-    timer_settime(timer->time, 0, &timer->ti, NULL);
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    timer->sec = now.tv_sec;
+    timer->milli = now.tv_nsec / 1000000;
+    timer->interval = interval;
 }
 
 void zjs_port_timer_stop(zjs_port_timer_t *timer)
 {
-    timer->ti.it_interval.tv_sec = 0;
-    timer->ti.it_interval.tv_nsec = 0;
-    timer->ti.it_value.tv_sec = 0;
-    timer->ti.it_value.tv_nsec = 0;
-    timer_settime(timer->time, 0, &timer->ti, NULL);
+    timer->interval = 0;
+}
+
+u8_t zjs_port_timer_test(zjs_port_timer_t *timer)
+{
+    u32_t elapsed;
+    struct timespec now;
+
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    elapsed = (1000 * (now.tv_sec - timer->sec)) +
+              ((now.tv_nsec / 1000000) - timer->milli);
+
+    if (elapsed >= timer->interval) {
+        return elapsed;
+    }
+    return 0;
 }
 
 u32_t zjs_port_timer_get_uptime(void)

--- a/src/zjs_util.h
+++ b/src/zjs_util.h
@@ -70,24 +70,24 @@ void zjs_pop_mem_stat(void *ptr);
 #else
 #include <zephyr.h>
 #ifdef ZJS_TRACE_MALLOC
-#define zjs_malloc(sz)                                                          \
-    ({                                                                          \
-        void *zjs_ptr = zjs_malloc_with_retry(sz);                              \
-        ZJS_PRINT("%s:%d: allocating %u bytes (%p)\n", __func__, __LINE__,      \
-                  (u32_t)sz, zjs_ptr);                                          \
-        zjs_push_mem_stat(zjs_ptr, __FILE__, __func__, __LINE__);               \
-        zjs_ptr;                                                                \
+#define zjs_malloc(sz)                                                      \
+    ({                                                                      \
+        void *zjs_ptr = zjs_malloc_with_retry(sz);                          \
+        ZJS_PRINT("%s:%d: allocating %u bytes (%p)\n", __func__, __LINE__,  \
+                  (u32_t)(sz), zjs_ptr);                                    \
+        zjs_push_mem_stat(zjs_ptr, __FILE__, __func__, __LINE__);           \
+        zjs_ptr;                                                            \
     })
 #define zjs_free(ptr) \
     (ZJS_PRINT("%s:%d: freeing %p\n", __func__, __LINE__, ptr), zjs_pop_mem_stat(ptr), free(ptr))
 #else
-#define zjs_malloc(sz)                             \
-    ({                                             \
-        void *zjs_ptr = zjs_malloc_with_retry(sz); \
-        if (!zjs_ptr) {                            \
-            ERR_PRINT("malloc(%d) failed\n", sz);  \
-        }                                          \
-        zjs_ptr;                                   \
+#define zjs_malloc(sz)                                      \
+    ({                                                      \
+        void *zjs_ptr = zjs_malloc_with_retry(sz);          \
+        if (!zjs_ptr) {                                     \
+            ERR_PRINT("malloc(%u) failed\n", (u32_t)(sz));  \
+        }                                                   \
+        zjs_ptr;                                            \
     })
 #define zjs_free(ptr) free(ptr)
 #endif  // ZJS_TRACE_MALLOC


### PR DESCRIPTION
The new timer patch #1542 uses librt which doesn't build on MacOS,
this patch revert linux builds to previous old timer
implementation for compatibility and adds a FIXME for all the places
the patch was reverted.  We need to find a way to add a cross-platform
implementation for timers that will work on both Linux and MacOS.

Fixes #1579