### PR TITLE
[build] Downgrade cmake version check to 3.8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2017, Intel Corporation.
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 if(NOT DEFINED ENV{ZEPHYR_BASE})
   message(FATAL_ERROR "Missing Zephyr base, did you source zephyr-env.sh?")

--- a/arc/CMakeLists.txt
+++ b/arc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (c) 2017, Intel Corporation.
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.8.2)
 
 if(NOT DEFINED ENV{ZEPHYR_BASE})
   message(FATAL_ERROR "Missing Zephyr base, did you source zephyr-env.sh?")


### PR DESCRIPTION
Zephyr 1.10 requires CMake 3.8.2. For some actively used Linux distros
(e.g. Ubuntu 16.04), that version is not in repositories, and users
have to do extra legwork to install it. Then Zephyr.js pushes it even
higher. Try to use the value consisten with what Zephyr uses instead.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>