### PR TITLE
[build] Disable LTO for JerryScript to prevent ar warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,6 @@ endif
 endif
 
 ifeq ($(BOARD), arduino_101)
-ifneq ($(OS), Darwin)
-EXT_JERRY_FLAGS += -DENABLE_LTO=ON
-endif
-$(info makecmd: $(MAKECMDGOALS))
 ifeq ($(MAKECMDGOALS),)
 TARGETS=all
 else


### PR DESCRIPTION
Not sure if these are going to cause a problem, but apparently Zephyr
doesn't use LTO now so we're better off making things match I expect.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>