### PR TITLE
[callback] Fixed crash when removing callback with id -1

### DIFF
--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -331,6 +331,7 @@ static void zjs_remove_callback_priv(zjs_callback_id id, bool skip_flush)
     if (id >= 0 && cb_map[id]) {
         // Don't free a callback after its been freed
         if (GET_CB_REMOVED(cb_map[id]->flags)) {
+            CB_UNLOCK();
             return;
         }
 

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -327,18 +327,13 @@ static void zjs_remove_callback_priv(zjs_callback_id id, bool skip_flush)
     // effects: removes the callback associated with id; if skip_flush is true,
     //            assumes the callback will be "flushed" elsewhere, that is
     //            freed and the id reclaimed; otherwise, tries to do it here
-
-    if (id < 0) {
-        return;
-    }
-
-    // Don't free a callback after its been freed
-    if (GET_CB_REMOVED(cb_map[id]->flags)) {
-        return;
-    }
-
     CB_LOCK();
     if (id >= 0 && cb_map[id]) {
+        // Don't free a callback after its been freed
+        if (GET_CB_REMOVED(cb_map[id]->flags)) {
+            return;
+        }
+
         if (GET_TYPE(cb_map[id]->flags) == CALLBACK_TYPE_JS) {
             jerry_release_value(cb_map[id]->js_func);
             jerry_release_value(cb_map[id]->this);

--- a/src/zjs_callbacks.c
+++ b/src/zjs_callbacks.c
@@ -328,6 +328,10 @@ static void zjs_remove_callback_priv(zjs_callback_id id, bool skip_flush)
     //            assumes the callback will be "flushed" elsewhere, that is
     //            freed and the id reclaimed; otherwise, tries to do it here
 
+    if (id < 0) {
+        return;
+    }
+
     // Don't free a callback after its been freed
     if (GET_CB_REMOVED(cb_map[id]->flags)) {
         return;


### PR DESCRIPTION
There's no check on callback id when calling zjs_remove_callback(),
this will cause a segfault when callback id has not been set or
has a negative value.

Fixes #1593

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>