### PR TITLE
[gpio] Expand GPIO tests for k64f/f411re to cover all external pins

### DIFF
--- a/samples/tests/GPIO-Inputs.js
+++ b/samples/tests/GPIO-Inputs.js
@@ -9,6 +9,17 @@ console.log('Wire a button to each input in turn!\n');
 var board = require('board');
 var gpio = require('gpio');
 
+// index into the testpin string names that contains the controller id
+//   For example, if the pin names are of the format "GPIOA.3", 'A' is the
+//   controller id and it's at offset 4 in the string.
+// If -1, we will just try to set up an interrupt on every pin; latest ones
+//   will probably win.
+var controllerIndex = -1;
+
+// id of the controller we want to test interrupts on
+// NOTE: set to A, B, or C for F411RE
+var intController = 'A';
+
 var testpins;
 if (board.name == 'arduino_101') {
     // expected results: works with IO2-5, IO7-8, IO10-13; IO0/1/6/9 can only
@@ -16,18 +27,76 @@ if (board.name == 'arduino_101') {
     testpins = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 }
 else if (board.name == 'frdm_k64f') {
-    // expected results: all pins but D8 work (not sure why not D8)
-    testpins = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    // change to 0 to test with full pin names below
+    if (1) {
+        // expected results: all pins but D8 work (not sure why not D8)
+        testpins = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    }
+    else {
+        // expected results: with default Zephyr config only D0 - D15 and the
+        //   onboard switch SW2 work as inputs. However, D8 and onboard switch
+        //   SW3 do not work. Also, PTE26 is both wired to one of the pins on
+        //   the inner right connector and to the green LED of the RGB and
+        //   actually works as an input too.
+        // The diagram below shows other GPIO pins connected but these may
+        //   require different pinmux settings to enable:
+        //     https://os.mbed.com/platforms/FRDM-K64F/
+        testpins = [
+            // outer left pins (analog inputs)
+            'GPIO_1.2', 'GPIO_1.3', 'GPIO_1.10', 'GPIO_1.11', 'GPIO_2.11',
+            'GPIO_2.10',
+            // inner left pins
+            'GPIO_1.20',
+            // inner right pins
+            'GPIO_4.26', 'GPIO_2.5',  'GPIO_2.7',  'GPIO_2.0',  'GPIO_2.9',
+            'GPIO_2.8',  'GPIO_2.1',  'GPIO_1.19', 'GPIO_1.18',
+            // outer right pins (D0 - D15)
+            'GPIO_4.24', 'GPIO_4.25', 'GPIO_3.1',  'GPIO_3.3', 'GPIO_3.2',
+            'GPIO_3.0',  'GPIO_2.4',  'GPIO_2.12', 'GPIO_2.3',  'GPIO_2.2',
+            'GPIO_0.2',  'GPIO_1.23', 'GPIO_0.1',  'GPIO_1.9',  'GPIO_2.17',
+            'GPIO_2.16',
+            // onboard switch SW2 (INT1)
+            'GPIO_2.6',
+            // onboard switch SW3 (INT2)
+            'GPIO_0.4',
+        ];
+    }
 }
 else if (board.name == 'nucleo_f411re') {
-    // expected results: pins D2-D15 all work as inputs, but only
-    //   D3,5,6 and D11-15 will give rising edge interrupts (not sure why)
-    // NOTE: D0 (GPIOA.3) must be left out or it will corrupt serial output;
-    //   D1 (GPIOA.2) must be left out or it will hang on pin configure
-    testpins = ['GPIOA.10', 'GPIOB.3', 'GPIOB.5', 'GPIOB.4', 'GPIOB.10',
-                'GPIOA.8', 'GPIOA.9', 'GPIOC.7', 'GPIOB.6', 'GPIOA.7',
-                'GPIOA.6', 'GPIOA.5', 'GPIOB.9', 'GPIOB.8', 'GPIOC.4',
-                'GPIOB.13'];
+    // NOTE: On F411RE at least, you can't set up an interrupt to detect a
+    //   rising edge on more than one pin with the same number, e.g. GPIOA.9
+    //   and GPIOB.9. The one you set up last will win. For that reason, to
+    //   test the interrupt part of pin behavior you need to set
+    //   intController above to either 'A', 'B', or 'C'. All the other pins
+    //   will still report changes when we read them on a timer, but only the
+    //   controller you specify will set up rising edge interrupts.
+    // expected results:
+    //   See the blue boxes in this diagram for all the GPIO pin locations:
+    //     http://docs.zephyrproject.org/_images/nucleo_f411re_morpho.png
+    //   GPIOA.2 and GPIOA.3 are configured for serial comms in default Zephyr
+    //     config and can't be used; attempting to can cause a hang.
+    //   GPIOA.13 and GPIOA.14 don't seem to work as inputs
+    //   GPOIB.11 doesn't show an external connection in docs
+    //   GPIOC.14 and GPIOC.15 don't seem to work as inputs
+    //   GPIOD.2, GPIOH.0, and GPIOH.1 don't work; the controllers are disabled
+    //     by default in Zephyr configuration, haven't tried enabling yet
+    //   All other pins in GPIO[A-C].[0-15] work as inputs, and with interrupts
+    //     as long as you avoid conflicts between pins with the same number.
+    //   NOTE: The blue "user button" on board is connected to GPIOC.13
+    controllerIndex = 4;
+    testpins = ['GPIOA.0',  'GPIOA.1',  // 'GPIOA.2',  'GPIOA.3',
+                'GPIOA.4',  'GPIOA.5',  'GPIOA.6',  'GPIOA.7',
+                'GPIOA.8',  'GPIOA.9',  'GPIOA.10', 'GPIOA.11',
+                'GPIOA.12', 'GPIOA.13', 'GPIOA.14', 'GPIOA.15',
+                'GPIOB.0',  'GPIOB.1',  'GPIOB.2',  'GPIOB.3',
+                'GPIOB.4',  'GPIOB.5',  'GPIOB.6',  'GPIOB.7',
+                'GPIOB.8',  'GPIOB.9',  'GPIOB.10', 'GPIOB.11',
+                'GPIOB.12', 'GPIOB.13', 'GPIOB.14', 'GPIOB.15',
+                'GPIOC.0',  'GPIOC.1',  'GPIOC.2',  'GPIOC.3',
+                'GPIOC.4',  'GPIOC.5',  'GPIOC.6',  'GPIOC.7',
+                'GPIOC.8',  'GPIOC.9',  'GPIOC.10', 'GPIOC.11',
+                'GPIOC.12', 'GPIOC.13', 'GPIOC.14', 'GPIOC.15',
+    ];
 }
 
 // open all pins for input and sign up for rising edge events
@@ -36,8 +105,17 @@ var gpios = [];
 var debounce = false;
 for (var i = 0; i < pincount; i++) {
     try {
-        gpios[i] = gpio.open({pin: testpins[i], mode: 'in', edge: 'rising',
-                              state: 'pulldown'});
+        var init = {
+            pin: testpins[i],
+            mode: 'in',
+            state: 'pulldown'
+        };
+        if (controllerIndex < 0 ||
+            testpins[i][controllerIndex] == intController) {
+            console.log('rising for', testpins[i]);
+            init['edge'] = 'rising';
+        }
+        gpios[i] = gpio.open(init);
         gpios[i].onchange = (function (event) {
             var name = testpins[i];
             var pin = i;
@@ -63,16 +141,20 @@ function resetDebounce() {
 // read initial states
 var last = [];
 for (var i = 0; i < pincount; i++) {
-    last[i] = gpios[i].read();
+    if (gpios[i]) {
+        last[i] = gpios[i].read();
+    }
 }
 
 // check for changes to pin state; this catches pins where interrupts don't work
 setInterval(function() {
     for (var i = 0; i < pincount; i++) {
-        var val = gpios[i].read();
-        if (val != last[i]) {
-            console.log('Pin ' + testpins[i] + ' changed to ' + val);
-            last[i] = val;
+        if (gpios[i]) {
+            var val = gpios[i].read();
+            if (val != last[i]) {
+                console.log('Pin ' + testpins[i] + ' changed to ' + val);
+                last[i] = val;
+            }
         }
     }
 }, 250);

--- a/samples/tests/GPIO-Outputs.js
+++ b/samples/tests/GPIO-Outputs.js
@@ -17,17 +17,62 @@ if (board.name == 'arduino_101') {
     testpins = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
 }
 else if (board.name == 'frdm_k64f') {
-    // expected results: all pins but D8 will blink (not sure why not D8)
-    testpins = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    // change to 0 to test with full pin names below
+    if (1) {
+        // expected results: D0-D15 will blink (except D8, not sure why)
+        testpins = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    }
+    else {
+        // expected results: with default Zephyr config only D0 - D15 and the
+        //   RGB LED work as outputs. However, D8 does not work. Also, PTE26 is
+        //   both wired to one of the pins on the inner right bank and to the
+        //   green LED of the RGB. The green LED appears to be active-low.
+        // The diagram below shows other GPIO pins connected but these may
+        //   require different pinmux settings to enable:
+        //     https://os.mbed.com/platforms/FRDM-K64F/
+        testpins = [
+            // outer left pins (analog inputs)
+            'GPIO_1.2', 'GPIO_1.3', 'GPIO_1.10', 'GPIO_1.11', 'GPIO_2.11',
+            'GPIO_2.10',
+            // inner left pins
+            'GPIO_1.20',
+            // inner right pins
+            'GPIO_4.26', 'GPIO_2.5',  'GPIO_2.7',  'GPIO_2.0',  'GPIO_2.9',
+            'GPIO_2.8',  'GPIO_2.1',  'GPIO_1.19', 'GPIO_1.18',
+            // outer right pins (D0 - D15)
+            'GPIO_4.24', 'GPIO_4.25', 'GPIO_3.1',  'GPIO_3.3', 'GPIO_3.2',
+            'GPIO_3.0',  'GPIO_2.4',  'GPIO_2.12', 'GPIO_2.3',  'GPIO_2.2',
+            'GPIO_0.2',  'GPIO_1.23', 'GPIO_0.1',  'GPIO_1.9',  'GPIO_2.17',
+            'GPIO_2.16',
+            // onboard RGB LED
+            'GPIO_1.22', 'GPIO_4.26', 'GPIO_1.21'
+        ];
+    }
 }
 else if (board.name == 'nucleo_f411re') {
     // expected results: pins D2-D15 will blink; onboard LED 'LD2' blinks in
     //   sync with D13; D0/D1 are set as serial so can't be used
+    //   GPIOA.13 and GPIOA.14 work oddly; when off the LED still shows a faint
+    //     glow so there might be a pullup resistor; probably best not to use
+    //   GPOIB.11 doesn't show an external connection in docs
+    //   GPIOC.14 and GPIOC.15 don't seem to work
+    //   GPIOD.2, GPIOH.0, and GPIOH.1 don't work; the controllers are disabled
+    //     by default in Zephyr configuration, haven't tried enabling yet
     // NOTE: D0 (GPIOA.3) and D1 (GPIOA.2) must be left out or they will
     //   corrupt serial output
-    testpins = ['GPIOA.10', 'GPIOB.3', 'GPIOB.5', 'GPIOB.4', 'GPIOB.10',
-                'GPIOA.8', 'GPIOA.9', 'GPIOC.7', 'GPIOB.6', 'GPIOA.7',
-                'GPIOA.6', 'GPIOA.5', 'GPIOB.9', 'GPIOB.8'];
+    testpins = ['GPIOA.0',  'GPIOA.1',  // 'GPIOA.2',  'GPIOA.3',
+                'GPIOA.4',  'GPIOA.5',  'GPIOA.6',  'GPIOA.7',
+                'GPIOA.8',  'GPIOA.9',  'GPIOA.10', 'GPIOA.11',
+                'GPIOA.12', 'GPIOA.13', 'GPIOA.14', 'GPIOA.15',
+                'GPIOB.0',  'GPIOB.1',  'GPIOB.2',  'GPIOB.3',
+                'GPIOB.4',  'GPIOB.5',  'GPIOB.6',  'GPIOB.7',
+                'GPIOB.8',  'GPIOB.9',  'GPIOB.10', 'GPIOB.11',
+                'GPIOB.12', 'GPIOB.13', 'GPIOB.14', 'GPIOB.15',
+                'GPIOC.0',  'GPIOC.1',  'GPIOC.2',  'GPIOC.3',
+                'GPIOC.4',  'GPIOC.5',  'GPIOC.6',  'GPIOC.7',
+                'GPIOC.8',  'GPIOC.9',  'GPIOC.10', 'GPIOC.11',
+                'GPIOC.12', 'GPIOC.13', 'GPIOC.14', 'GPIOC.15',
+    ];
 }
 
 // open all pins for output


### PR DESCRIPTION
For F411RE, this demonstrates how there are a total of 41 external pins
that actually work as GPIOs. For K64F, basically none of the extra pins
actually work w/ the default Zephyr configuration, but may in the
future if we update pinmux settings.

Signed-off-by: Geoff Gustafson <geoff@linux.intel.com>