### PR TITLE
[build] Allow outdir to be specified with O=

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -7,7 +7,7 @@ endif
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 OCF_ROOT ?= deps/iotivity-constrained
 
-BUILD_DIR = $(ZJS_BASE)/outdir/linux/$(VARIANT)
+BUILD_DIR = $(O)/linux/$(VARIANT)
 
 UNAME := $(shell uname)
 
@@ -37,7 +37,7 @@ CORE_SRC +=	src/zjs_a101_pins.c \
 CORE_OBJ =	$(CORE_SRC:%.c=%.o)
 
 LINUX_INCLUDES += 	-Isrc/ \
-			-I$(ZJS_BASE)/outdir/include \
+			-I$(O)/include \
 			-I$(JERRY_BASE)/jerry-core/include \
 			-I$(JERRY_BASE)/jerry-ext/include \
 			-I$(JERRY_BASE)/jerry-core/jrt
@@ -137,7 +137,7 @@ LINUX_INCLUDES += 	-I$(OCF_ROOT)/deps/tinydtls \
 			-I$(OCF_ROOT)/messaging/coap \
 			-I$(OCF_ROOT)/api \
 			-include $(ZJS_BASE)/src/zjs_ocf_config.h \
-			-Ioutdir/include
+			-I$(O)/include
 
 include Makefile.ocf_linux
 
@@ -172,5 +172,5 @@ linux: setup $(BUILD_OBJ)
 
 .PHONY: clean
 clean:
-	rm -rf $(ZJS_BASE)/outdir/linux/
+	rm -rf $(O)/linux/
 	rm -rf $(JERRY_BASE)/build/lib/

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -7,7 +7,7 @@ endif
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 OCF_ROOT ?= deps/iotivity-constrained
 
-BUILD_DIR = $(O)/linux/$(VARIANT)
+BUILD_DIR = $(O)/$(VARIANT)
 
 UNAME := $(shell uname)
 
@@ -137,7 +137,7 @@ LINUX_INCLUDES += 	-I$(OCF_ROOT)/deps/tinydtls \
 			-I$(OCF_ROOT)/messaging/coap \
 			-I$(OCF_ROOT)/api \
 			-include $(ZJS_BASE)/src/zjs_ocf_config.h \
-			-I$(O)/include
+			-I$(O)/../include
 
 include Makefile.ocf_linux
 
@@ -172,5 +172,5 @@ linux: setup $(BUILD_OBJ)
 
 .PHONY: clean
 clean:
-	rm -rf $(O)/linux/
+	rm -rf $(O)
 	rm -rf $(JERRY_BASE)/build/lib/

--- a/scripts/analyze
+++ b/scripts/analyze
@@ -20,6 +20,7 @@ def usage():
     print("      FORCE=      Force inclusion of certain JSON files")
     print("      PROFILE=    Where to write the JerryScript profile")
     print("      JS_OUT=     Output file if any JS modules are found in SCRIPT")
+    print("      O=          Output directory")
     quit()
 
 args = {}
@@ -54,6 +55,11 @@ if 'SCRIPT' not in args:
 else:
     script = args['SCRIPT']
     print("Analyzing %s for %s" % (script, board))
+
+if 'O' not in args:
+    outdir = 'outdir'
+else:
+    outdir = args['O']
 
 def do_print(s):
     """Debug print controlled with V option"""
@@ -338,7 +344,8 @@ def write_modules(list, tree):
     """Write zjs_modules_gen.h file"""
     headers = []
     gbl_inits = {}
-    with open('outdir/include/zjs_modules_gen.h', 'w') as file:
+    with open(os.path.join(outdir, 'include/zjs_modules_gen.h'),
+              'w') as file:
         for i in list:
             entry = tree.get(i, None)
             if entry:

--- a/src/Makefile.base
+++ b/src/Makefile.base
@@ -19,7 +19,7 @@ ccflags-y += -I$(JERRY_BASE)/jerry-core/include
 ccflags-y += -I$(JERRY_BASE)/jerry-core/jrt
 ccflags-y += -I$(JERRY_BASE)/jerry-ext/include
 ccflags-y += -I$(ZEPHYR_BASE)/drivers
-ccflags-y += -I$(ZJS_BASE)/outdir/include
+ccflags-y += -I$(O)/../include
 
 ifeq ($(VARIANT), debug)
 ccflags-y += -DDEBUG_BUILD

--- a/src/ashell/Makefile
+++ b/src/ashell/Makefile
@@ -30,5 +30,5 @@ ifneq ($(BOARD), linux)
 # Select extended ANSI C/POSIX function set in recent Newlib versions
 ccflags-y += -D_XOPEN_SOURCE=700
 endif
-ccflags-y += -I$(ZJS_BASE)/outdir/include -I$(JERRY_BASE)/jerry-ext/include
+ccflags-y += -I$(O)/include -I$(JERRY_BASE)/jerry-ext/include
 ccflags-y += -DZJS_ASHELL -Wall -Werror

--- a/tools/Makefile.snapshot
+++ b/tools/Makefile.snapshot
@@ -6,7 +6,7 @@ JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript
 
 JERRY_FLAGS ?= --snapshot-save=on
 
-BUILD_DIR = $(ZJS_BASE)/outdir/snapshot/
+BUILD_DIR = $(O)/snapshot/
 
 UNAME := $(shell uname)
 ifeq ($(UNAME),Darwin)
@@ -20,8 +20,8 @@ all: snapshot
 
 .PHONY: setup
 setup:
-	@if [ ! -d $(ZJS_BASE)/outdir/snapshot/ ]; then \
-		mkdir -p $(ZJS_BASE)/outdir/snapshot/; \
+	@if [ ! -d $(O)/snapshot/ ]; then \
+		mkdir -p $(O)/snapshot/; \
 	fi
 
 CORE_SRC +=		tools/snapshot.c \


### PR DESCRIPTION
If not specified, 'outdir' remains the default.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>