### PR TITLE
[ble] Fixed ble addr set default addr to "none"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ OCF_ROOT ?= deps/iotivity-constrained
 JS ?= samples/HelloWorld.js
 VARIANT ?= release
 DEVICE_NAME ?= "ZJS Device"
-BLE_ADDR ?= "none"
+BLE_ADDR ?= none
 FUNC_NAME ?= off
 # JerryScript options
 JERRY_BASE ?= $(ZJS_BASE)/deps/jerryscript


### PR DESCRIPTION
The Makefile is setting BLE_ADDR to "none" which
it should be none instead so it doesn't think it's
valid BLE address.

Fixes #1678

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>