### PR TITLE
[ashell] Boot cfg should start after terminal started

### DIFF
--- a/src/ashell/term-cmd.c
+++ b/src/ashell/term-cmd.c
@@ -1156,6 +1156,8 @@ ansi_cmd:
 u32_t terminal_init()
 {
     DBG("[SHELL] Init\n");
+    ashell_run_boot_cfg();
+
     return 0;
 }
 

--- a/src/ashell/term-uart.c
+++ b/src/ashell/term-uart.c
@@ -461,8 +461,6 @@ void uart_init()
 
     k_fifo_init(&data_queue);
     k_fifo_init(&avail_queue);
-
-    ashell_run_boot_cfg();
 }
 
 void zjs_ashell_init()


### PR DESCRIPTION
Currently when the JS is run before ternminal is started
and callbacks starts before it can get printed, thus
queuing up the message queue.  Moving it to be run
after terminal is started.

Fixes #1644

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>