### PR TITLE
[ble] Updated Zephyr net config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,15 +299,15 @@ analyze: $(JS)
 	@# Add bluetooth debug configs if BLE is enabled
 	@if grep -q BUILD_MODULE_BLE src/Makefile; then \
 		if [ "$(VARIANT)" = "debug" ]; then \
-			echo "CONFIG_BLUETOOTH_DEBUG_LOG=y" >> prj.conf; \
+			echo "CONFIG_BT_DEBUG_LOG=y" >> prj.conf; \
 		fi \
 	fi
 
 	@if grep -q BUILD_MODULE_OCF src/Makefile; then \
-		echo "CONFIG_BLUETOOTH_DEVICE_NAME=\"$(DEVICE_NAME)\"" >> prj.conf; \
+		echo "CONFIG_BT_DEVICE_NAME=\"$(DEVICE_NAME)\"" >> prj.conf; \
 	fi
 	@if grep -q BUILD_MODULE_DGRAM src/Makefile; then \
-		echo "CONFIG_BLUETOOTH_DEVICE_NAME=\"$(DEVICE_NAME)\"" >> prj.conf; \
+		echo "CONFIG_BT_DEVICE_NAME=\"$(DEVICE_NAME)\"" >> prj.conf; \
 	fi
 	@if [ -e outdir/$(BOARD)/jerry_feature.profile.bak ]; then \
 		if ! cmp outdir/$(BOARD)/jerry_feature.profile.bak outdir/$(BOARD)/jerry_feature.profile; \

--- a/src/main.c
+++ b/src/main.c
@@ -7,9 +7,9 @@
 // Zephyr includes
 #include "zjs_zephyr_port.h"
 #include <zephyr.h>
-#if defined(BUILD_MODULE_BLE) || (CONFIG_NET_L2_BLUETOOTH)
+#if defined(BUILD_MODULE_BLE) || (CONFIG_NET_L2_BT)
 #include <bluetooth/bluetooth.h>
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
 #include <bluetooth/storage.h>
 #include <gatt/ipss.h>
 #include "zjs_net_config.h"
@@ -236,7 +236,7 @@ if (start_debug_server) {
        goto error;
     }
 #endif
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
     if (bt_enable(NULL)) {
        ERR_PRINT("Failed to enable Bluetooth\n");
        goto error;

--- a/src/zjs_dgram.c
+++ b/src/zjs_dgram.c
@@ -6,7 +6,7 @@
 #include <net/net_context.h>
 #include <net/net_pkt.h>
 #include <net/udp.h>
-#if defined(CONFIG_NET_L2_BLUETOOTH)
+#if defined(CONFIG_NET_L2_BT)
 #include <bluetooth/bluetooth.h>
 #endif
 

--- a/src/zjs_net_config.c
+++ b/src/zjs_net_config.c
@@ -12,7 +12,7 @@ static char FTRACE_PREFIX[] = "net";
 #include <net/net_context.h>
 #endif
 
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/storage.h>
 #include <gatt/ipss.h>
@@ -26,7 +26,7 @@ static char FTRACE_PREFIX[] = "net";
 #ifndef BUILD_MODULE_NET_CONFIG
 static u8_t net_enabled = 0;
 #endif
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
 u8_t net_ble_enabled = 0;
 #endif
 
@@ -37,7 +37,7 @@ void zjs_net_config_default(void)
      */
     FTRACE("\n");
 #ifndef BUILD_MODULE_NET_CONFIG
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
     if (!net_ble_enabled) {
         zjs_init_ble_address();
     }
@@ -99,7 +99,7 @@ int zjs_is_ip(char *addr)
     }
 }
 
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
 static bt_addr_le_t id_addr;
 #ifdef ZJS_CONFIG_BLE_ADDRESS
 static char default_ble[18] = ZJS_CONFIG_BLE_ADDRESS;
@@ -271,7 +271,7 @@ static ZJS_DECL_FUNC(dhcp)
 }
 #endif
 
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
 static ZJS_DECL_FUNC(set_ble_address)
 {
 #ifndef ZJS_CONFIG_BLE_ADDRESS
@@ -356,7 +356,7 @@ jerry_value_t zjs_net_config_init(void)
 #ifdef CONFIG_NET_DHCPV4
     zjs_obj_add_function(config, "dhcp", dhcp);
 #endif
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
     zjs_obj_add_function(config, "setBleAddress", set_ble_address);
 #endif
     zjs_make_emitter(config, ZJS_UNDEFINED, NULL, NULL);
@@ -371,7 +371,7 @@ jerry_value_t zjs_net_config_init(void)
             NET_EVENT_IF_UP | NET_EVENT_IF_DOWN);
     net_mgmt_add_event_callback(&cb);
 
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
     if (!net_ble_enabled) {
         zjs_init_ble_address();
     }

--- a/src/zjs_net_config.h
+++ b/src/zjs_net_config.h
@@ -5,7 +5,7 @@
 #ifndef ZJS_LINUX_BUILD
 #include <net/net_context.h>
 
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
 extern u8_t net_ble_enabled;
 #endif
 #endif

--- a/src/zjs_net_l2_bluetooth.json
+++ b/src/zjs_net_l2_bluetooth.json
@@ -12,8 +12,8 @@
             "CONFIG_BT_L2CAP_DYNAMIC_CHANNEL=y",
             "CONFIG_NETWORKING_WITH_6LOWPAN=y",
             "CONFIG_6LOWPAN_COMPRESSION_IPHC=y",
-            "CONFIG_NET_L2_BLUETOOTH_ZEP1656=y",
-            "CONFIG_NET_L2_BLUETOOTH=y"
+            "CONFIG_NET_L2_BT_ZEP1656=y",
+            "CONFIG_NET_L2_BT=y"
         ]
     },
     "src": ["../deps/zephyr/samples/bluetooth/gatt/ipss.c"],

--- a/src/zjs_ocf_common.c
+++ b/src/zjs_ocf_common.c
@@ -526,7 +526,7 @@ jerry_value_t zjs_ocf_init()
 #endif
 
 #ifndef ZJS_LINUX_BUILD
-#if defined(CONFIG_NET_L2_BLUETOOTH)
+#if defined(CONFIG_NET_L2_BT)
     // init BLE address
     zjs_init_ble_address();
 #endif

--- a/src/zjs_web_sockets.c
+++ b/src/zjs_web_sockets.c
@@ -21,7 +21,7 @@ static char FTRACE_PREFIX[] = "net";
 #include <net/net_mgmt.h>
 #include <net/net_pkt.h>
 
-#ifdef CONFIG_NET_L2_BLUETOOTH
+#ifdef CONFIG_NET_L2_BT
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
 #endif


### PR DESCRIPTION
Zephyr 1.9 has renamed all _BLUETOOTH configs to _BT

Fixes #1598

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>