### PR TITLE
[gfx] Fixing bugs and adding new drawImmediate mode

### DIFF
--- a/modules/ST7735.js
+++ b/modules/ST7735.js
@@ -19,12 +19,15 @@ function ST7735() {
     var spi = require("spi");
     var board = require('board');
     var busSpeed = board.name === "arduino_101" ? 16000000 : 32000000;
+    var busNum = board.name === "arduino_101" ? 1 : 0;
+    var dcPinNum = board.name === "arduino_101" ? 8 : 9;
 
     // You can reset these pins from your JS if you want
-    st7735API.dcPin = gpio.open(8);   // Command / Data select pin
+    st7735API.dcPin = gpio.open(dcPinNum);   // Command / Data select pin
     st7735API.csPin = gpio.open(4);   // SPI slave pin
     st7735API.rstPin = gpio.open(7);  // Reset pin
-    st7735API.spiBus = spi.open({bus:1, speed:busSpeed, polarity:0, phase:0, bits:8});
+    st7735API.spiBus = spi.open({bus:busNum, speed:busSpeed, polarity:0,
+                                 phase:0, bits:8});
 
     st7735API.cmdAddrs = {
         SWRESET: [0x01],    // Software reset

--- a/samples/SPI_Screen.js
+++ b/samples/SPI_Screen.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2017, Intel Corporation.
 // JS for using the SPI LCD screen ST7735 module
 // Setup:
-// DC - Pin 8
+// DC - Pin 8 for A101, Pin 9 for all others
 // CS - Pin 4
 // RST - Pin 7
 // SCL - Pin 13
@@ -17,25 +17,33 @@ var MAGENTA = [0xF8, 0x1F];
 var YELLOW =  [0xFF, 0xE0];
 var WHITE =  [0xFF, 0xFF];
 
+// Load the screen, gpio, and GFX modules
 var LCD = require("ST7735.js");
+var board = require('board');
+var drawImmediate = board.name === "arduino_101" ? true : false;
 var gpio = require('gpio');
 var gfxLib = require("gfx");
+
 console.log("SPI screen test starting..");
 
 try {
-    var GFX = gfxLib.init(LCD.width, LCD.height, LCD.initScreen, LCD.drawCB, LCD);
+    // Initialize the screen
+    var GFX = gfxLib.init(LCD.width, LCD.height, LCD.initScreen, LCD.drawCB,
+                          drawImmediate, LCD);
+
     GFX.fillRect(0, 0, LCD.width, LCD.height, BLACK);
-    GFX.drawVLine(123, 0, 160, RED, 5);
+    GFX.drawVLine(123, 0, 160, GREEN, 5);
     GFX.drawVLine(118, 0, 160, YELLOW, 3);
     GFX.drawVLine(113, 0, 160, WHITE);
-    GFX.drawLine(0, 20, 100, 160, WHITE, 15);
-    GFX.drawLine(0, 10, 115, 160, BLUE, 10);
-    GFX.drawLine(0, 0, 128, 160, RED);
+    GFX.drawLine(0, 20, 110, 160, WHITE, 15);
+    GFX.drawLine(0, 10, 118, 160, BLUE, 10);
+    GFX.drawLine(0, 0, 127, 160, RED);
     GFX.drawString(0, 20, "Hello", RED, 2);
     GFX.drawString(0, 35, "WORLD", [0x06, 0x1F], 3);
-    GFX.drawChar(20, 60,'Z', YELLOW, 4);
-    GFX.drawChar(40, 70,'J', YELLOW, 4);
-    GFX.drawChar(60, 80,'S', YELLOW, 4);
+    GFX.drawChar(20, 70,'Z', YELLOW, 3);
+    GFX.drawChar(40, 80,'J', YELLOW, 3);
+    GFX.drawChar(60, 90,'S', YELLOW, 3)
+    GFX.flush();
 } catch (err) {
-  console.log("SPI error: " + err.message);
+  console.log("Screen error: " + err.message);
 }

--- a/src/zjs_gfx.c
+++ b/src/zjs_gfx.c
@@ -106,24 +106,21 @@ static void zjs_gfx_reset_touched_pixels(gfx_handle_t *gfxHandle)
 static void zjs_gfx_touch_pixels(u32_t x, u32_t y, u32_t w, u32_t h, u8_t color[], gfx_handle_t *gfxHandle)
 {
     // Check that x and y aren't past the screen
-    if (x > gfxHandle->screenW || y > gfxHandle->screenH)
+    if (x >= gfxHandle->screenW || y >= gfxHandle->screenH)
         return;
 
-    if (x >= gfxHandle->screenW) {
-        x = gfxHandle->screenW - 1;
-    }
-    if (y >= gfxHandle->screenH) {
-        y = gfxHandle->screenH - 1;
+    if (gfxHandle->tpX0 > x ) {
+            gfxHandle->tpX0 = x;
     }
 
     if (gfxHandle->tpX1 < x + w - 1) {
-        if (x + w -1 < gfxHandle->screenW) {
-            gfxHandle->tpX1 = x + w -1;
+        if (x + w - 1 < gfxHandle->screenW) {
+            gfxHandle->tpX1 = x + w - 1;
         }
         else{
             gfxHandle->tpX1 = gfxHandle->screenW - 1;
+            w = gfxHandle->tpX1 - x;
         }
-
     }
 
     if (gfxHandle->tpY0 > y) {
@@ -136,11 +133,8 @@ static void zjs_gfx_touch_pixels(u32_t x, u32_t y, u32_t w, u32_t h, u8_t color[
         }
         else {
             gfxHandle->tpY1 = gfxHandle->screenH - 1;
+            h = gfxHandle->tpY1 - y;
         }
-    }
-
-    if (gfxHandle->tpX0 > x ) {
-            gfxHandle->tpX0 = x;
     }
 
     if (!drawImmediate) {
@@ -187,7 +181,7 @@ static jerry_value_t zjs_gfx_flush(gfx_handle_t *gfxHandle)
 {
     if (!gfxHandle->touched)
         return ZJS_UNDEFINED;
-    u32_t tpW = gfxHandle->tpX1 - gfxHandle->tpX0 + 1 ;
+    u32_t tpW = gfxHandle->tpX1 - gfxHandle->tpX0 + 1;
     u32_t tpH = gfxHandle->tpY1 - gfxHandle->tpY0 + 1;
     u32_t pixels = tpW * tpH * COLORBYTES;
     zjs_buffer_t *recBuf = NULL;

--- a/src/zjs_gfx.c
+++ b/src/zjs_gfx.c
@@ -110,14 +110,14 @@ static void zjs_gfx_touch_pixels(u32_t x, u32_t y, u32_t w, u32_t h, u8_t color[
         return;
 
     if (gfxHandle->tpX0 > x ) {
-            gfxHandle->tpX0 = x;
+        gfxHandle->tpX0 = x;
     }
 
     if (gfxHandle->tpX1 < x + w - 1) {
         if (x + w - 1 < gfxHandle->screenW) {
             gfxHandle->tpX1 = x + w - 1;
         }
-        else{
+        else {
             gfxHandle->tpX1 = gfxHandle->screenW - 1;
             w = gfxHandle->tpX1 - x;
         }
@@ -154,7 +154,7 @@ static void zjs_gfx_touch_pixels(u32_t x, u32_t y, u32_t w, u32_t h, u8_t color[
                 for (u8_t cbyte = 0; cbyte < COLORBYTES; cbyte++) {
                     gfxHandle->pixelsPtr->buffer[pixelsIndex + cbyte] = color[cbyte];
                 }
-                pixelsIndex+=COLORBYTES;
+                pixelsIndex += COLORBYTES;
             }
         }
     }


### PR DESCRIPTION
New mode will draw pixels as it goes rather than saving them up.
This method uses far less RAM and is better suited for the A101.
Boards with more RAM can now take advantage of the flush mode
which draws far faster.

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>