### PR TITLE
[webusb] Update the Web IDE url

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,4 +833,4 @@ configure the heap size available to the ZJS API.
 - `tests/` - JavaScript unit tests (incomplete).
 
 
-[Web IDE]: https://01org.github.io/zephyrjs-ide
+[Web IDE]: https://intel.github.io/zephyrjs-ide

--- a/src/ashell/term-webusb.c
+++ b/src/ashell/term-webusb.c
@@ -98,7 +98,7 @@ static const u8_t webusb_origin_url[] = {
     0x1F,  // Length
     0x03,  // URL descriptor
     0x01,  // Scheme https://
-    '0', '1', 'o', 'r', 'g', '.', 'g', 'i', 't', 'h', 'u', 'b', '.',
+    'i', 'n', 't', 'e', 'l', '.', 'g', 'i', 't', 'h', 'u', 'b', '.',
     'i', 'o', '/', 'z', 'e', 'p', 'h', 'y', 'r', 'j', 's', '-', 'i',
     'd', 'e'
 };


### PR DESCRIPTION
Web IDE repo has been migrated from 01org to Intel,
so update the landing page url.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>