### PR TITLE
[gpio] Check for bad gpio device

### DIFF
--- a/src/zjs_gpio.c
+++ b/src/zjs_gpio.c
@@ -232,6 +232,9 @@ static ZJS_DECL_FUNC(zjs_gpio_open)
         return zjs_error("pin not found");
     }
     DEVICE gpiodev = device_get_binding(devname);
+    if (!gpiodev) {
+        return zjs_error("device not found");
+    }
 
     // ignore mapping for now as we can do it automatically
 


### PR DESCRIPTION
With the full pin naming method, the first part is used as a device name
so we should check that it's actually a legitimate device name.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>