### PR TITLE
[build] Update Makefile to support olimex_stm32_e407 and 96b_carbon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,11 +222,19 @@ ide: zephyr
 .PHONY: ashell
 ashell: zephyr
 
-# Flash Arduino 101 x86 and arc images
+# Flash for Arduino 101 x86 and arc images, olimex_stm32_e407, 96b_carbon
 .PHONY: dfu
 dfu:
+ifeq ($(BOARD), arduino_101)
 	dfu-util -a x86_app -D $(A101BIN).dfu
 	dfu-util -a sensor_core -D $(A101SSBIN).dfu
+endif
+ifeq ($(BOARD), olimex_stm32_e407)
+	dfu-util -a 0 -d 0483:df11 -D $(OUT)/olimex_stm32_e407/zephyr.bin --dfuse-address 0x08000000
+endif
+ifeq ($(BOARD), 96b_carbon)
+	dfu-util -a 0 -d 0483:df11 -D $(OUT)/96b_carbon/zephyr.bin --dfuse-address 0x08000000
+endif
 
 # Give an error if we're asked to create the JS file
 $(JS):

--- a/Makefile
+++ b/Makefile
@@ -230,10 +230,10 @@ ifeq ($(BOARD), arduino_101)
 	dfu-util -a sensor_core -D $(A101SSBIN).dfu
 endif
 ifeq ($(BOARD), olimex_stm32_e407)
-	dfu-util -a 0 -d 0483:df11 -D $(OUT)/olimex_stm32_e407/zephyr.bin --dfuse-address 0x08000000
+	dfu-util -a 0 -d 0483:df11 -D $(OUT)/olimex_stm32_e407/zephyr/zephyr.bin --dfuse-address 0x08000000
 endif
 ifeq ($(BOARD), 96b_carbon)
-	dfu-util -a 0 -d 0483:df11 -D $(OUT)/96b_carbon/zephyr.bin --dfuse-address 0x08000000
+	dfu-util -a 0 -d 0483:df11 -D $(OUT)/96b_carbon/zephyr/zephyr.bin --dfuse-address 0x08000000
 endif
 
 # Give an error if we're asked to create the JS file

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ ide: zephyr
 .PHONY: ashell
 ashell: zephyr
 
-# Flash for Arduino 101 x86 and arc images, olimex_stm32_e407, 96b_carbon
+# Flash images
 .PHONY: dfu
 dfu:
 ifeq ($(BOARD), arduino_101)


### PR DESCRIPTION
Update Makefile to support olimex_stm32_e407 and 96b_carbon boards using dfu mode.

a101: `make dfu` or `make dfu BOARD=arduino_101`
olimex_stm32_e407: `make dfu BOARD=olimex_stm32_e407`
96b_carbon: `make dfu BOARD=96b_carbon`

Signed-off-by: Cui Yan <yanx.cui@intel.com>