### PR TITLE
[bluetooth] Fixed IP over Bluetooth issues

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -107,8 +107,8 @@ u8_t process_cmd_line(int argc, char *argv[])
     return 1;
 }
 #else
+#ifndef CONFIG_NET_APP_AUTO_INIT
 #ifdef BUILD_MODULE_BLE
-#ifndef BUILD_MODULE_OCF  // OCF will call bt_enable() itself
 extern void ble_bt_ready(int err);
 #endif
 #endif
@@ -229,22 +229,24 @@ if (start_debug_server) {
 
 #ifndef ZJS_LINUX_BUILD
 #ifndef ZJS_ASHELL  // Ashell will call bt_enable when module is loaded
-#ifndef BUILD_MODULE_OCF  // OCF will call bt_enable() itself
+
+#ifndef CONFIG_NET_APP_AUTO_INIT  // net_app will call bt_enable() itself
+    int err = 0;
 #ifdef BUILD_MODULE_BLE
-    if (bt_enable(ble_bt_ready)) {
-       ERR_PRINT("Failed to enable Bluetooth\n");
+    err = bt_enable(ble_bt_ready);
+#elif CONFIG_NET_L2_BT
+    err = bt_enable(NULL);
+#endif
+    if (err) {
+       ERR_PRINT("Failed to enable Bluetooth, error %d\n", err);
        goto error;
     }
 #endif
+
 #ifdef CONFIG_NET_L2_BT
-    if (bt_enable(NULL)) {
-       ERR_PRINT("Failed to enable Bluetooth\n");
-       goto error;
-    }
     ipss_init();
     ipss_advertise();
     net_ble_enabled = 1;
-#endif
 #endif
 #endif
 #endif

--- a/src/zjs_net_l2_bluetooth.json
+++ b/src/zjs_net_l2_bluetooth.json
@@ -7,13 +7,14 @@
         "arduino_101": [
             "CONFIG_BT=y",
             "CONFIG_BT_SMP=y",
-            "CONFIG_BT_SIGNING=y",
             "CONFIG_BT_PERIPHERAL=y",
             "CONFIG_BT_L2CAP_DYNAMIC_CHANNEL=y",
-            "CONFIG_NETWORKING_WITH_6LOWPAN=y",
-            "CONFIG_6LOWPAN_COMPRESSION_IPHC=y",
             "CONFIG_NET_L2_BT_ZEP1656=y",
-            "CONFIG_NET_L2_BT=y"
+            "CONFIG_NET_L2_BT=y",
+            "CONFIG_NET_APP_SETTINGS=y",
+            "CONFIG_NET_APP_MY_IPV6_ADDR=\"2001:db8::1\"",
+            "CONFIG_NET_APP_PEER_IPV6_ADDR=\"2001:db8::2\"",
+            "CONFIG_NET_APP_AUTO_INIT=n"
         ]
     },
     "src": ["../deps/zephyr/samples/bluetooth/gatt/ipss.c"],


### PR DESCRIPTION
Zephyr IP over Bluetooth now uses net_app configs
for configuring 6lowpan, and net_app will by
default call bt_enable() when initilized, so
we also need to unset CONFIG_NET_APP_AUTO_INIT
so that we can call bt_enable()

Fixes #1599

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>