### PR TITLE
[modules] Fix to allow linux to load JS modules

### DIFF
--- a/scripts/trlite
+++ b/scripts/trlite
@@ -243,9 +243,7 @@ function try_test()
         echo "******************************************************************************"
         echo Error: Test incomplete in $LABEL subtest \#$TESTNUM with code $CODE \(rerun with: trlite $VMNUM $TESTNUM\)!
         echo "******************************************************************************"
-        # FIXME: Should exit here but we'll soft fail until we fix things
-        # The callbacks, event, gpio, promise, and timers tests all fail ATM
-        #   and were broken by PR #1542 (commit a36b2c9)
+        exit 1
     else
         echo Success: $LABEL
     fi

--- a/src/main.c
+++ b/src/main.c
@@ -291,7 +291,7 @@ if (start_debug_server) {
 #endif
 
 #ifdef ZJS_LINUX_BUILD
-    zjs_free_script(script);
+    zjs_free(script);
 #endif
 
 #ifdef ZJS_SNAPSHOT_BUILD

--- a/src/zjs_modules.c
+++ b/src/zjs_modules.c
@@ -197,7 +197,7 @@ static ZJS_DECL_FUNC(native_require_handler)
     // Try each of the resolvers to see if we can find the requested module
     jerry_value_t result = jerryx_module_resolve(argv[0], resolvers, 3);
     if (jerry_value_has_error_flag(result)) {
-        //ERR_PRINT("Couldn't load module %s\n", module);
+        DBG_PRINT("Couldn't load module %s\n", module);
         return NOTSUPPORTED_ERROR("Module not found");
     }
     else {

--- a/src/zjs_script.c
+++ b/src/zjs_script.c
@@ -56,13 +56,4 @@ uint8_t zjs_read_script(char *name, char **script, uint32_t *length)
 
     return 0;
 }
-
-void zjs_free_script(char *script)
-{
-    if (script) {
-        free(script);
-    }
-    return;
-}
-
 #endif

--- a/src/zjs_script.h
+++ b/src/zjs_script.h
@@ -8,6 +8,4 @@
 
 uint8_t zjs_read_script(char *name, char **script, uint32_t *length);
 
-void zjs_free_script(char *script);
-
 #endif /* ZJS_SCRIPT_H_ */

--- a/tools/snapshot.c
+++ b/tools/snapshot.c
@@ -46,7 +46,8 @@ int main(int argc, char *argv[])
                                                 snapshot_buf,
                                                 sizeof(snapshot_buf));
 
-    zjs_free_script(script);
+    if (script != NULL)
+        free(script);
 
     if (size == 0) {
         fprintf(stderr, "JerryScript: failed to parse JS and create snapshot\n");


### PR DESCRIPTION
Linux requires the module object be returned to work.
Fixes #1687

Signed-off-by: Brian J Jones <brian.j.jones@intel.com>