### PR TITLE
[ashell] Fix broken ashell CLI

### DIFF
--- a/src/zjs_ashell.json
+++ b/src/zjs_ashell.json
@@ -24,7 +24,6 @@
         "src/ashell/term-ihex.c",
         "src/ashell/term-uart.c",
         "src/ashell/term-webusb.c",
-        "${ZEPHYR_BASE}/samples/subsys/usb/webusb/src/webusb_serial.c",
         "./deps/ihex/kk_ihex_read.c"
     ],
     "zephyr_conf": {

--- a/src/zjs_ashell_ide.json
+++ b/src/zjs_ashell_ide.json
@@ -1,6 +1,7 @@
 {
     "module": "ashell_ide",
     "depends": ["ashell"],
+    "src": ["${ZEPHYR_BASE}/samples/subsys/usb/webusb/src/webusb_serial.c"],
     "zephyr_conf": {
         "arduino_101": ["CONFIG_USB_CDC_ACM=n"]
     }


### PR DESCRIPTION
Including this webusb_serial.c file with the ashell CLI causes
it to never get events, which means it hangs and waits forever
after the first print.  Moving the file to where it belongs.
Signed-off-by: Brian Jones <brian.j.jones@intel.com>