### PR TITLE
[samples] Making the timer longer for I2CBMP280.js

### DIFF
--- a/samples/I2CBMP280.js
+++ b/samples/I2CBMP280.js
@@ -130,4 +130,4 @@ glcdInit();
 
 /* Loop read forever */
 
-var timer = setInterval(readTemperature, 10);
+var timer = setInterval(readTemperature, 200);


### PR DESCRIPTION
The current timer is too fast, and it gets called multiple times
before the first call gets serviced. Increasing the time allows
the CB to get serviced befor the next interval hits.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>